### PR TITLE
Enable greedy sampling

### DIFF
--- a/notebooks/text-classification/scripts/train.py
+++ b/notebooks/text-classification/scripts/train.py
@@ -1,19 +1,18 @@
-import os
 import argparse
-import numpy as np
-from transformers import (
-    AutoModelForSequenceClassification,
-    DataCollatorForSeq2Seq,
-    AutoTokenizer,
-    set_seed,
-)
-from datasets import load_from_disk
-import torch
+import logging
+import os
+
 import evaluate
 import numpy as np
-import logging 
+from datasets import load_from_disk
 from huggingface_hub import HfFolder
-from transformers import TrainingArguments
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    TrainingArguments,
+    set_seed,
+)
+
 from optimum.neuron import TrainiumTrainer as Trainer
 
 
@@ -22,15 +21,14 @@ logger = logging.getLogger(__name__)
 
 print(f"is precompilation: {os.environ.get('NEURON_PARALLEL_COMPILE')}")
 
+
 def parse_args():
     """Parse the arguments."""
     parser = argparse.ArgumentParser()
     # add model id and dataset path argument
     parser.add_argument("--model_id", type=str, default="bert-large-uncased", help="Model id to use for training.")
     parser.add_argument("--dataset_path", type=str, default="dataset", help="Path to the already processed dataset.")
-    parser.add_argument(
-        "--output_dir", type=str, default=None, help="Hugging Face Repository id for uploading models"
-    )
+    parser.add_argument("--output_dir", type=str, default=None, help="Hugging Face Repository id for uploading models")
     parser.add_argument(
         "--repository_id", type=str, default=None, help="Hugging Face Repository id for uploading models"
     )
@@ -55,8 +53,10 @@ def parse_args():
     args = parser.parse_known_args()
     return args
 
+
 # Metric Id
 metric = evaluate.load("f1")
+
 
 # Metric helper method
 def compute_metrics(eval_pred):
@@ -73,11 +73,11 @@ def training_function(args):
     train_dataset = load_from_disk(os.path.join(args.dataset_path, "train"))
     eval_dataset = load_from_disk(os.path.join(args.dataset_path, "eval"))
     tokenizer = AutoTokenizer.from_pretrained(args.model_id)
-    
+
     # Prepare model labels - useful for inference
     labels = train_dataset.features["labels"].names
     num_labels = len(labels)
-    label2id, id2label = dict(), dict()
+    label2id, id2label = {}, {}
     for i, label in enumerate(labels):
         label2id[label] = str(i)
         id2label[str(i)] = label

--- a/optimum/neuron/generation/utils.py
+++ b/optimum/neuron/generation/utils.py
@@ -14,8 +14,1262 @@
 # limitations under the License.
 """Utilities for generation with Neuron."""
 
+import copy
+import inspect
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+import torch_xla.core.xla_model as xm
 from transformers import GenerationMixin
+from transformers.deepspeed import is_deepspeed_zero3_enabled
+from transformers.generation.beam_constraints import DisjunctiveConstraint, PhrasalConstraint
+from transformers.generation.beam_search import BeamSearchScorer, ConstrainedBeamSearchScorer
+from transformers.generation.configuration_utils import GenerationConfig
+from transformers.generation.logits_process import (
+    LogitsProcessorList,
+    MinLengthLogitsProcessor,
+)
+from transformers.generation.stopping_criteria import (
+    MaxLengthCriteria,
+    MaxTimeCriteria,
+    StoppingCriteriaList,
+    validate_stopping_criteria,
+)
+from transformers.utils import ModelOutput, logging
+
+if TYPE_CHECKING:
+    from transformers.modeling_utils import PreTrainedModel
+    from transformers.generation.streamers import BaseStreamer
+
+logger = logging.get_logger(__name__)
+
+
+@dataclass
+class GreedySearchDecoderOnlyOutput(ModelOutput):
+    """
+    Base class for outputs of decoder-only generation models using greedy search.
+
+
+    Args:
+        sequences (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+            The generated sequences. The second dimension (sequence_length) is either equal to `max_length` or shorter
+            if all batches finished early due to the `eos_token_id`.
+        scores (`tuple(torch.FloatTensor)` *optional*, returned when `output_scores=True` is passed or when `config.output_scores=True`):
+            Processed prediction scores of the language modeling head (scores for each vocabulary token before SoftMax)
+            at each generation step. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for
+            each generated token), with each tensor of shape `(batch_size, config.vocab_size)`.
+        attentions (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_attentions=True` is passed or `config.output_attentions=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, num_heads, generated_length, sequence_length)`.
+        hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+    """
+
+    sequences: torch.LongTensor = None
+    scores: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+
+
+@dataclass
+class GreedySearchEncoderDecoderOutput(ModelOutput):
+    """
+    Base class for outputs of encoder-decoder generation models using greedy search. Hidden states and attention
+    weights of the decoder (respectively the encoder) can be accessed via the encoder_attentions and the
+    encoder_hidden_states attributes (respectively the decoder_attentions and the decoder_hidden_states attributes)
+
+
+    Args:
+        sequences (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+            The generated sequences. The second dimension (sequence_length) is either equal to `max_length` or shorter
+            if all batches finished early due to the `eos_token_id`.
+        scores (`tuple(torch.FloatTensor)` *optional*, returned when `output_scores=True` is passed or when `config.output_scores=True`):
+            Processed prediction scores of the language modeling head (scores for each vocabulary token before SoftMax)
+            at each generation step. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for
+            each generated token), with each tensor of shape `(batch_size, config.vocab_size)`.
+        encoder_attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or `config.output_attentions=True`):
+            Tuple of `torch.FloatTensor` (one for each layer of the decoder) of shape `(batch_size, num_heads,
+            sequence_length, sequence_length)`.
+        encoder_hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer) of
+            shape `(batch_size, sequence_length, hidden_size)`.
+        decoder_attentions (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_attentions=True` is passed or `config.output_attentions=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, num_heads, generated_length, sequence_length)`.
+        cross_attentions (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_attentions=True` is passed or `config.output_attentions=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, num_heads, generated_length, sequence_length)`.
+        decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+    """
+
+    sequences: torch.LongTensor = None
+    scores: Optional[Tuple[torch.FloatTensor]] = None
+    encoder_attentions: Optional[Tuple[torch.FloatTensor]] = None
+    encoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+
+
+GreedySearchOutput = Union[GreedySearchEncoderDecoderOutput, GreedySearchDecoderOnlyOutput]
+GenerateOutput = Union[GreedySearchOutput]
 
 
 class NeuronGenerationMixin(GenerationMixin):
