### PR TITLE
`optimum-cli neuron cache list` command

### DIFF
--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -165,28 +165,28 @@ class ListRepoCommand(BaseOptimumCLICommand):
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
         parser.add_argument(
-            "-n", 
-            "--name", 
-            type=str, 
-            default=None, 
-            help="The name of the repo to list. Will use the locally saved cache repo if left unspecified."
+            "-n",
+            "--name",
+            type=str,
+            default=None,
+            help="The name of the repo to list. Will use the locally saved cache repo if left unspecified.",
         )
         parser.add_argument(
-            "-m", 
-            "--model", 
-            type=str, 
-            default=None, 
-            help="The model name or path of the model to consider. If left unspecified, will list all available models."
+            "-m",
+            "--model",
+            type=str,
+            default=None,
+            help="The model name or path of the model to consider. If left unspecified, will list all available models.",
         )
         parser.add_argument(
-            "-v", 
-            "--version", 
-            type=str, 
-            default=None, 
+            "-v",
+            "--version",
+            type=str,
+            default=None,
             help=(
                 "The version of the Neuron X Compiler to consider. Will list all available versions if left "
                 "unspecified."
-            )
+            ),
         )
 
     def run(self):
@@ -197,8 +197,10 @@ class ListRepoCommand(BaseOptimumCLICommand):
                     "No custom cache repo was set locally so you need to specify a cache repo using the -n / --name option."
                 )
             self.args.name = custom_cache_repo_name
-        
-        entries = list_in_registry(self.args.name, model_name_or_path_or_hash=self.args.model, neuron_compiler_version=self.args.version)
+
+        entries = list_in_registry(
+            self.args.name, model_name_or_path_or_hash=self.args.model, neuron_compiler_version=self.args.version
+        )
         if not entries:
             entries = ["Nothing was found."]
         line = "\n" + "=" * 50 + "\n"

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -164,10 +164,30 @@ class AddToCacheRepoCommand(BaseOptimumCLICommand):
 class ListRepoCommand(BaseOptimumCLICommand):
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
-        # TODO: improve help
-        parser.add_argument("-n", "--name", type=str, default=None, help="The name of the repo to list. Will use the locally saved cache repo if left unspecified.")
-        parser.add_argument("-m", "--model", type=str, default=None, help="The model name or path of the model to consider. Will consider all available models if left unspecified.")
-        parser.add_argument("-v", "--version", type=str, default=None, help="The version of the Neuron X Compiler to consider. Will consider all available versions if left unspecified.")
+        parser.add_argument(
+            "-n", 
+            "--name", 
+            type=str, 
+            default=None, 
+            help="The name of the repo to list. Will use the locally saved cache repo if left unspecified."
+        )
+        parser.add_argument(
+            "-m", 
+            "--model", 
+            type=str, 
+            default=None, 
+            help="The model name or path of the model to consider. If left unspecified, will list all available models."
+        )
+        parser.add_argument(
+            "-v", 
+            "--version", 
+            type=str, 
+            default=None, 
+            help=(
+                "The version of the Neuron X Compiler to consider. Will list all available versions if left "
+                "unspecified."
+            )
+        )
 
     def run(self):
         if self.args.name is None:

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -398,7 +398,6 @@ def _list_in_registry_dict(registry: Dict[str, Any], model_name_or_path_or_hash:
             f"Precision:\t{features['precision']}",
             f"Neuron X Compiler version:\t{neuron_compiler_version}",
             f"Num of neuron cores:\t{features['num_neuron_cores']}",
-            # TODO: what happens if there is only one input?
             f"Input shapes:\n{inputs}",
         ]
         entries.append("\n".join(information))

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -365,23 +365,28 @@ def add_in_registry(repo_id: str, neuron_hash: "NeuronHash"):
         _ADDED_IN_REGISTRY[(repo_id, neuron_hash)] = True
 
 
