### PR TITLE
Neuron-compatible `GenerationMixin`

### DIFF
--- a/optimum/neuron/generation/__init__.py
+++ b/optimum/neuron/generation/__init__.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .utils import NeuronGenerationMixin

--- a/optimum/neuron/generation/utils.py
+++ b/optimum/neuron/generation/utils.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""Utilities for generation with Neuron."""
+
+from transformers import GenerationMixin
+
+
+class NeuronGenerationMixin(GenerationMixin):
+    pass

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -20,9 +20,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch.utils.data import DataLoader, Dataset
-from transformers import Seq2SeqTrainer, Trainer
+from transformers import GenerationMixin, Seq2SeqTrainer, Trainer
 
 from ..utils import logging
+from .generation import NeuronGenerationMixin
 from .trainer_callback import NeuronCacheCallaback
 from .utils.argument_utils import validate_arg
 from .utils.cache_utils import get_neuron_cache_path
@@ -92,6 +93,9 @@ class AugmentTrainerForTrainiumMixin:
             )
             self.add_callback(callback)
 
+        # Make the model Neuron-compatible for generation.
+        self.patch_generation_mixin_to_neuron_generation_mixin(self.model)
+
     def prepare_args_for_precompilation(self, args: "TrainingArguments"):
         if args.num_train_epochs != 1:
             logger.info("Setting the number of epochs for precompilation to 1.")
@@ -114,6 +118,26 @@ class AugmentTrainerForTrainiumMixin:
                 "prediction_loss_only=False is not supported for now because it requires generation.",
                 expected_value=True,
             )
+
+    def patch_generation_mixin_to_neuron_generation_mixin(self, model: "PreTrainedModel"):
+        """
+        Changes the vanilla `GenerationMixin` class from Transformers to `NeuronGenerationMixin` in the model's
+        inheritance. This allows to make the model Neuron-compatible for generation without much hassle.
+        """
+        to_visit = [model.__class__]
+        should_stop = False
+        while to_visit and not should_stop:
+            cls = to_visit.pop(0)
+            bases = cls.__bases__
+            new_bases = []
+            for base in bases:
+                to_visit.append(base)
+                if base == GenerationMixin:
+                    new_bases.append(NeuronGenerationMixin)
+                    should_stop = True
+                else:
+                    new_bases.append(base)
+            cls.__bases__ = tuple(new_bases)
 
     def _wrap_model(self, model, training=True, dataloader=None):
         logger.info(


### PR DESCRIPTION
This PR creates a `NeuronGenerationMixin` which will be able to support generation on Neuron.
On top of creating this class, which corresponds to the vanilla Transformers `GenerationMixin` for now, this PR makes it so that models from Transformers inheriting from `GenerationMixin` will use the `NeuronGenerationMixin` automatically, without any code change.

The plan is to integrate features from https://github.com/huggingface/transformers/pull/23021 here in `optimum-neuron`