-    pass
+    """
+    A class containing all functions for auto-regressive text generation on Trn1, to be used as a mixin in [`PreTrainedModel`].
+
+    The class exposes [`~generation.GenerationMixin.generate`], which can be used for:
+        - *greedy decoding* by calling [`~generation.GenerationMixin.greedy_search`] if `num_beams=1` and
+          `do_sample=False`
+        - *contrastive search* by calling [`~generation.GenerationMixin.contrastive_search`] if `penalty_alpha>0` and
+          `top_k>1`
+        - *multinomial sampling* by calling [`~generation.GenerationMixin.sample`] if `num_beams=1` and
+          `do_sample=True`
+        - *beam-search decoding* by calling [`~generation.GenerationMixin.beam_search`] if `num_beams>1` and
+          `do_sample=False`
+        - *beam-search multinomial sampling* by calling [`~generation.GenerationMixin.beam_sample`] if `num_beams>1`
+          and `do_sample=True`
+        - *diverse beam-search decoding* by calling [`~generation.GenerationMixin.group_beam_search`], if `num_beams>1`
+          and `num_beam_groups>1`
+        - *constrained beam-search decoding* by calling [`~generation.GenerationMixin.constrained_beam_search`], if
+          `constraints!=None` or `force_words_ids!=None`
+
+    You do not need to call any of the above methods directly. Pass custom parameter values to 'generate' instead. To
+    learn more about decoding strategies refer to the [text generation strategies guide](../generation_strategies).
+    """
+
+    def _update_model_kwargs_for_xla_generation(
+            self,
+            outputs: ModelOutput,
+            model_kwargs: Dict[str, Any],
+            batch_size: int,
+            is_encoder_decoder: bool = False,
+            standardize_cache_format: bool = False,
+            max_length: int = None,
+            seq_length: int = None,
+            use_cache=True,
+    ) -> Dict[str, Any]:
+        def _initialize_attention(model_kwargs, num_padding_values, is_encoder_decoder):
+            """initializes the appropriate attention mask -- encoder-decoder models use `decoder_attention_mask`"""
+            if is_encoder_decoder:
+                # One 1 for decoder_start_token_id, 0s for the currently-unfilled locations in the past_key_values tensor,
+                # 1s for the actual input_ids
+                decoder_attention_mask = torch.cat(
+                    [
+                        torch.zeros((batch_size, num_padding_values), dtype=torch.int32),
+                        torch.ones((batch_size, 2), dtype=torch.int32),
+                    ],
+                    axis=1,
+                ).to(outputs.logits.device)
+                mask = {"decoder_attention_mask": decoder_attention_mask}
+            else:
+                attention_mask = model_kwargs.pop("attention_mask")
+                # 0s for the currently-unfilled locations in the past_key_values tensor, 1s for the actual input_ids
+                attention_mask = torch.cat(
+                    [
+                        torch.zeros(
+                            (batch_size, num_padding_values), dtype=attention_mask.dtype, device=attention_mask.device
+                        ),
+                        attention_mask,
+                        torch.ones((batch_size, 1), dtype=attention_mask.dtype, device=attention_mask.device),
+                    ],
+                    axis=1,
+                )
+                mask = {"attention_mask": attention_mask}
+
+            return mask
+
+        def _update_attention(model_kwargs, is_encoder_decoder):
+            """updates the appropriate attention mask -- encoder-decoder models use `decoder_attention_mask`"""
+            if is_encoder_decoder:
+                decoder_attention_mask = model_kwargs.pop("decoder_attention_mask")
+                decoder_attention_mask_update_slice = torch.ones(
+                    (batch_size, 1), dtype=decoder_attention_mask.dtype, device=decoder_attention_mask.device
+                )
+                decoder_attention_mask = torch.cat(
+                    [decoder_attention_mask[:, 1:], decoder_attention_mask_update_slice], dim=-1
+                )
+                mask = {"decoder_attention_mask": decoder_attention_mask}
+            else:
+                attention_mask = model_kwargs.pop("attention_mask")
+                attention_mask_update_slice = torch.ones(
+                    (batch_size, 1), dtype=attention_mask.dtype, device=attention_mask.device
+                )
+                attention_mask = torch.cat([attention_mask[:, 1:], attention_mask_update_slice], dim=-1)
+                mask = {"attention_mask": attention_mask}
+            return mask
+
+        def _initialize_past(past_key_values, num_padding_values):
+            """initialize past_key_values with zeros -- the structure depends on `batch_axis`"""
+
+            # padding_values = torch.tensor([[0, 0], [0, 0], [0, num_padding_values], [0, 0]], dtype=torch.int32)
+            new_past = ()
+            for past_layer in past_key_values:
+                new_past_layer = list(past_layer)
+                for i in range(len(new_past_layer[:2])):
+                    b, n_heads, _, head_dim = past_layer[i].shape
+                    new_past_layer[i] = torch.cat(
+                        [
+                            torch.zeros(
+                                (b, n_heads, num_padding_values, head_dim),
+                                dtype=past_layer[i].dtype,
+                                device=past_layer[i].device,
+                            ),
+                            past_layer[i],
+                        ],
+                        dim=2,
+                    )
+                new_past += (tuple(new_past_layer),)
+
+            return new_past
+
+        def _update_past(past_key_values):
+            new_past = ()
+            for past_layer in past_key_values:
+                new_past_layer = list(past_layer)
+                for i in range(len(new_past_layer[:2])):
+                    new_past_layer[i] = past_layer[i][:, :, 1:]
+                new_past += (tuple(new_past_layer),)
+
+            return new_past
+
+        if use_cache:
+            past_key_values = self._extract_past_from_model_output(outputs)
+            if past_key_values is None:
+                raise ValueError(
+                    "No known `past_key_values variable` found in model outputs (model outputs keys:"
+                    f" {list(outputs.keys())})"
+                )
+            is_past_initialized = model_kwargs.pop("past_key_values", None) is not None
+
+            if not is_past_initialized:
+                # The padded version of `past_key_values` has a length of `max_length - 1`, as `past_key_values` holds information relative to
+                # previous autoregressive generation steps (step 0 has no past_key_values, step 1 has 1 past_key_values value, ..., the last step
+                # has `max_length - 1` past_key_values values).
+                num_padding_values = max_length - seq_length
+                mask = _initialize_attention(model_kwargs, num_padding_values, is_encoder_decoder)
+                new_past = _initialize_past(past_key_values, num_padding_values)
+            else:
+                mask = _update_attention(model_kwargs, is_encoder_decoder)
+                new_past = _update_past(past_key_values)
+
+            # sets the updated variables (mask and past_key_values)
+            model_kwargs.update(mask)
+            model_kwargs["past_key_values"] = tuple(new_past)
+        else:
+            if "token_type_ids" in model_kwargs:
+                token_type_ids = model_kwargs["token_type_ids"]
+                model_kwargs["token_type_ids"] = torch.cat(
+                    [token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1
+                )
+
+            if not is_encoder_decoder:
+                # update attention mask
+                if "attention_mask" in model_kwargs:
+                    attention_mask = model_kwargs["attention_mask"]
+                    model_kwargs["attention_mask"] = torch.cat(
+                        [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))], dim=-1
+                    )
+            else:
+                # update decoder attention mask
+                if "decoder_attention_mask" in model_kwargs:
+                    decoder_attention_mask = model_kwargs["decoder_attention_mask"]
+                    model_kwargs["decoder_attention_mask"] = torch.cat(
+                        [
+                            decoder_attention_mask,
+                            decoder_attention_mask.new_ones((decoder_attention_mask.shape[0], 1)),
+                        ],
+                        dim=-1,
+                    )
+
+        return model_kwargs
+
+    @torch.no_grad()
+    def generate(
+            self,
+            inputs: Optional[torch.Tensor] = None,
+            generation_config: Optional[GenerationConfig] = None,
+            logits_processor: Optional[LogitsProcessorList] = None,
+            stopping_criteria: Optional[StoppingCriteriaList] = None,
+            prefix_allowed_tokens_fn: Optional[Callable[[int, torch.Tensor], List[int]]] = None,
+            synced_gpus: Optional[bool] = None,
+            assistant_model: Optional["PreTrainedModel"] = None,
+            streamer: Optional["BaseStreamer"] = None,
+            **kwargs,
+    ) -> Union[GenerateOutput, torch.LongTensor]:
+        r"""
+
+        Generates sequences of token ids for models with a language modeling head.
+
+        <Tip warning={true}>
+
+        Most generation-controlling parameters are set in `generation_config` which, if not passed, will be set to the
+        model's default generation configuration. You can override any `generation_config` by passing the corresponding
+        parameters to generate(), e.g. `.generate(inputs, num_beams=4, do_sample=True)`.
+
+        For an overview of generation strategies and code examples, check out the [following
+        guide](../generation_strategies).
+
+        </Tip>
+
+        Parameters:
+            inputs (`torch.Tensor` of varying shape depending on the modality, *optional*):
+                The sequence used as a prompt for the generation or as model inputs to the encoder. If `None` the
+                method initializes it with `bos_token_id` and a batch size of 1. For decoder-only models `inputs`
+                should of in the format of `input_ids`. For encoder-decoder models *inputs* can represent any of
+                `input_ids`, `input_values`, `input_features`, or `pixel_values`.
+            generation_config (`~generation.GenerationConfig`, *optional*):
+                The generation configuration to be used as base parametrization for the generation call. `**kwargs`
+                passed to generate matching the attributes of `generation_config` will override them. If
+                `generation_config` is not provided, the default will be used, which had the following loading
+                priority: 1) from the `generation_config.json` model file, if it exists; 2) from the model
+                configuration. Please note that unspecified parameters will inherit [`~generation.GenerationConfig`]'s
+                default values, whose documentation should be checked to parameterize generation.
+            logits_processor (`LogitsProcessorList`, *optional*):
+                Custom logits processors that complement the default logits processors built from arguments and
+                generation config. If a logit processor is passed that is already created with the arguments or a
+                generation config an error is thrown. This feature is intended for advanced users.
+            stopping_criteria (`StoppingCriteriaList`, *optional*):
+                Custom stopping criteria that complement the default stopping criteria built from arguments and a
+                generation config. If a stopping criteria is passed that is already created with the arguments or a
+                generation config an error is thrown. This feature is intended for advanced users.
+            prefix_allowed_tokens_fn (`Callable[[int, torch.Tensor], List[int]]`, *optional*):
+                If provided, this function constraints the beam search to allowed tokens only at each step. If not
+                provided no constraint is applied. This function takes 2 arguments: the batch ID `batch_id` and
+                `input_ids`. It has to return a list with the allowed tokens for the next generation step conditioned
+                on the batch ID `batch_id` and the previously generated tokens `inputs_ids`. This argument is useful
+                for constrained generation conditioned on the prefix, as described in [Autoregressive Entity
+                Retrieval](https://arxiv.org/abs/2010.00904).
+            synced_gpus (`bool`, *optional*):
+                Whether to continue running the while loop until max_length. Unless overridden this flag will be set to
+                `True` under DeepSpeed ZeRO Stage 3 multiple GPUs environment to avoid hanging if one GPU finished
+                generating before other GPUs. Otherwise it'll be set to `False`.
+            assistant_model (`PreTrainedModel`, *optional*):
+                An assistant model that can be used to accelerate generation. The assistant model must have the exact
+                same tokenizer. The acceleration is achieved when forecasting candidate tokens with the assistent model
+                is much faster than running generation with the model you're calling generate from. As such, the
+                assistant model should be much smaller.
+            streamer (`BaseStreamer`, *optional*):
+                Streamer object that will be used to stream the generated sequences. Generated tokens are passed
+                through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
+            kwargs:
+                Ad hoc parametrization of `generate_config` and/or additional model-specific kwargs that will be
+                forwarded to the `forward` function of the model. If the model is an encoder-decoder model, encoder
+                specific kwargs should not be prefixed and decoder specific kwargs should be prefixed with *decoder_*.
+
+        Return:
+            [`~utils.ModelOutput`] or `torch.LongTensor`: A [`~utils.ModelOutput`] (if `return_dict_in_generate=True`
+            or when `config.return_dict_in_generate=True`) or a `torch.FloatTensor`.
+
+                If the model is *not* an encoder-decoder model (`model.config.is_encoder_decoder=False`), the possible
+                [`~utils.ModelOutput`] types are:
+
+                    - [`~generation.GreedySearchDecoderOnlyOutput`],
+                    - [`~generation.SampleDecoderOnlyOutput`],
+                    - [`~generation.BeamSearchDecoderOnlyOutput`],
+                    - [`~generation.BeamSampleDecoderOnlyOutput`]
+
+                If the model is an encoder-decoder model (`model.config.is_encoder_decoder=True`), the possible
+                [`~utils.ModelOutput`] types are:
+
+                    - [`~generation.GreedySearchEncoderDecoderOutput`],
+                    - [`~generation.SampleEncoderDecoderOutput`],
+                    - [`~generation.BeamSearchEncoderDecoderOutput`],
+                    - [`~generation.BeamSampleEncoderDecoderOutput`]
+        """
+
+        if synced_gpus is None:
+            if is_deepspeed_zero3_enabled() and dist.get_world_size() > 1:
+                synced_gpus = True
+            else:
+                synced_gpus = False
+
+        # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
+        self._validate_model_class()
+
+        # priority: `generation_config` argument > `model.generation_config` (the default generation config)
+        if generation_config is None:
+            # legacy: users may modify the model configuration to control generation -- update the generation config
+            # model attribute accordingly, if it was created from the model config
+            if self.generation_config._from_model_config:
+                new_generation_config = GenerationConfig.from_model_config(self.config)
+                if new_generation_config != self.generation_config:
+                    warnings.warn(
+                        "You have modified the pretrained model configuration to control generation. This is a"
+                        " deprecated strategy to control generation and will be removed soon, in a future version."
+                        " Please use a generation configuration file (see"
+                        " https://huggingface.co/docs/transformers/main_classes/text_generation)"
+                    )
+                    self.generation_config = new_generation_config
+            generation_config = self.generation_config
+
+        generation_config = copy.deepcopy(generation_config)
+        model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs
+        generation_config.validate()
+        self._validate_model_kwargs(model_kwargs.copy())
+
+        # 2. Set generation parameters if not already defined
+        logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
+        stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
+
+        if generation_config.pad_token_id is None and generation_config.eos_token_id is not None:
+            if model_kwargs.get("attention_mask", None) is None:
+                logger.warning(
+                    "The attention mask and the pad token id were not set. As a consequence, you may observe "
+                    "unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results."
+                )
+            eos_token_id = generation_config.eos_token_id
+            if isinstance(eos_token_id, list):
+                eos_token_id = eos_token_id[0]
+            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_id} for open-end generation.")
+            generation_config.pad_token_id = eos_token_id
+
+        # 3. Define model inputs
+        # inputs_tensor has to be defined
+        # model_input_name is defined if model-specific keyword input is passed
+        # otherwise model_input_name is None
+        # all model-specific keyword inputs are removed from `model_kwargs`
+        inputs_tensor, model_input_name, model_kwargs = self._prepare_model_inputs(
+            inputs, generation_config.bos_token_id, model_kwargs
+        )
+        batch_size = inputs_tensor.shape[0]
+
+        # 4. Define other model kwargs
+        model_kwargs["output_attentions"] = generation_config.output_attentions
+        model_kwargs["output_hidden_states"] = generation_config.output_hidden_states
+        model_kwargs["use_cache"] = generation_config.use_cache
+
+        accepts_attention_mask = "attention_mask" in set(inspect.signature(self.forward).parameters.keys())
+        requires_attention_mask = "encoder_outputs" not in model_kwargs
+
+        if model_kwargs.get("attention_mask", None) is None and requires_attention_mask and accepts_attention_mask:
+            model_kwargs["attention_mask"] = self._prepare_attention_mask_for_generation(
+                inputs_tensor, generation_config.pad_token_id, generation_config.eos_token_id
+            )
+
+        # decoder-only models should use left-padding for generation
+        if not self.config.is_encoder_decoder:
+            if (
+                    generation_config.pad_token_id is not None
+                    and torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id) > 0
+            ):
+                logger.warning(
+                    "A decoder-only architecture is being used, but right-padding was detected! For correct "
+                    "generation results, please set `padding_side='left'` when initializing the tokenizer."
+                )
+
+        if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
+            # if model is encoder decoder encoder_outputs are created
+            # and added to `model_kwargs`
+            model_kwargs = self._prepare_encoder_decoder_kwargs_for_generation(
+                inputs_tensor, model_kwargs, model_input_name
+            )
+
+        # 5. Prepare `input_ids` which will be used for auto-regressive generation
+        if self.config.is_encoder_decoder:
+            input_ids, model_kwargs = self._prepare_decoder_input_ids_for_generation(
+                batch_size=batch_size,
+                model_input_name=model_input_name,
+                model_kwargs=model_kwargs,
+                decoder_start_token_id=generation_config.decoder_start_token_id,
+                bos_token_id=generation_config.bos_token_id,
+                device=inputs_tensor.device,
+            )
+        else:
+            input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
+
+        if streamer is not None:
+            streamer.put(input_ids.cpu())
+
+        # 6. Prepare `max_length` depending on other stopping criteria.
+        input_ids_seq_length = input_ids.shape[-1]
+        has_default_max_length = kwargs.get("max_length") is None and generation_config.max_length is not None
+        if has_default_max_length and generation_config.max_new_tokens is None:
+            warnings.warn(
+                f"Using `max_length`'s default ({generation_config.max_length}) to control the generation length. "
+                "This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we"
+                " recommend using `max_new_tokens` to control the maximum length of the generation.",
+                UserWarning,
+            )
+        elif generation_config.max_new_tokens is not None:
+            generation_config.max_length = generation_config.max_new_tokens + input_ids_seq_length
+            if not has_default_max_length:
+                logger.warning(
+                    f"Both `max_new_tokens` (={generation_config.max_new_tokens}) and `max_length`(="
+                    f"{generation_config.max_length}) seem to have been set. `max_new_tokens` will take precedence. "
+                    "Please refer to the documentation for more information. "
+                    "(https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)"
+                )
+
+        if generation_config.min_length is not None and generation_config.min_length > generation_config.max_length:
+            raise ValueError(
+                f"Unfeasible length constraints: the minimum length ({generation_config.min_length}) is larger than"
+                f" the maximum length ({generation_config.max_length})"
+            )
+        if input_ids_seq_length >= generation_config.max_length:
+            input_ids_string = "decoder_input_ids" if self.config.is_encoder_decoder else "input_ids"
+            logger.warning(
+                f"Input length of {input_ids_string} is {input_ids_seq_length}, but `max_length` is set to"
+                f" {generation_config.max_length}. This can lead to unexpected behavior. You should consider"
+                " increasing `max_new_tokens`."
+            )
+
+        # Pad to max_length
+
+        input_ids = torch.cat(
+            [
+                input_ids,
+                torch.ones(
+                    (batch_size, (generation_config.max_length - input_ids_seq_length)),
+                    dtype=torch.long,
+                    device=input_ids.device,
+                )
+                * generation_config.pad_token_id,
+                ],
+            1,
+        )
+
+        # 7. determine generation mode
+        is_constraint_gen_mode = (
+                generation_config.constraints is not None or generation_config.force_words_ids is not None
+        )
+
+        is_contrastive_search_gen_mode = (
+                (generation_config.num_beams == 1)
+                and generation_config.top_k is not None
+                and generation_config.top_k > 1
+                and generation_config.do_sample is False
+                and generation_config.penalty_alpha is not None
+                and generation_config.penalty_alpha > 0
+        )
+
+        is_greedy_gen_mode = (
+                (generation_config.num_beams == 1)
+                and (generation_config.num_beam_groups == 1)
+                and generation_config.do_sample is False
+                and not is_constraint_gen_mode
+                and not is_contrastive_search_gen_mode
+        )
+        is_sample_gen_mode = (
+                (generation_config.num_beams == 1)
+                and (generation_config.num_beam_groups == 1)
+                and generation_config.do_sample is True
+                and not is_constraint_gen_mode
+                and not is_contrastive_search_gen_mode
+        )
+        is_beam_gen_mode = (
+                (generation_config.num_beams > 1)
+                and (generation_config.num_beam_groups == 1)
+                and generation_config.do_sample is False
+                and not is_constraint_gen_mode
+                and not is_contrastive_search_gen_mode
+        )
+        is_beam_sample_gen_mode = (
+                (generation_config.num_beams > 1)
+                and (generation_config.num_beam_groups == 1)
+                and generation_config.do_sample is True
+                and not is_constraint_gen_mode
+                and not is_contrastive_search_gen_mode
+        )
+        is_group_beam_gen_mode = (
+                (generation_config.num_beams > 1)
+                and (generation_config.num_beam_groups > 1)
+                and not is_constraint_gen_mode
+                and not is_contrastive_search_gen_mode
+        )
+        is_assisted_gen_mode = False
+        if assistant_model is not None:
+            if not (is_greedy_gen_mode or is_sample_gen_mode):
+                raise ValueError(
+                    "You've set `assistant_model`, which triggers assisted generate. Currently, assisted generate "
+                    "is only supported with Greedy Search and Sample."
+                )
+            is_assisted_gen_mode = True
+
+        if generation_config.num_beam_groups > generation_config.num_beams:
+            raise ValueError("`num_beam_groups` has to be smaller or equal to `num_beams`")
+        if is_group_beam_gen_mode and generation_config.do_sample is True:
+            raise ValueError(
+                "Diverse beam search cannot be used in sampling mode. Make sure that `do_sample` is set to `False`."
+            )
+
+        if streamer is not None and (generation_config.num_beams > 1):
+            raise ValueError(
+                "`streamer` cannot be used with beam search (yet!). Make sure that `num_beams` is set to 1."
+            )
+
+        if self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .generate() with the `input_ids` being on a device type different"
+                f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
+                f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
+                " Please make sure that you have put `input_ids` to the"
+                f" correct device by calling for example input_ids = input_ids.to('{self.device.type}') before"
+                " running `.generate()`.",
+                UserWarning,
+            )
+
+        # 8. prepare distribution pre_processing samplers
+        logits_processor = self._get_logits_processor(
+            generation_config=generation_config,
+            input_ids_seq_length=input_ids_seq_length,
+            encoder_input_ids=inputs_tensor,
+            prefix_allowed_tokens_fn=prefix_allowed_tokens_fn,
+            logits_processor=logits_processor,
+        )
+
+        # 9. prepare stopping criteria
+        stopping_criteria = self._get_stopping_criteria(
+            generation_config=generation_config, stopping_criteria=stopping_criteria
+        )
+        # 10. go into different generation modes
+        if is_assisted_gen_mode:
+            if generation_config.num_return_sequences > 1:
+                raise ValueError(
+                    "num_return_sequences has to be 1 when doing assisted generate, "
+                    f"but is {generation_config.num_return_sequences}."
+                )
+            if batch_size > 1:
+                raise ValueError("assisted generate is only supported for batch_size = 1")
+            if not model_kwargs["use_cache"]:
+                raise ValueError("assisted generate requires `use_cache=True`")
+
+            # 11. If the assistant model is an encoder-decoder, prepare its encoder outputs
+            if assistant_model.config.is_encoder_decoder:
+                assistant_model_kwargs = copy.deepcopy(model_kwargs)
+                inputs_tensor, model_input_name, assistant_model_kwargs = assistant_model._prepare_model_inputs(
+                    inputs_tensor, assistant_model.generation_config.bos_token_id, assistant_model_kwargs
+                )
+                assistant_model_kwargs = assistant_model._prepare_encoder_decoder_kwargs_for_generation(
+                    inputs_tensor, assistant_model_kwargs, model_input_name
+                )
+                model_kwargs["assistant_encoder_outputs"] = assistant_model_kwargs["encoder_outputs"]
+
+            # 12. run assisted generate
+            return self.assisted_decoding(
+                input_ids,
+                assistant_model=assistant_model,
+                do_sample=generation_config.do_sample,
+                logits_processor=logits_processor,
+                logits_warper=self._get_logits_warper(generation_config) if generation_config.do_sample else None,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                streamer=streamer,
+                **model_kwargs,
+            )
+        if is_greedy_gen_mode:
+            if generation_config.num_return_sequences > 1:
+                raise ValueError(
+                    "num_return_sequences has to be 1 when doing greedy search, "
+                    f"but is {generation_config.num_return_sequences}."
+                )
+
+            # 11. run greedy search
+            return self.greedy_search(
+                input_ids,
+                logits_processor=logits_processor,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                seq_length=input_ids_seq_length,
+                streamer=streamer,
+                **model_kwargs,
+            )
+
+        elif is_contrastive_search_gen_mode:
+            if generation_config.num_return_sequences > 1:
+                raise ValueError(
+                    "num_return_sequences has to be 1 when doing contrastive search, "
+                    f"but is {generation_config.num_return_sequences}."
+                )
+            if not model_kwargs["use_cache"]:
+                raise ValueError("Contrastive search requires `use_cache=True`")
+
+            return self.contrastive_search(
+                input_ids,
+                top_k=generation_config.top_k,
+                penalty_alpha=generation_config.penalty_alpha,
+                logits_processor=logits_processor,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                streamer=streamer,
+                **model_kwargs,
+            )
+
+        elif is_sample_gen_mode:
+            # 11. prepare logits warper
+            logits_warper = self._get_logits_warper(generation_config)
+
+            # 12. expand input_ids with `num_return_sequences` additional sequences per batch
+            input_ids, model_kwargs = self._expand_inputs_for_generation(
+                input_ids=input_ids,
+                expand_size=generation_config.num_return_sequences,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                **model_kwargs,
+            )
+
+            # 13. run sample
+            return self.sample(
+                input_ids,
+                logits_processor=logits_processor,
+                logits_warper=logits_warper,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                streamer=streamer,
+                **model_kwargs,
+            )
+
+        elif is_beam_gen_mode:
+            if generation_config.num_return_sequences > generation_config.num_beams:
+                raise ValueError("`num_return_sequences` has to be smaller or equal to `num_beams`.")
+
+            if stopping_criteria.max_length is None:
+                raise ValueError("`max_length` needs to be a stopping_criteria for now.")
+
+            # 11. prepare beam search scorer
+            beam_scorer = BeamSearchScorer(
+                batch_size=batch_size,
+                num_beams=generation_config.num_beams,
+                device=inputs_tensor.device,
+                length_penalty=generation_config.length_penalty,
+                do_early_stopping=generation_config.early_stopping,
+                num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                max_length=generation_config.max_length,
+            )
+            # 12. interleave input_ids with `num_beams` additional sequences per batch
+            input_ids, model_kwargs = self._expand_inputs_for_generation(
+                input_ids=input_ids,
+                expand_size=generation_config.num_beams,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                **model_kwargs,
+            )
+            # 13. run beam search
+            return self.beam_search(
+                input_ids,
+                beam_scorer,
+                logits_processor=logits_processor,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                **model_kwargs,
+            )
+
+        elif is_beam_sample_gen_mode:
+            # 11. prepare logits warper
+            logits_warper = self._get_logits_warper(generation_config)
+
+            if stopping_criteria.max_length is None:
+                raise ValueError("`max_length` needs to be a stopping_criteria for now.")
+            # 12. prepare beam search scorer
+            beam_scorer = BeamSearchScorer(
+                batch_size=batch_size * generation_config.num_return_sequences,
+                num_beams=generation_config.num_beams,
+                device=inputs_tensor.device,
+                length_penalty=generation_config.length_penalty,
+                do_early_stopping=generation_config.early_stopping,
+                max_length=generation_config.max_length,
+            )
+
+            # 13. interleave input_ids with `num_beams` additional sequences per batch
+            input_ids, model_kwargs = self._expand_inputs_for_generation(
+                input_ids=input_ids,
+                expand_size=generation_config.num_beams * generation_config.num_return_sequences,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                **model_kwargs,
+            )
+
+            # 14. run beam sample
+            return self.beam_sample(
+                input_ids,
+                beam_scorer,
+                logits_processor=logits_processor,
+                logits_warper=logits_warper,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                **model_kwargs,
+            )
+
+        elif is_group_beam_gen_mode:
+            if generation_config.num_return_sequences > generation_config.num_beams:
+                raise ValueError("`num_return_sequences` has to be smaller or equal to `num_beams`.")
+
+            if generation_config.num_beams % generation_config.num_beam_groups != 0:
+                raise ValueError("`num_beams` should be divisible by `num_beam_groups` for group beam search.")
+
+            if stopping_criteria.max_length is None:
+                raise ValueError("`max_length` needs to be a stopping_criteria for now.")
+
+            has_default_typical_p = kwargs.get("typical_p") is None and generation_config.typical_p == 1.0
+            if not has_default_typical_p:
+                raise ValueError("Decoder argument `typical_p` is not supported with beam groups.")
+
+            # 11. prepare beam search scorer
+            beam_scorer = BeamSearchScorer(
+                batch_size=batch_size,
+                num_beams=generation_config.num_beams,
+                device=inputs_tensor.device,
+                length_penalty=generation_config.length_penalty,
+                do_early_stopping=generation_config.early_stopping,
+                num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                num_beam_groups=generation_config.num_beam_groups,
+                max_length=generation_config.max_length,
+            )
+            # 12. interleave input_ids with `num_beams` additional sequences per batch
+            input_ids, model_kwargs = self._expand_inputs_for_generation(
+                input_ids=input_ids,
+                expand_size=generation_config.num_beams,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                **model_kwargs,
+            )
+            # 13. run beam search
+            return self.group_beam_search(
+                input_ids,
+                beam_scorer,
+                logits_processor=logits_processor,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                **model_kwargs,
+            )
+
+        elif is_constraint_gen_mode:
+            if generation_config.num_return_sequences > generation_config.num_beams:
+                raise ValueError("`num_return_sequences` has to be smaller or equal to `num_beams`.")
+
+            if stopping_criteria.max_length is None:
+                raise ValueError("`max_length` needs to be a stopping_criteria for now.")
+
+            if generation_config.num_beams <= 1:
+                raise ValueError("`num_beams` needs to be greater than 1 for constrained generation.")
+
+            if generation_config.do_sample:
+                raise ValueError("`do_sample` needs to be false for constrained generation.")
+
+            if generation_config.num_beam_groups is not None and generation_config.num_beam_groups > 1:
+                raise ValueError("`num_beam_groups` not supported yet for constrained generation.")
+
+            final_constraints = []
+            if generation_config.constraints is not None:
+                final_constraints = generation_config.constraints
+
+            if generation_config.force_words_ids is not None:
+
+                def typeerror():
+                    raise ValueError(
+                        "`force_words_ids` has to either be a `List[List[List[int]]]` or `List[List[int]]`"
+                        f"of positive integers, but is {generation_config.force_words_ids}."
+                    )
+
+                if (
+                        not isinstance(generation_config.force_words_ids, list)
+                        or len(generation_config.force_words_ids) == 0
+                ):
+                    typeerror()
+
+                for word_ids in generation_config.force_words_ids:
+                    if isinstance(word_ids[0], list):
+                        if not isinstance(word_ids, list) or len(word_ids) == 0:
+                            typeerror()
+                        if any(not isinstance(token_ids, list) for token_ids in word_ids):
+                            typeerror()
+                        if any(
+                                any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids)
+                                for token_ids in word_ids
+                        ):
+                            typeerror()
+
+                        constraint = DisjunctiveConstraint(word_ids)
+                    else:
+                        if not isinstance(word_ids, list) or len(word_ids) == 0:
+                            typeerror()
+                        if any((not isinstance(token_id, int) or token_id < 0) for token_id in word_ids):
+                            typeerror()
+
+                        constraint = PhrasalConstraint(word_ids)
+                    final_constraints.append(constraint)
+
+            # 11. prepare beam search scorer
+            constrained_beam_scorer = ConstrainedBeamSearchScorer(
+                constraints=final_constraints,
+                batch_size=batch_size,
+                num_beams=generation_config.num_beams,
+                device=inputs_tensor.device,
+                length_penalty=generation_config.length_penalty,
+                do_early_stopping=generation_config.early_stopping,
+                num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                max_length=generation_config.max_length,
+            )
+            # 12. interleave input_ids with `num_beams` additional sequences per batch
+            input_ids, model_kwargs = self._expand_inputs_for_generation(
+                input_ids=input_ids,
+                expand_size=generation_config.num_beams,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                **model_kwargs,
+            )
+            # 13. run beam search
+            return self.constrained_beam_search(
+                input_ids,
+                constrained_beam_scorer=constrained_beam_scorer,
+                logits_processor=logits_processor,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=generation_config.pad_token_id,
+                eos_token_id=generation_config.eos_token_id,
+                output_scores=generation_config.output_scores,
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                synced_gpus=synced_gpus,
+                **model_kwargs,
+            )
+
+    def greedy_search(
+            self,
+            input_ids: torch.LongTensor,
+            logits_processor: Optional[LogitsProcessorList] = None,
+            stopping_criteria: Optional[StoppingCriteriaList] = None,
+            max_length: Optional[int] = None,
+            pad_token_id: Optional[int] = None,
+            eos_token_id: Optional[Union[int, List[int]]] = None,
+            output_attentions: Optional[bool] = None,
+            output_hidden_states: Optional[bool] = None,
+            output_scores: Optional[bool] = None,
+            return_dict_in_generate: Optional[bool] = None,
+            synced_gpus: bool = False,
+            seq_length: Optional[int] = int,
+            streamer: Optional["BaseStreamer"] = None,
+            **model_kwargs,
+    ) -> Union[GreedySearchOutput, torch.LongTensor]:
+        r"""
+        Generates sequences of token ids for models with a language modeling head using **greedy decoding** and can be
+        used for text-decoder, text-to-text, speech-to-text, and vision-to-text models.
+
+        <Tip warning={true}>
+
+        In most cases, you do not need to call [`~generation.GenerationMixin.greedy_search`] directly. Use generate()
+        instead. For an overview of generation strategies and code examples, check the [following
+        guide](../generation_strategies).
+
+        </Tip>
+
+
+        Parameters:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                The sequence used as a prompt for the generation.
+            logits_processor (`LogitsProcessorList`, *optional*):
+                An instance of [`LogitsProcessorList`]. List of instances of class derived from [`LogitsProcessor`]
+                used to modify the prediction scores of the language modeling head applied at each generation step.
+            stopping_criteria (`StoppingCriteriaList`, *optional*):
+                An instance of [`StoppingCriteriaList`]. List of instances of class derived from [`StoppingCriteria`]
+                used to tell if the generation loop should stop.
+
+            max_length (`int`, *optional*, defaults to 20):
+                **DEPRECATED**. Use `logits_processor` or `stopping_criteria` directly to cap the number of generated
+                tokens. The maximum length of the sequence to be generated.
+            pad_token_id (`int`, *optional*):
+                The id of the *padding* token.
+            eos_token_id (`Union[int, List[int]]`, *optional*):
+                The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
+            output_attentions (`bool`, *optional*, defaults to `False`):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more details.
+            output_hidden_states (`bool`, *optional*, defaults to `False`):
+                Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
+                for more details.
+            output_scores (`bool`, *optional*, defaults to `False`):
+                Whether or not to return the prediction scores. See `scores` under returned tensors for more details.
+            return_dict_in_generate (`bool`, *optional*, defaults to `False`):
+                Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+            synced_gpus (`bool`, *optional*, defaults to `False`):
+                Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
+            seq_length:
+                Length of current input_ids sequence
+            streamer (`BaseStreamer`, *optional*):
+                Streamer object that will be used to stream the generated sequences. Generated tokens are passed
+                through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
+                Unsupported for XLA devices
+            model_kwargs:
+                Additional model specific keyword arguments will be forwarded to the `forward` function of the model.
+                If model is an encoder-decoder model the kwargs should include `encoder_outputs`.
+
+        Return:
+            [`~generation.GreedySearchDecoderOnlyOutput`], [`~generation.GreedySearchEncoderDecoderOutput`] or
+            `torch.LongTensor`: A `torch.LongTensor` containing the generated tokens (default behaviour) or a
+            [`~generation.GreedySearchDecoderOnlyOutput`] if `model.config.is_encoder_decoder=False` and
+            `return_dict_in_generate=True` or a [`~generation.GreedySearchEncoderDecoderOutput`] if
+            `model.config.is_encoder_decoder=True`.
+
+        Examples:
+
+        ```python
+        >>> from transformers import (
+        ...     AutoTokenizer,
+        ...     AutoModelForCausalLM,
+        ...     LogitsProcessorList,
+        ...     MinLengthLogitsProcessor,
+        ...     StoppingCriteriaList,
+        ...     MaxLengthCriteria,
+        ... )
+
+        >>> tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
+
+        >>> # set pad_token_id to eos_token_id because GPT2 does not have a PAD token
+        >>> model.generation_config.pad_token_id = model.generation_config.eos_token_id
+
+        >>> input_prompt = "It might be possible to"
+        >>> input_ids = tokenizer(input_prompt, return_tensors="pt").input_ids
+
+        >>> # instantiate logits processors
+        >>> logits_processor = LogitsProcessorList(
+        ...     [
+        ...         MinLengthLogitsProcessor(10, eos_token_id=model.generation_config.eos_token_id),
+        ...     ]
+        ... )
+        >>> stopping_criteria = StoppingCriteriaList([MaxLengthCriteria(max_length=20)])
+
+        >>> outputs = model.greedy_search(
+        ...     input_ids, logits_processor=logits_processor, stopping_criteria=stopping_criteria
+        ... )
+
+        >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        ["It might be possible to get a better understanding of the nature of the problem, but it's not"]
+        ```"""
+        # init values
+        logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
+        use_cache = model_kwargs["use_cache"] if "use_cache" in model_kwargs else False
+        stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
+        if max_length is not None:
+            warnings.warn(
+                "`max_length` is deprecated in this function, use"
+                " `stopping_criteria=StoppingCriteriaList([MaxLengthCriteria(max_length=max_length)])` instead.",
+                UserWarning,
+            )
+            stopping_criteria = validate_stopping_criteria(stopping_criteria, max_length)
+        pad_token_id = pad_token_id if pad_token_id is not None else self.generation_config.pad_token_id
+        eos_token_id = eos_token_id if eos_token_id is not None else self.generation_config.eos_token_id
+        if isinstance(eos_token_id, int):
+            eos_token_id = [eos_token_id]
+        eos_token_id_tensor = torch.tensor(eos_token_id).to(input_ids.device) if eos_token_id is not None else None
+        output_scores = output_scores if output_scores is not None else self.generation_config.output_scores
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.generation_config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
+        )
+        return_dict_in_generate = (
+            return_dict_in_generate
+            if return_dict_in_generate is not None
+            else self.generation_config.return_dict_in_generate
+        )
+
+        # init attention / hidden states / scores tuples
+        scores = () if (return_dict_in_generate and output_scores) else None
+        decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
+        cross_attentions = () if (return_dict_in_generate and output_attentions) else None
+        decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+
+        # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
+        if return_dict_in_generate and self.config.is_encoder_decoder:
+            encoder_attentions = model_kwargs["encoder_outputs"].get("attentions") if output_attentions else None
+            encoder_hidden_states = (
+                model_kwargs["encoder_outputs"].get("hidden_states") if output_hidden_states else None
+            )
+
+        # keep track of which sequences are already finished
+        unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
+
+        this_peer_finished = False  # used by synced_gpus only
+        while True:
+            if synced_gpus:
+                # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
+                # The following logic allows an early break if all peers finished generating their sequence
+                this_peer_finished_flag = torch.tensor(0.0 if this_peer_finished else 1.0).to(input_ids.device)
+                # send 0.0 if we finished, 1.0 otherwise
+                dist.all_reduce(this_peer_finished_flag, op=dist.ReduceOp.SUM)
+                # did all peers finish? the reduced sum will be 0.0 then
+                if this_peer_finished_flag.item() == 0.0:
+                    break
+
+            # prepare model inputs
+            if use_cache:
+                # From max_length-sized input_ids, select first
+                # seq_length - 1 values.
+                update_indices = torch.stack(
+                    [torch.arange(input_ids.size(0)), torch.tensor(seq_length - 1).repeat(input_ids.size(0))], dim=-1
+                )
+                input_ids_ = input_ids[update_indices[:, 0], update_indices[:, 1], None]
+                model_inputs = self.prepare_inputs_for_generation(input_ids_, **model_kwargs)
+            else:
+                model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+
+            # forward pass to get next token
+            outputs = self(
+                **model_inputs,
+                return_dict=True,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+            )
+
+            if synced_gpus and this_peer_finished:
+                continue  # don't waste resources running the code we don't need
+
+            if not use_cache:
+                one_hot = (
+                    torch.cat(
+                        [
+                            torch.tensor([0]).repeat(1, seq_length - 1),
+                            torch.tensor([1]).repeat(1, 1),
+                            torch.tensor([0]).repeat(1, input_ids.size(1) - seq_length),
+                        ],
+                        dim=1,
+                    )
+                    .to(device=outputs.logits.device)
+                    .float()
+                )
+                next_token_logits = torch.matmul(one_hot, outputs.logits)
+                next_token_logits = next_token_logits.squeeze(1)
+            else:
+                next_token_logits = outputs.logits[:, -1, :]
+
+            # pre-process distribution
+            next_tokens_scores = logits_processor(input_ids, next_token_logits)
+
+            # Store scores, attentions and hidden_states when required
+            if return_dict_in_generate:
+                if output_scores:
+                    scores += (next_tokens_scores,)
+                if output_attentions:
+                    decoder_attentions += (
+                        (outputs.decoder_attentions,) if self.config.is_encoder_decoder else (outputs.attentions,)
+                    )
+                    if self.config.is_encoder_decoder:
+                        cross_attentions += (outputs.cross_attentions,)
+
+                if output_hidden_states:
+                    decoder_hidden_states += (
+                        (outputs.decoder_hidden_states,)
+                        if self.config.is_encoder_decoder
+                        else (outputs.hidden_states,)
+                    )
+
+            # argmax
+            next_tokens = torch.argmax(next_tokens_scores, dim=-1)
+
+            # finished sentences should have their next token be a padding token
+            if eos_token_id is not None:
+                if pad_token_id is None:
+                    raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
+                next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
+
+            # update generated ids, model inputs, and length for next step
+
+            batch_size, _ = input_ids.shape
+            update_indices = torch.stack(
+                [torch.arange(batch_size), torch.tensor(seq_length).repeat(batch_size)], dim=-1
+            )
+            input_ids[update_indices[:, 0], update_indices[:, 1]] = next_tokens[:]
+            model_kwargs = self._update_model_kwargs_for_xla_generation(
+                outputs,
+                model_kwargs,
+                batch_size=batch_size,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                max_length=stopping_criteria.max_length,
+                seq_length=seq_length,
+                use_cache=use_cache,
+            )
+
+            seq_length += 1
+
+            # if eos_token was found in one sentence, set sentence to finished
+            if eos_token_id_tensor is not None:
+                unfinished_sequences = unfinished_sequences.mul(
+                    next_tokens.tile(eos_token_id_tensor.shape[0], 1).ne(eos_token_id_tensor.unsqueeze(1)).prod(dim=0)
+                )
+
+            xm.mark_step()
+
+            # stop when each sentence is finished, or if we exceed the maximum length
+            stop_criterion_1 = unfinished_sequences.max() == 0
+
+            if isinstance(stopping_criteria, list):
+                if len(stopping_criteria) == 1:
+                    stopping_criteria = stopping_criteria[0]
+
+            # Cases that can be handled in XLA without requiring
+            # non-padded input_ids
+            if isinstance(stopping_criteria, MaxLengthCriteria):
+                stop_criterion_2 = seq_length >= stopping_criteria.max_length
+            elif isinstance(stopping_criteria, MaxTimeCriteria):
+                stop_criterion_2 = stopping_criteria(input_ids, scores)
+            else:
+                # Other cases will be handled on CPU
+                batch_size, _ = input_ids.shape
+                mask = torch.cat(
+                    [torch.ones(batch_size, seq_length), torch.zeros(batch_size, input_ids.shape[1] - seq_length)],
+                    dim=1,
+                ).bool()
+                input_ids_cpu = torch.masked_select(input_ids, mask).reshape((batch_size, seq_length)).to("cpu")
+                scores_cpu = scores.to("cpu") if torch.is_tensor(scores) else scores
+                stop_criterion_2 = stopping_criteria(input_ids_cpu, scores_cpu)
+
+            if stop_criterion_1 or stop_criterion_2:
+                this_peer_finished = True
+
+            if this_peer_finished and not synced_gpus:
+                break
+
+        if streamer is not None:
+            streamer.end()
+
+        if return_dict_in_generate:
+            if self.config.is_encoder_decoder:
+                return GreedySearchEncoderDecoderOutput(
+                    sequences=input_ids,
+                    scores=scores,
+                    encoder_attentions=encoder_attentions,
+                    encoder_hidden_states=encoder_hidden_states,
+                    decoder_attentions=decoder_attentions,
+                    cross_attentions=cross_attentions,
+                    decoder_hidden_states=decoder_hidden_states,
+                )
+            else:
+                return GreedySearchDecoderOnlyOutput(
+                    sequences=input_ids,
+                    scores=scores,
+                    attentions=decoder_attentions,
+                    hidden_states=decoder_hidden_states,
+                )
+        else:
+            return input_ids
+

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -62,6 +62,29 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
             raise AssertionError("Failed to initialize torch.distributed process group using XLA backend.")
 
 
