### PR TITLE
Check dummy inputs order and correct it with wrapper

### DIFF
--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -217,7 +217,7 @@ class NeuronConfig(ExportConfig, ABC):
         This method is actually used to determine the input specs and their static shapes that are needed for the export.
 
         Returns:
-            `Union[Dict[str, torch.Tensor], Tuple[torch.Tensor]]`: A dictionary mapping input names to dummy tensors.
+            `Union[Dict[str, torch.Tensor], Tuple[torch.Tensor]]`: A dictionary mapping input names to dummy tensors or a tuple with dummy tensors.
         """
         dummy_inputs_generators = self._create_dummy_input_generator_classes(**kwargs)
         dummy_inputs = {}

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -241,7 +241,7 @@ class NeuronConfig(ExportConfig, ABC):
 
     def check_model_inputs_order(
         self,
-        model: "PreTrainedModel",
+        model: PreTrainedModel,
         dummy_inputs: Dict[str, torch.Tensor],
     ):
         """
@@ -250,7 +250,7 @@ class NeuronConfig(ExportConfig, ABC):
         """
 
         class ModelWrapper(PreTrainedModel):
-            def __init__(self, model: "PreTrainedModel", config: "PretrainedConfig", input_names: List[str]):
+            def __init__(self, model: PreTrainedModel, config: "PretrainedConfig", input_names: List[str]):
                 super().__init__(config)
                 self.model = model
                 self.input_names = input_names

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -209,13 +209,15 @@ class NeuronConfig(ExportConfig, ABC):
         """
         return self._TASK_TO_COMMON_OUTPUTS[self.task]
 