-def _list_in_registry_dict(registry: Dict[str, Any], model_name_or_path_or_hash: Optional[str] = None, neuron_compiler_version: Optional[str] = None) -> List[str]:
+def _list_in_registry_dict(
+    registry: Dict[str, Any],
+    model_name_or_path_or_hash: Optional[str] = None,
+    neuron_compiler_version: Optional[str] = None,
+) -> List[str]:
     entries = []
     if neuron_compiler_version is not None:
         registry = registry.get(neuron_compiler_version, {})
     else:
         for version in registry:
             entries += _list_in_registry_dict(
-                registry, 
-                model_name_or_path_or_hash=model_name_or_path_or_hash, 
-                neuron_compiler_version=version
+                registry, model_name_or_path_or_hash=model_name_or_path_or_hash, neuron_compiler_version=version
             )
             return entries
-    
+
     # model_key is either a model name or path or a model hash.
     for model_key in registry:
         data = registry[model_key]
-        if model_name_or_path_or_hash is not None and not (data["model_name_or_path"].startswith(model_name_or_path_or_hash) or data["model_hash"].startswith(model_name_or_path_or_hash)):
+        if model_name_or_path_or_hash is not None and not (
+            data["model_name_or_path"].startswith(model_name_or_path_or_hash)
+            or data["model_hash"].startswith(model_name_or_path_or_hash)
+        ):
             continue
 
         features = data["features"][0]