+def patch_generation_mixin_to_neuron_generation_mixin(model: "PreTrainedModel"):
+    """
+    Changes the vanilla `GenerationMixin` class from Transformers to `NeuronGenerationMixin` in the model's
+    inheritance. This allows to make the model Neuron-compatible for generation without much hassle.
+    """
+    to_visit = [model.__class__]
+    should_stop = False
+    while to_visit and not should_stop:
+        cls = to_visit.pop(0)
+        bases = cls.__bases__
+        new_bases = []
+        for base in bases:
+            to_visit.append(base)
+            if base == GenerationMixin:
+                new_bases.append(NeuronGenerationMixin)
+                should_stop = True
+            elif base == NeuronGenerationMixin:
+                should_stop = True
+                new_bases.append(base)
+            else:
+                new_bases.append(base)
+        cls.__bases__ = tuple(new_bases)
+
 class AugmentTrainerForTrainiumMixin:
     def __init__(self, *args, **kwargs):
         if not isinstance(self, Trainer):
@@ -95,7 +118,7 @@ class AugmentTrainerForTrainiumMixin:
             self.add_callback(callback)
 
         # Make the model Neuron-compatible for generation.
-        self.patch_generation_mixin_to_neuron_generation_mixin(self.model)
+        patch_generation_mixin_to_neuron_generation_mixin(self.model)
 
     def prepare_args_for_precompilation(self, args: "TrainingArguments"):
         if args.num_train_epochs != 1:
@@ -112,36 +135,7 @@ class AugmentTrainerForTrainiumMixin:
             args.do_predict = False
 
     def validate_args(self, args: "TrainingArguments"):
-        if isinstance(self, Seq2SeqTrainer):
-            validate_arg(
-                args,
-                "prediction_loss_only",
-                "prediction_loss_only=False is not supported for now because it requires generation.",
-                expected_value=True,
-            )
-
-    def patch_generation_mixin_to_neuron_generation_mixin(self, model: "PreTrainedModel"):
-        """
-        Changes the vanilla `GenerationMixin` class from Transformers to `NeuronGenerationMixin` in the model's
-        inheritance. This allows to make the model Neuron-compatible for generation without much hassle.
-        """
-        to_visit = [model.__class__]
-        should_stop = False
-        while to_visit and not should_stop:
-            cls = to_visit.pop(0)
-            bases = cls.__bases__
-            new_bases = []
-            for base in bases:
-                to_visit.append(base)
-                if base == GenerationMixin:
-                    new_bases.append(NeuronGenerationMixin)
-                    should_stop = True
-                elif base == NeuronGenerationMixin:
-                    should_stop = True
-                    new_bases.append(base)
-                else:
-                    new_bases.append(base)
-            cls.__bases__ = tuple(new_bases)
+        pass
 
     def _wrap_model(self, model, training=True, dataloader=None):
         logger.info(

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -26,7 +26,6 @@ from transformers import GenerationMixin, Seq2SeqTrainer, Trainer
 from ..utils import logging
 from .generation import NeuronGenerationMixin
 from .trainer_callback import NeuronCacheCallaback
-from .utils.argument_utils import validate_arg
 from .utils.cache_utils import get_neuron_cache_path
 from .utils.training_utils import (
     FirstAndLastDataset,
@@ -84,6 +83,7 @@ def patch_generation_mixin_to_neuron_generation_mixin(model: "PreTrainedModel"):
             else:
                 new_bases.append(base)
         cls.__bases__ = tuple(new_bases)
+
 
 class AugmentTrainerForTrainiumMixin:
     def __init__(self, *args, **kwargs):

--- a/optimum/neuron/utils/compilation_utils.py
+++ b/optimum/neuron/utils/compilation_utils.py
@@ -131,7 +131,6 @@ class ExampleRunner:
             "set_max_target_length": True,
             "extra_command_line_arguments": [
                 "--pad_to_max_length",
-                "--prediction_loss_only",
             ],
         },
         "translation": {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,57 @@
+import os
+
+import numpy as np
+from transformers import (
+    AutoTokenizer,
+    AutoModelForSeq2SeqLM,
+)
+
+from optimum.neuron.trainers import patch_generation_mixin_to_neuron_generation_mixin
+
+
+def _create_samples(model_name="t5-small", device="cpu", use_cache=False):
+    if device == "xla":
+        import torch_xla.core.xla_model as xm
+        device = xm.xla_device()
+    else:
+        device = "cpu"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    patch_generation_mixin_to_neuron_generation_mixin(model)
+    model.generation_config.pad_token_id = model.generation_config.eos_token_id
+    task_prompt = "translate English to German: "
+    input_strings = [
+        "How old are you?",
+        "What is your name?",
+        "We work at Amazon",
+        "I am trying to test the generation method"
+    ]
+
+    results = []
+    if device == "xla":
+        xm.mark_step()
+    for input_str in input_strings:
+        encoder_input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length",
+                                      max_length=50).to(device)
+        outputs = model.generate(
+            **encoder_input_ids, max_new_tokens=20, use_cache=False
+        )
+        outputs = outputs.detach().cpu().numpy()
+        if device == "cpu":
+            outputs = np.pad(outputs, ((0, 0), (0, 21 - outputs.shape[-1])))
+        results.append(outputs)
+
+    return np.array(results)
+
+
+def test_greedy():
+    os.environ['XLA_USE_BF16'] = '0'
+    xla_neuron_samples_fp32 = _create_samples(device="xla")
+    os.environ['XLA_USE_BF16'] = '1'
+    xla_neuron_samples_bf16 = _create_samples(device="xla")
+
+    cpu_samples = _create_samples(device="cpu")
+
+    assert np.array_equal(cpu_samples, xla_neuron_samples_fp32), "XLA Neuron FP32 output doesn't match CPU only output"
+    assert np.array_equal(cpu_samples, xla_neuron_samples_bf16), "XLA Neuron bf16 output doesn't match CPU only output"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,35 +2,39 @@ import os
 
 import numpy as np
 import pytest
-from optimum.neuron.utils.testing_utils import is_trainium_test
 from transformers import (
-    AutoTokenizer,
-    AutoModelForSeq2SeqLM,
-    AutoModelForCausalLM,
     AutoConfig,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
 )
 from transformers.generation.configuration_utils import GenerationConfig
 
 from optimum.neuron.trainers import patch_generation_mixin_to_neuron_generation_mixin
+from optimum.neuron.utils.testing_utils import is_trainium_test
 
 
 def _test_greedy_decoding(model_name, device="cpu", use_cache=False, decoder_only=False):
     if device == "xla":
         import torch_xla.core.xla_model as xm
+
         device = xm.xla_device()
     else:
         device = "cpu"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name).to(device) if decoder_only else \