-    def generate_dummy_inputs(self, return_tuple: bool = False, **kwargs) -> Union[Dict[str, torch.Tensor], Tuple]:
+    def generate_dummy_inputs(
+        self, return_tuple: bool = False, **kwargs
+    ) -> Union[Dict[str, torch.Tensor], Tuple[torch.Tensor]]:
         """
         Generates dummy inputs that the exported model should be able to process.
         This method is actually used to determine the input specs and their static shapes that are needed for the export.
 
         Returns:
-            `Union[Dict[str, torch.Tensor], Tuple]`: A dictionary mapping input names to dummy tensors.
+            `Union[Dict[str, torch.Tensor], Tuple[torch.Tensor]]`: A dictionary mapping input names to dummy tensors.
         """
         dummy_inputs_generators = self._create_dummy_input_generator_classes(**kwargs)
         dummy_inputs = {}

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -240,7 +240,7 @@ class NeuronConfig(ExportConfig, ABC):
 
     def check_model_inputs_order(
         self,
-        model: PreTrainedModel,
+        model: "PreTrainedModel",
         dummy_inputs: Dict[str, torch.Tensor],
     ):
         """

--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -270,8 +270,10 @@ def export_neuron(
         input_shapes[axe] = getattr(config, axe)
 
     dummy_inputs = config.generate_dummy_inputs(**input_shapes)
+    dummy_inputs_tuple = tuple(dummy_inputs.values())
+    checked_model = config.check_model_inputs_order(model, dummy_inputs)
     compiler_args = convert_neuronx_compiler_args_to_neuron(auto_cast, auto_cast_type, disable_fast_relayout)
-    neuron_model = neuron.trace(model, dummy_inputs, compiler_args=compiler_args)
+    neuron_model = neuron.trace(checked_model, dummy_inputs_tuple, compiler_args=compiler_args)
     neuron_model.save(output)
 
     return config.inputs, config.outputs

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -49,6 +49,7 @@ class AlbertNeuronConfig(BertNeuronConfig):
 
 
 # Issue: https://github.com/aws-neuron/aws-neuron-sdk/issues/641
+# (will be fixed by the next neuron sdk release)
 # @register_in_tasks_manager("convbert", *COMMON_TEXT_TASKS)
 # class ConvBertNeuronConfig(BertNeuronConfig):
 #     pass
@@ -120,6 +121,8 @@ class XLMRobertaNeuronConfig(CamembertNeuronConfig):
     pass
 
 
+# https://github.com/aws-neuron/aws-neuron-sdk/issues/642
+# Failed only for INF1: 'XSoftmax'
 @register_in_tasks_manager("deberta", *COMMON_TEXT_TASKS)
 class DebertaNeuronConfig(BertNeuronConfig):
     @property
@@ -131,6 +134,8 @@ class DebertaNeuronConfig(BertNeuronConfig):
         return common_inputs
 
 
+# https://github.com/aws-neuron/aws-neuron-sdk/issues/642
+# Failed only for INF1: 'XSoftmax'
 @register_in_tasks_manager("deberta-v2", *COMMON_TEXT_TASKS)
 class DebertaV2NeuronConfig(DebertaNeuronConfig):
     pass

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -64,7 +64,7 @@ class ElectraNeuronConfig(BertNeuronConfig):
 
 @register_in_tasks_manager("flaubert", *COMMON_TEXT_TASKS)
 class FlaubertNeuronConfig(ElectraNeuronConfig):
-    ATOL_FOR_VALIDATION = 1e-1
+    pass
 
 
 @register_in_tasks_manager("mobilebert", *COMMON_TEXT_TASKS)
@@ -79,7 +79,7 @@ class RoFormerNeuronConfig(ElectraNeuronConfig):
 
 @register_in_tasks_manager("xlm", *COMMON_TEXT_TASKS)
 class XLMNeuronConfig(ElectraNeuronConfig):
-    ATOL_FOR_VALIDATION = 1e-1
+    pass
 
 
 @register_in_tasks_manager("distilbert", *COMMON_TEXT_TASKS)

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -59,7 +59,8 @@ class AlbertNeuronConfig(BertNeuronConfig):
 class ElectraNeuronConfig(BertNeuronConfig):
     @property
     def outputs(self) -> List[str]:
-        self._TASK_TO_COMMON_OUTPUTS["feature-extraction"] = ["last_hidden_state"]
+        if self.task == "feature-extraction":
+            return ["last_hidden_state"]
         return self._TASK_TO_COMMON_OUTPUTS[self.task]
 
 
@@ -93,7 +94,8 @@ class DistilBertNeuronConfig(BertNeuronConfig):
 
     @property
     def outputs(self) -> List[str]:
-        self._TASK_TO_COMMON_OUTPUTS["feature-extraction"] = ["last_hidden_state"]
+        if self.task == "feature-extraction":
+            return ["last_hidden_state"]
         return self._TASK_TO_COMMON_OUTPUTS[self.task]
 
 

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -21,15 +21,7 @@ EXPORT_MODELS_TINY = {
     # "convbert": "hf-internal-testing/tiny-random-ConvBertModel",  # Failed for INF2
     # "deberta": "hf-internal-testing/tiny-random-DebertaModel",  # Failed for INF1: 'XSoftmax'
     # "deberta-v2": "hf-internal-testing/tiny-random-DebertaV2Model",  # Failed for INF1: 'XSoftmax'
-    "distilbert": {
-        "hf-internal-testing/tiny-random-DistilBertModel": [
-            "feature-extraction",
-            "fill-mask",
-            "text-classification",
-            "token-classification",
-            "question-answering",
-        ]
-    },  # Failed for DistilBERT: https://github.com/aws-neuron/aws-neuron-sdk/issues/645
+    "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
@@ -37,13 +29,5 @@ EXPORT_MODELS_TINY = {
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
-    "xlm-roberta": {
-        "hf-internal-testing/tiny-xlm-roberta": [
-            "feature-extraction",
-            "fill-mask",
-            "text-classification",
-            "token-classification",
-            "question-answering",
-        ]
-    },
+    "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
 }


### PR DESCRIPTION
*Related issue: #18 and https://github.com/aws-neuron/aws-neuron-sdk/issues/642*

__Context__

`torch_neuronx.trace` accepts tuples as inputs for the tracing, whereas we need to ensure that the dummy inputs tuple corresponds to the order of `model.forward()`. 

This PR will fix the previous unusual behavior of Flaubert and XLM models (where `token_type_ids` was mistaken as `langs` during the compilation).