@@ -404,16 +409,20 @@ def _list_in_registry_dict(registry: Dict[str, Any], model_name_or_path_or_hash:
     return entries
 
 
-def list_in_registry(repo_id: str, model_name_or_path_or_hash: Optional[str] = None, neuron_compiler_version: Optional[str] = None):
+def list_in_registry(
+    repo_id: str, model_name_or_path_or_hash: Optional[str] = None, neuron_compiler_version: Optional[str] = None
+):
     with tempfile.TemporaryDirectory() as tmpdirname:
         hf_hub_download(repo_id, REGISTRY_FILENAME, local_dir=tmpdirname, local_dir_use_symlinks=False)
         registry_filename = Path(tmpdirname) / REGISTRY_FILENAME
         with open(registry_filename, "r") as fp:
             registry = json.load(fp)
 
-    return _list_in_registry_dict(registry, model_name_or_path_or_hash=model_name_or_path_or_hash, neuron_compiler_version=neuron_compiler_version)
-
-
+    return _list_in_registry_dict(
+        registry,
+        model_name_or_path_or_hash=model_name_or_path_or_hash,
+        neuron_compiler_version=neuron_compiler_version,
+    )
 
 
 class StaticTemporaryDirectory:

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -116,6 +116,7 @@ def delete_custom_cache_repo_name_from_hf_home(hf_home_cache_repo_file: str = HF
 
 def create_custom_cache_repo(repo_id: str = CACHE_REPO_NAME, private: bool = True) -> RepoUrl:
     repo_url = create_repo(repo_id, private=private, repo_type="model")
+    create_registry_file_if_does_not_exist(repo_id)
     set_custom_cache_repo_name_in_hf_home(repo_url.repo_id)
     return repo_url
 
@@ -459,7 +460,7 @@ class _MutableHashAttribute:
 @dataclass(frozen=True)
 class NeuronHash:
     model: "PreTrainedModel"
-    input_shapes: Tuple[Tuple[str, Tuple[int]], ...]
+    input_shapes: Tuple[Tuple[str, Tuple[int, ...]], ...]
     data_type: torch.dtype
     num_neuron_cores: int = field(default_factory=get_num_neuron_cores_used)
     neuron_compiler_version: str = field(default_factory=get_neuronxcc_version)

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -378,7 +378,7 @@ def _list_in_registry_dict(
             entries += _list_in_registry_dict(
                 registry, model_name_or_path_or_hash=model_name_or_path_or_hash, neuron_compiler_version=version
             )
-            return entries
+        return entries
 
     # model_key is either a model name or path or a model hash.
     for model_key in registry:
@@ -389,23 +389,23 @@ def _list_in_registry_dict(
         ):
             continue
 
-        features = data["features"][0]
-        if len(features["input_shapes"]) > 1:
-            inputs = "\n\t- ".join(f"{x[0]} => {x[1]}" for x in features["input_shapes"])
-            inputs = f"\t- {inputs}"
-        else:
-            x = features["input_shapes"]
-            inputs = f"\t- {x[0]} => {x[1]}"
-        information = [
-            f"Model name:\t{data['model_name_or_path']}",
-            f"Model hash:\t{data['model_hash']}",
-            f"Global hash:\t{features['neuron_hash']}",
-            f"Precision:\t{features['precision']}",
-            f"Neuron X Compiler version:\t{neuron_compiler_version}",
-            f"Num of neuron cores:\t{features['num_neuron_cores']}",
-            f"Input shapes:\n{inputs}",
-        ]
-        entries.append("\n".join(information))
+        for features in data["features"]:
+            if len(features["input_shapes"]) > 1:
+                inputs = "\n\t- ".join(f"{x[0]} => {x[1]}" for x in features["input_shapes"])
+                inputs = f"\t- {inputs}"
+            else:
+                x = features["input_shapes"]
+                inputs = f"\t- {x[0]} => {x[1]}"
+            information = [
+                f"Model name:\t{data['model_name_or_path']}",
+                f"Model hash:\t{data['model_hash']}",
+                f"Global hash:\t{features['neuron_hash']}",
+                f"Precision:\t{features['precision']}",
+                f"Neuron X Compiler version:\t{neuron_compiler_version}",
+                f"Num of neuron cores:\t{features['num_neuron_cores']}",
+                f"Input shapes:\n{inputs}",
+            ]
+            entries.append("\n".join(information))
     return entries
 
 

--- a/tests/cli/test_neuron_cache_cli.py
+++ b/tests/cli/test_neuron_cache_cli.py
@@ -18,14 +18,20 @@ import subprocess
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import torch
 from huggingface_hub import HfApi, create_repo, delete_repo
 from huggingface_hub.utils import RepositoryNotFoundError
+from transformers import BertConfig, BertModel
 from transformers.testing_utils import is_staging_test
 
 from optimum.neuron.utils.cache_utils import (
     CACHE_REPO_FILENAME,
     CACHE_REPO_NAME,
+    NeuronHash,
+    add_in_registry,
+    create_registry_file_if_does_not_exist,
     load_custom_cache_repo_name_from_hf_home,
+    set_custom_cache_repo_name_in_hf_home,
 )
 from optimum.neuron.utils.testing_utils import is_trainium_test
 from optimum.utils.testing_utils import USER
@@ -178,3 +184,66 @@ class TestNeuronCacheCLI(StagingTestMixin, TestCase):
         p = subprocess.Popen(command)
         returncode = p.wait()
         self.assertEqual(returncode, 0)
+
+    def test_optimum_neuron_cache_list(self):
+        set_custom_cache_repo_name_in_hf_home(self.CUSTOM_CACHE_REPO)
+        create_registry_file_if_does_not_exist(self.CUSTOM_CACHE_REPO)
+
+        # Without specifying the id of the repo, it should used the saved one, here self.CUSTOM_CACHE_REPO.
+        command = ("optimum-cli neuron cache list").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn("Nothing was found", stdout)
+
+        bert_model = BertModel(BertConfig())
+        neuron_hash = NeuronHash(
+            bert_model,
+            (("x", (4, 12)), ("y", (4, 12))),
+            torch.float32,
+            2,
+            neuron_compiler_version="2.8.0",
+        )
+        add_in_registry(self.CUSTOM_CACHE_REPO, neuron_hash)
+        model_hash = neuron_hash.compute_hash()[0]
+
+        # With a repo id.
+        command = (f"optimum-cli neuron cache list -n {self.CUSTOM_CACHE_REPO}").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn(model_hash, stdout)
+
+        # Filtering with a bad model name or hash, it should not return anything.
+        command = (f"optimum-cli neuron cache list -n {self.CUSTOM_CACHE_REPO} -m bad_model_name_or_hash").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn("Nothing was found", stdout)
+
+        # Filtering with an existing model, it should return it.
+        command = (f"optimum-cli neuron cache list -n {self.CUSTOM_CACHE_REPO} -m {model_hash}").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn(model_hash, stdout)
+
+        # Filtering with an existing version, it should return something.
+        command = (f"optimum-cli neuron cache list -n {self.CUSTOM_CACHE_REPO} -v 2.8.0").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn(model_hash, stdout)
+
+        # Filtering with a bad version, it should not return anything.
+        command = (f"optimum-cli neuron cache list -n {self.CUSTOM_CACHE_REPO} -v 1.120.0").split()
+        p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.decode("utf-8")
+        self.assertEqual(p.returncode, 0)
+        self.assertIn("Nothing was found", stdout)

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -32,11 +32,11 @@ from transformers.testing_utils import USER as TRANSFORMERS_USER
 from transformers.testing_utils import is_staging_test
 
 from optimum.neuron.utils.cache_utils import (
-    _list_in_registry_dict,
     CACHE_REPO_FILENAME,
     NEURON_COMPILE_CACHE_NAME,
     REGISTRY_FILENAME,
     NeuronHash,
+    _list_in_registry_dict,
     download_cached_model_from_hub,
     get_cached_model_on_the_hub,
     get_neuron_cache_path,
@@ -154,75 +154,64 @@ class NeuronUtilsTestCase(TestCase):
 
     def test_list_in_registry_dict(self):
         registry = {
-            "2.1.0":
-                {
-                    "model_1":  {
-                        "model_name_or_path": "model_1",
-                        "model_hash": "my model hash",
-                        "features": [
-                            {
-                                "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
-                                "precision": "torch.float32",
-                                "num_neuron_cores": 16,
-                                "neuron_hash": "neuron hash 1",
-
-                            },
-                            {
-                                "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
-                                "precision": "torch.float32",
-                                "num_neuron_cores": 8,
-                                "neuron_hash": "neuron hash 2",
-
-                            },
-                        ]
-
-                    },
-                    "model_2":  {
-                        "model_name_or_path": "null",
-                        "model_hash": "my model hash 2",
-                        "features": [
-                            {
-                                "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
-                                "precision": "torch.float16",
-                                "num_neuron_cores": 16,
-                                "neuron_hash": "neuron hash 3",
-
-                            },
-                            {
-                                "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
-                                "precision": "torch.float32",
-                                "num_neuron_cores": 8,
-                                "neuron_hash": "neuron hash 4",
-
-                            },
-                        ]
-
-                    },
+            "2.1.0": {
+                "model_1": {
+                    "model_name_or_path": "model_1",
+                    "model_hash": "my model hash",
+                    "features": [
+                        {
+                            "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
+                            "precision": "torch.float32",
+                            "num_neuron_cores": 16,
+                            "neuron_hash": "neuron hash 1",
+                        },
+                        {
+                            "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
+                            "precision": "torch.float32",
+                            "num_neuron_cores": 8,
+                            "neuron_hash": "neuron hash 2",
+                        },
+                    ],
                 },
-            "2.5.0":
-                {
-                    "model_1":  {
-                        "model_name_or_path": "model_1",
-                        "model_hash": "my model hash",
-                        "features": [
-                            {
-                                "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
-                                "precision": "torch.float32",
-                                "num_neuron_cores": 16,
-                                "neuron_hash": "neuron hash 5",
-
-                            },
-                            {
-                                "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
-                                "precision": "torch.float32",
-                                "num_neuron_cores": 8,
-                                "neuron_hash": "neuron hash 6",
-
-                            },
-                        ]
-
-                    },
-            }
+                "model_2": {
+                    "model_name_or_path": "null",
+                    "model_hash": "my model hash 2",
+                    "features": [
+                        {
+                            "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
+                            "precision": "torch.float16",
+                            "num_neuron_cores": 16,
+                            "neuron_hash": "neuron hash 3",
+                        },
+                        {
+                            "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
+                            "precision": "torch.float32",
+                            "num_neuron_cores": 8,
+                            "neuron_hash": "neuron hash 4",
+                        },
+                    ],
+                },
+            },
+            "2.5.0": {
+                "model_1": {
+                    "model_name_or_path": "model_1",
+                    "model_hash": "my model hash",
+                    "features": [
+                        {
+                            "input_shapes": [["x", [1, 2]], ["y", [2, 3]]],
+                            "precision": "torch.float32",
+                            "num_neuron_cores": 16,
+                            "neuron_hash": "neuron hash 5",
+                        },
+                        {
+                            "input_shapes": [["x", [3, 2]], ["y", [7, 3]]],
+                            "precision": "torch.float32",
+                            "num_neuron_cores": 8,
+                            "neuron_hash": "neuron hash 6",
+                        },
+                    ],
+                },
+            },
         }
 
         result = _list_in_registry_dict(registry)

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -37,12 +37,15 @@ from optimum.neuron.utils.cache_utils import (
     REGISTRY_FILENAME,
     NeuronHash,
     _list_in_registry_dict,
+    add_in_registry,
+    create_registry_file_if_does_not_exist,
     download_cached_model_from_hub,
     get_cached_model_on_the_hub,
     get_neuron_cache_path,
     get_num_neuron_cores_used,
     has_write_access_to_repo,
     list_files_in_neuron_cache,
+    list_in_registry,
     load_custom_cache_repo_name_from_hf_home,
     path_after_folder,
     push_to_cache_on_hub,
@@ -286,12 +289,67 @@ class StagingNeuronUtilsTestCase(StagingTestMixin, TestCase):
         self.assertTrue(has_write_access_to_repo(self.CUSTOM_CACHE_REPO))
         self.assertTrue(has_write_access_to_repo(self.CUSTOM_PRIVATE_CACHE_REPO))
 
+    @is_staging_test
+    def test_list_in_registry(self):
+        def _test_list_in_registry(use_private_cache_repo: bool):
+            if use_private_cache_repo:
+                cache_repo = self.CUSTOM_PRIVATE_CACHE_REPO
+            else:
+                cache_repo = self.CUSTOM_CACHE_REPO
+            create_registry_file_if_does_not_exist(cache_repo)
+            entries = list_in_registry(cache_repo)
+            self.assertEqual(len(entries), 0)
+
+            bert_model = BertModel(BertConfig())
+            neuron_hash = NeuronHash(
+                bert_model,
+                (("x", (4, 12)), ("y", (4, 12))),
+                torch.float32,
+                2,
+                neuron_compiler_version=DUMMY_COMPILER_VERSION,
+            )
+            add_in_registry(cache_repo, neuron_hash)
+            entries = list_in_registry(cache_repo)
+            self.assertEqual(len(entries), 1)
+
+            bert_model = BertModel(BertConfig())
+            neuron_hash = NeuronHash(
+                bert_model,
+                (("x", (4, 8)), ("y", (4, 12))),
+                torch.float32,
+                2,
+                neuron_compiler_version=DUMMY_COMPILER_VERSION,
+            )
+            add_in_registry(cache_repo, neuron_hash)
+            entries = list_in_registry(cache_repo)
+            self.assertEqual(len(entries), 2)
+
+            model_hash = neuron_hash.compute_hash()[0]
+            entries = list_in_registry(cache_repo, model_name_or_path_or_hash=model_hash)
+            self.assertEqual(len(entries), 1)
+
+            entries = list_in_registry(cache_repo, model_name_or_path_or_hash="dummy hash")
+            self.assertEqual(len(entries), 0)
+
+            entries = list_in_registry(cache_repo, neuron_compiler_version=DUMMY_COMPILER_VERSION)
+            self.assertEqual(len(entries), 2)
+
+            entries = list_in_registry(cache_repo, neuron_compiler_version="Bad version")
+            self.assertEqual(len(entries), 0)
+
+        _test_list_in_registry(False)
+        _test_list_in_registry(True)
+
 
 class NeuronHashTestCase(TestCase):
     def test_neuron_hash_is_not_mutable(self):
         bert_model = BertModel(BertConfig())
         neuron_hash = NeuronHash(
-            bert_model, ((4, 12), (4, 12)), torch.float32, 2, neuron_compiler_version=DUMMY_COMPILER_VERSION
+            bert_model,
+            (("x", (4, 12)), ("y", (4, 12))),
+            torch.float32,
+            2,
+            neuron_compiler_version=DUMMY_COMPILER_VERSION,
         )
 
         with self.assertRaises(FrozenInstanceError):


### PR DESCRIPTION
Adds a new command to list what's already available on a cache repo on the HF Hub:

```
optimum-cli neuron cache list -n optimum-internal-testing/optimum-neuron-cache-for-testing
```

Fixes: #66 