-        AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    model = (
+        AutoModelForCausalLM.from_pretrained(model_name).to(device)
+        if decoder_only
+        else AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    )
     model_config = AutoConfig.from_pretrained(model_name)
     generation_config = GenerationConfig.from_model_config(model_config)
 
     if decoder_only:
         tokenizer.pad_token = tokenizer.eos_token
         model.config.pad_token_id = tokenizer.pad_token_id
-        tokenizer.padding_side = 'left'
+        tokenizer.padding_side = "left"
         generation_config.pad_token_id = generation_config.eos_token_id
 
     # Set to greedy search
@@ -45,18 +49,17 @@ def _test_greedy_decoding(model_name, device="cpu", use_cache=False, decoder_onl
         "How old are you?",
         "What is your name?",
         "We work at Amazon",
-        "I am trying to test the generation method"
+        "I am trying to test the generation method",
     ]
 
     results = []
     if device == "xla":
         xm.mark_step()
     for input_str in input_strings:
-        input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length",
-                              max_length=50).to(device)
-        outputs = model.generate(
-            **input_ids, max_new_tokens=20, use_cache=False, generation_config=generation_config
+        input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length", max_length=50).to(
+            device
         )
+        outputs = model.generate(**input_ids, max_new_tokens=20, use_cache=False, generation_config=generation_config)
         outputs = outputs.detach().cpu().numpy()
         results.append(outputs)
 
@@ -64,17 +67,17 @@ def _test_greedy_decoding(model_name, device="cpu", use_cache=False, decoder_onl
 
 
 testdata = [
-    ('t5-small', True, False),
-    ('t5-small', False, False),
+    ("t5-small", True, False),
+    ("t5-small", False, False),
 ]
 
 
 @is_trainium_test
 @pytest.mark.parametrize("model_name, use_cache, decoder_only", testdata)
 def test_greedy_decoding(model_name, use_cache, decoder_only):
-    os.environ['XLA_USE_BF16'] = '0'
+    os.environ["XLA_USE_BF16"] = "0"
     xla_neuron_samples_fp32 = _test_greedy_decoding(model_name=model_name, device="xla", decoder_only=decoder_only)
-    os.environ['XLA_USE_BF16'] = '1'
+    os.environ["XLA_USE_BF16"] = "1"
     xla_neuron_samples_bf16 = _test_greedy_decoding(model_name=model_name, device="xla", decoder_only=decoder_only)
 
     cpu_samples = _test_greedy_decoding(model_name=model_name, device="cpu", decoder_only=decoder_only)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -5,6 +5,7 @@ import pytest
 from transformers import (
     AutoTokenizer,
     AutoModelForSeq2SeqLM,
+    AutoModelForCausalLM,
     AutoConfig,
 )
 from transformers.generation.configuration_utils import GenerationConfig
@@ -12,7 +13,7 @@ from transformers.generation.configuration_utils import GenerationConfig
 from optimum.neuron.trainers import patch_generation_mixin_to_neuron_generation_mixin
 
 
-def _test_greedy_decoding(model_name, device="cpu", use_cache=False):
+def _test_greedy_decoding(model_name, device="cpu", use_cache=False, decoder_only=False):
     if device == "xla":
         import torch_xla.core.xla_model as xm
         device = xm.xla_device()
@@ -20,14 +21,22 @@ def _test_greedy_decoding(model_name, device="cpu", use_cache=False):
         device = "cpu"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    model = AutoModelForCausalLM.from_pretrained(model_name).to(device) if decoder_only else \
+        AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
     model_config = AutoConfig.from_pretrained(model_name)
     generation_config = GenerationConfig.from_model_config(model_config)
+
+    if decoder_only:
+        tokenizer.pad_token = tokenizer.eos_token
+        model.config.pad_token_id = tokenizer.pad_token_id
+        tokenizer.padding_side = 'left'
+        generation_config.pad_token_id = generation_config.eos_token_id
 
     # Set to greedy search
     generation_config.num_beams = 1
     generation_config.do_sample = False
     generation_config.use_cache = use_cache
+
 
     patch_generation_mixin_to_neuron_generation_mixin(model)
     model.generation_config.pad_token_id = model.generation_config.eos_token_id
@@ -43,33 +52,34 @@ def _test_greedy_decoding(model_name, device="cpu", use_cache=False):
     if device == "xla":
         xm.mark_step()
     for input_str in input_strings:
-        encoder_input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length",
+
+        input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length",
                                       max_length=50).to(device)
         outputs = model.generate(
-            **encoder_input_ids, max_new_tokens=20, use_cache=False, generation_config=generation_config
+            **input_ids, max_new_tokens=20, use_cache=False, generation_config=generation_config
         )
         outputs = outputs.detach().cpu().numpy()
-        if device == "cpu":
-            outputs = np.pad(outputs, ((0, 0), (0, 21 - outputs.shape[-1])))
         results.append(outputs)
 
     return np.array(results)
 
 
 testdata = [
-    ('t5-small', True),
-    ('t5-small', False),
+    ('t5-small', True, False),
+    ('t5-small', False, False),
 ]
 
 
-@pytest.mark.parametrize("model_name, use_cache", testdata)
-def test_greedy_decoding(model_name, use_cache):
+@pytest.mark.parametrize("model_name, use_cache, decoder_only", testdata)
+def test_greedy_decoding(model_name, use_cache, decoder_only):
     os.environ['XLA_USE_BF16'] = '0'
-    xla_neuron_samples_fp32 = _test_greedy_decoding(model_name=model_name, device="xla")
+    xla_neuron_samples_fp32 = _test_greedy_decoding(model_name=model_name, device="xla", decoder_only=decoder_only)
     os.environ['XLA_USE_BF16'] = '1'
-    xla_neuron_samples_bf16 = _test_greedy_decoding(model_name=model_name, device="xla")
+    xla_neuron_samples_bf16 = _test_greedy_decoding(model_name=model_name, device="xla", decoder_only=decoder_only)
 
-    cpu_samples = _test_greedy_decoding(model_name=model_name, device="cpu")
+    cpu_samples = _test_greedy_decoding(model_name=model_name, device="cpu", decoder_only=decoder_only)
 
     assert np.array_equal(cpu_samples, xla_neuron_samples_fp32), "XLA Neuron FP32 output doesn't match CPU only output"
     assert np.array_equal(cpu_samples, xla_neuron_samples_bf16), "XLA Neuron bf16 output doesn't match CPU only output"
+
+

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,15 +1,18 @@
 import os
 
 import numpy as np
+import pytest
 from transformers import (
     AutoTokenizer,
     AutoModelForSeq2SeqLM,
+    AutoConfig,
 )
+from transformers.generation.configuration_utils import GenerationConfig
 
 from optimum.neuron.trainers import patch_generation_mixin_to_neuron_generation_mixin
 
 
-def _create_samples(model_name="t5-small", device="cpu", use_cache=False):
+def _test_greedy_decoding(model_name, device="cpu", use_cache=False):
     if device == "xla":
         import torch_xla.core.xla_model as xm
         device = xm.xla_device()
@@ -18,6 +21,14 @@ def _create_samples(model_name="t5-small", device="cpu", use_cache=False):
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    model_config = AutoConfig.from_pretrained(model_name)
+    generation_config = GenerationConfig.from_model_config(model_config)
+
+    # Set to greedy search
+    generation_config.num_beams = 1
+    generation_config.do_sample = False
+    generation_config.use_cache = use_cache
+
     patch_generation_mixin_to_neuron_generation_mixin(model)
     model.generation_config.pad_token_id = model.generation_config.eos_token_id
     task_prompt = "translate English to German: "
@@ -35,7 +46,7 @@ def _create_samples(model_name="t5-small", device="cpu", use_cache=False):
         encoder_input_ids = tokenizer(task_prompt + input_str, return_tensors="pt", padding="max_length",
                                       max_length=50).to(device)
         outputs = model.generate(
-            **encoder_input_ids, max_new_tokens=20, use_cache=False
+            **encoder_input_ids, max_new_tokens=20, use_cache=False, generation_config=generation_config
         )
         outputs = outputs.detach().cpu().numpy()
         if device == "cpu":
@@ -45,13 +56,20 @@ def _create_samples(model_name="t5-small", device="cpu", use_cache=False):
     return np.array(results)
 
 
-def test_greedy():
-    os.environ['XLA_USE_BF16'] = '0'
-    xla_neuron_samples_fp32 = _create_samples(device="xla")
-    os.environ['XLA_USE_BF16'] = '1'
-    xla_neuron_samples_bf16 = _create_samples(device="xla")
+testdata = [
+    ('t5-small', True),
+    ('t5-small', False),
+]
 
-    cpu_samples = _create_samples(device="cpu")
+
+@pytest.mark.parametrize("model_name, use_cache", testdata)
+def test_greedy_decoding(model_name, use_cache):
+    os.environ['XLA_USE_BF16'] = '0'
+    xla_neuron_samples_fp32 = _test_greedy_decoding(model_name=model_name, device="xla")
+    os.environ['XLA_USE_BF16'] = '1'
+    xla_neuron_samples_bf16 = _test_greedy_decoding(model_name=model_name, device="xla")
+
+    cpu_samples = _test_greedy_decoding(model_name=model_name, device="cpu")
 
     assert np.array_equal(cpu_samples, xla_neuron_samples_fp32), "XLA Neuron FP32 output doesn't match CPU only output"
     assert np.array_equal(cpu_samples, xla_neuron_samples_bf16), "XLA Neuron bf16 output doesn't match CPU only output"


### PR DESCRIPTION
This CR enables greedy sampling in model.generate on XLA devices such as Trainium and TPU. This addresses issues such as https://github.com/huggingface/transformers/issues/18661 and https://github.com/huggingface/transformers/issues/12322.

The implementation is inspired by the corresponding Tensorflow generate function in transformers. The CR uses conditional statements to support greedy sampling, and also implements kv-cache functionality that is XLA compatible.