### PR TITLE
Neuron model for causal lm partial support

### DIFF
--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -51,3 +51,7 @@ The following Neuron model classes are available for natural language processing
 ### NeuronModelForMultipleChoice
 
 [[autodoc]] modeling.NeuronModelForMultipleChoice
+
+### NeuronModelForCausalLM
+
+[[autodoc]] modeling.NeuronModelForCausalLM

--- a/optimum/exporters/neuron/config.py
+++ b/optimum/exporters/neuron/config.py
@@ -16,17 +16,14 @@
 Common Neuron configuration classes that handle most of the features for building model specific
 configurations.
 """
-import importlib
 
-from ...exporters.base import ExportConfig
-from ...neuron.utils import is_transformers_neuronx_available
 from ...utils import (
     DummyBboxInputGenerator,
     DummyTextInputGenerator,
     DummyVisionInputGenerator,
     logging,
 )
-from .base import NeuronConfig
+from .base import NeuronConfig, NeuronDecoderConfig
 
 
 logger = logging.get_logger(__name__)
@@ -58,37 +55,9 @@ class TextAndVisionNeuronConfig(NeuronConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, DummyVisionInputGenerator, DummyBboxInputGenerator)
 
 
-class DecoderNeuronConfig(ExportConfig):
+class TextNeuronDecoderConfig(NeuronDecoderConfig):
     """
-    Handles decoder architectures.
+    Handles text decoder architectures.
     """
 
-    NEURONX_ARGS = {}
-    NEURONX_MODULE = None
-    NEURONX_CLASS = None
-
-    def __init__(self, task):
-        if not is_transformers_neuronx_available():
-            raise ModuleNotFoundError("The transformers-neuronx package is required.")
-        module = importlib.import_module(self.NEURONX_MODULE)
-        self._neuronx_class = getattr(module, self.NEURONX_CLASS, None)
-        if self._neuronx_class is None:
-            raise ImportError(f"{self.NEURONX_CLASS} not found in {self.NEURONX_MODULE}. Please check versions.")
-
-    def split_kwargs(self, **kwargs):
-        """Split between kwargs that need to be passed when loading the transformers model
-        and those that need to be passed to the neuron optimizer.
-        """
-        model_kwargs = kwargs
-        neuron_kwargs = {}
-        for arg, default in self.NEURONX_ARGS.items():
-            if arg in model_kwargs:
-                neuron_kwargs[arg] = model_kwargs[arg]
-                model_kwargs.pop(arg)
-            else:
-                neuron_kwargs[arg] = default
-        return model_kwargs, neuron_kwargs
-
-    @property
-    def neuronx_class(self):
-        return self._neuronx_class
+    pass

--- a/optimum/exporters/neuron/config.py
+++ b/optimum/exporters/neuron/config.py
@@ -16,7 +16,10 @@
 Common Neuron configuration classes that handle most of the features for building model specific
 configurations.
 """
+import importlib
 
+from ...exporters.base import ExportConfig
+from ...neuron.utils import is_transformers_neuronx_available
 from ...utils import (
     DummyBboxInputGenerator,
     DummyTextInputGenerator,
@@ -53,3 +56,39 @@ class TextAndVisionNeuronConfig(NeuronConfig):
     """
 
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, DummyVisionInputGenerator, DummyBboxInputGenerator)
+
+
+class DecoderNeuronConfig(ExportConfig):
+    """
+    Handles decoder architectures.
+    """
+
+    NEURONX_ARGS = {"batch_size": 1, "n_positions": 128, "tp_degree": 2, "amp": "f32"}
+    NEURONX_MODULE = None
+    NEURONX_CLASS = None
+
+    def __init__(self, task, **kwargs):
+        if not is_transformers_neuronx_available():
+            raise ModuleNotFoundError("The transformers-neuronx package is required.")
+        module = importlib.import_module(self.NEURONX_MODULE)
+        self._neuronx_class = getattr(module, self.NEURONX_CLASS, None)
+        if self._neuronx_class is None:
+            raise ImportError(f"{self.NEURONX_CLASS} not found in {self.NEURONX_MODULE}. Please check versions.")
+
+    def split_kwargs(self, **kwargs):
+        """Split between kwargs that need to be passed when loading the transformers model
+        and those that need to be passed to the neuron optimizer.
+        """
+        model_kwargs = kwargs
+        neuron_kwargs = {}
+        for arg, default in self.NEURONX_ARGS.items():
+            if arg in model_kwargs:
+                neuron_kwargs[arg] = model_kwargs[arg]
+                model_kwargs.pop(arg)
+            else:
+                neuron_kwargs[arg] = default
+        return model_kwargs, neuron_kwargs
+
+    @property
+    def neuronx_class(self):
+        return self._neuronx_class

--- a/optimum/exporters/neuron/config.py
+++ b/optimum/exporters/neuron/config.py
@@ -67,7 +67,7 @@ class DecoderNeuronConfig(ExportConfig):
     NEURONX_MODULE = None
     NEURONX_CLASS = None
 
-    def __init__(self, task, **kwargs):
+    def __init__(self, task):
         if not is_transformers_neuronx_available():
             raise ModuleNotFoundError("The transformers-neuronx package is required.")
         module = importlib.import_module(self.NEURONX_MODULE)

--- a/optimum/exporters/neuron/config.py
+++ b/optimum/exporters/neuron/config.py
@@ -63,7 +63,7 @@ class DecoderNeuronConfig(ExportConfig):
     Handles decoder architectures.
     """
 
-    NEURONX_ARGS = {"batch_size": 1, "n_positions": 128, "tp_degree": 2, "amp": "f32"}
+    NEURONX_ARGS = {}
     NEURONX_MODULE = None
     NEURONX_CLASS = None
 

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -30,6 +30,7 @@ from ...utils import (
 )
 from ..tasks import TasksManager
 from .config import (
+    DecoderNeuronConfig,
     TextAndVisionNeuronConfig,
     TextEncoderNeuronConfig,
     VisionNeuronConfig,
@@ -315,3 +316,9 @@ class UNetNeuronConfig(VisionNeuronConfig):
             return tuple(dummy_inputs.values())
         else:
             return dummy_inputs
+
+
+@register_in_tasks_manager("gpt2", "text-generation")
+class GPT2NeuronConfig(DecoderNeuronConfig):
+    NEURONX_MODULE = "transformers_neuronx.gpt2.model"
+    NEURONX_CLASS = "GPT2ForSampling"

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -30,9 +30,9 @@ from ...utils import (
 )
 from ..tasks import TasksManager
 from .config import (
-    DecoderNeuronConfig,
     TextAndVisionNeuronConfig,
     TextEncoderNeuronConfig,
+    TextNeuronDecoderConfig,
     VisionNeuronConfig,
 )
 
@@ -319,7 +319,6 @@ class UNetNeuronConfig(VisionNeuronConfig):
 
 
 @register_in_tasks_manager("gpt2", "text-generation")
-class GPT2NeuronConfig(DecoderNeuronConfig):
+class GPT2NeuronConfig(TextNeuronDecoderConfig):
     NEURONX_ARGS = {"n_positions": 128}
-    NEURONX_MODULE = "transformers_neuronx.gpt2.model"
-    NEURONX_CLASS = "GPT2ForSampling"
+    NEURONX_CLASS = "gpt2.model.GPT2ForSampling"

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -320,5 +320,6 @@ class UNetNeuronConfig(VisionNeuronConfig):
 
 @register_in_tasks_manager("gpt2", "text-generation")
 class GPT2NeuronConfig(DecoderNeuronConfig):
+    NEURONX_ARGS = {"n_positions": 128}
     NEURONX_MODULE = "transformers_neuronx.gpt2.model"
     NEURONX_CLASS = "GPT2ForSampling"

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -30,6 +30,7 @@ _import_structure = {
         "NeuronModelForSequenceClassification",
         "NeuronModelForTokenClassification",
         "NeuronModelForMultipleChoice",
+        "NeuronModelForCausalLM",
     ],
     "modeling_decoder": ["NeuronDecoderModel"],
     "accelerate": [
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
     from .accelerate import NeuronAccelerator, NeuronAcceleratorState, NeuronPartialState
     from .hf_argparser import NeuronHfArgumentParser
     from .modeling import (
+        NeuronModelForCausalLM,
         NeuronModelForFeatureExtraction,
         NeuronModelForMaskedLM,
         NeuronModelForMultipleChoice,

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -31,6 +31,7 @@ _import_structure = {
         "NeuronModelForTokenClassification",
         "NeuronModelForMultipleChoice",
     ],
+    "modeling_decoder": ["NeuronDecoderModel"],
     "accelerate": [
         "NeuronAccelerator",
         "NeuronAcceleratorState",
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
         NeuronModelForTokenClassification,
     )
     from .modeling_base import NeuronBaseModel
+    from .modeling_decoder import NeuronDecoderModel
     from .pipelines import pipeline
     from .trainers import NeuronTrainer, Seq2SeqNeuronTrainer
     from .training_args import NeuronTrainingArguments, Seq2SeqNeuronTrainingArguments

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -557,14 +557,8 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
     def __init__(self, model, config, model_path, generation_config):
         super().__init__(model, config, model_path, generation_config)
         self.cur_len = 0
-        neuron_config = getattr(config, "neuron", None)
-        if neuron_config is None:
-            raise ValueError(
-                "The specified directory does not contain a neuron model. "
-                "Please convert your model to neuron format by passing export=True."
-            )
-        self.batch_size = neuron_config["neuron_kwargs"]["batch_size"]
-        self.max_length = neuron_config["neuron_kwargs"]["n_positions"]
+        self.batch_size = model.config.batch_size
+        self.max_length = model.config.n_positions
 
     def reset_generation(self):
         self.cur_len = 0

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -594,7 +594,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
         output_hidden_states: bool = False,
         output_attentions: bool = False,
         attention_mask: torch.Tensor = None,
-        return_dict: bool = False,
+        return_dict: bool = True,
     ):
         if output_hidden_states or output_attentions or attention_mask is not None:
             warnings.warn(

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -554,8 +554,8 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
     auto_model_class = AutoModelForCausalLM
     main_input_name = "input_ids"
 
-    def __init__(self, model, config, generation_config):
-        super().__init__(model, config, generation_config)
+    def __init__(self, model, config, model_path, generation_config):
+        super().__init__(model, config, model_path, generation_config)
         self.cur_len = 0
 
     def reset_generation(self):

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -28,6 +28,7 @@ from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
 from ..modeling_base import OptimizedModel
 from .utils import is_transformers_neuronx_available
+from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 
 
 if is_transformers_neuronx_available():
@@ -135,6 +136,8 @@ class NeuronDecoderModel(OptimizedModel):
             "num_cores": num_cores,
             "auto_cast_type": auto_cast_type,
             "neuron_kwargs": neuron_kwargs,
+            "compiler_type": "neuronx-cc",
+            "compiler_version": get_neuronxcc_version(),
         }
 
         return cls._from_pretrained(checkpoint_dir, config)
@@ -173,6 +176,8 @@ class NeuronDecoderModel(OptimizedModel):
         num_cores = neuron_config["num_cores"]
         auto_cast_type = neuron_config["auto_cast_type"]
         neuron_kwargs = neuron_config["neuron_kwargs"]
+
+        check_compiler_compatibility(neuron_config["compiler_type"], neuron_config["compiler_version"])
 
         exporter = get_exporter(config, task)
 

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -15,6 +15,7 @@
 """Base class for text-generation model architectures on neuron devices."""
 
 import logging
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Union
@@ -120,6 +121,7 @@ class NeuronDecoderModel(OptimizedModel):
         neuronx_model = exporter.neuronx_class.from_pretrained(checkpoint_dir.name, **neuron_kwargs)
 
         # Compile the model
+        os.environ["NEURON_CC_FLAGS"] = "--model-type=transformer-inference"
         neuronx_model.to_neuron()
 
         # Try to reload the generation config (if any)

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -78,7 +78,6 @@ class NeuronDecoderModel(OptimizedModel):
         if generation_config is None:
             generation_config = GenerationConfig.from_model_config(config)
         self.generation_config = generation_config
-        self.device = torch.device("cpu")
 
     @classmethod
     def _from_transformers(

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -19,7 +19,7 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import torch
 from transformers import GenerationConfig
@@ -132,9 +132,8 @@ class NeuronDecoderModel(OptimizedModel):
         return cls._from_pretrained(checkpoint_dir, config)
 
     @classmethod
-    def _get_neuron_paths(cls, model_dir):
+    def _get_neuron_paths(cls, model_dir: Union[str, Path, TemporaryDirectory]) -> Tuple[str, str, str]:
         if isinstance(model_dir, TemporaryDirectory):
-            # Convert the model directory to a path
             model_path = model_dir.name
             # We are in the middle of an export: the checkpoint is in the temporary model directory
             checkpoint_path = model_path
@@ -211,7 +210,7 @@ class NeuronDecoderModel(OptimizedModel):
             shutil.copytree(src_compiled_path, dst_compiled_path)
 
         if isinstance(self.model_path, TemporaryDirectory):
-            # let temporary directory go out-of-scope to release disk space
+            # Let temporary directory go out-of-scope to release disk space
             self.model_path = save_directory
 
         # Save generation config (the model config is already saved by the caller)

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -21,6 +21,7 @@ from .import_utils import (
     is_neuronx_available,
     is_neuronx_distributed_available,
     is_torch_xla_available,
+    is_transformers_neuronx_available,
 )
 from .optimization_utils import get_attention_scores
 from .patching import DynamicPatch, ModelPatcher, Patcher, patch_everywhere, patch_within_function

--- a/optimum/neuron/utils/import_utils.py
+++ b/optimum/neuron/utils/import_utils.py
@@ -46,6 +46,10 @@ def is_neuronx_distributed_available() -> bool:
     return importlib.util.find_spec("neuronx_distributed") is not None
 
 
+def is_transformers_neuronx_available() -> bool:
+    return importlib.util.find_spec("transformers_neuronx") is not None
+
+
 def is_accelerate_available(min_version: Optional[str] = MIN_ACCELERATE_VERSION) -> bool:
     _accelerate_available = importlib.util.find_spec("accelerate") is not None
     if min_version is not None:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ EXTRAS_REQUIRE = {
         "wheel",
         "neuronx-cc==2.6.*",
         "torch-neuronx",
+        "transformers-neuronx",
         "torch==1.13.1.*",
         "torchvision==0.14.*",
     ],

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -24,6 +24,7 @@ EXPORT_MODELS_TINY = {
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "flaubert": "flaubert/flaubert_small_cased",
+    "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",

--- a/tests/test_modeling_decoder.py
+++ b/tests/test_modeling_decoder.py
@@ -53,36 +53,32 @@ def neuron_model_path(model_id):
     yield model_path
 
 
-def _check_neuron_model(neuron_model, batch_size=None, seq_length=None, tp_degree=None, amp=None):
+def _check_neuron_model(neuron_model, batch_size=None, num_cores=None, auto_cast_type=None):
     neuron_config = getattr(neuron_model.config, "neuron", None)
     assert neuron_config
-    neuron_kwargs = neuron_config.get("neuron_kwargs", None)
-    assert neuron_kwargs
     if batch_size:
-        assert neuron_kwargs["batch_size"] == batch_size
-    if seq_length:
-        assert neuron_kwargs["n_positions"] == seq_length
-    if tp_degree:
-        assert neuron_kwargs["tp_degree"] == tp_degree
-    if amp:
-        assert neuron_kwargs["amp"] == amp
+        assert neuron_config["batch_size"] == batch_size
+    if num_cores:
+        assert neuron_config["num_cores"] == num_cores
+    if auto_cast_type:
+        assert neuron_config["auto_cast_type"] == auto_cast_type
 
 
 @is_inferentia_test
 @requires_neuronx
 @pytest.mark.parametrize(
-    "batch_size, seq_length, tp_degree, amp",
+    "batch_size, num_cores, auto_cast_type",
     [
-        pytest.param(1, 128, 2, "f32", marks=pytest.mark.skip(reason="Does not work with batch_size 1")),
-        [2, 128, 2, "f32"],
-        [2, 32, 2, "bf16"],
+        pytest.param(1, 2, "f32", marks=pytest.mark.skip(reason="Does not work with batch_size 1")),
+        [2, 2, "f32"],
+        [2, 2, "bf16"],
     ],
 )
-def test_model_from_hub(model_id, batch_size, seq_length, tp_degree, amp):
+def test_model_from_hub(model_id, batch_size, num_cores, auto_cast_type):
     model = NeuronModelForCausalLM.from_pretrained(
-        model_id, export=True, batch_size=batch_size, n_positions=seq_length, tp_degree=tp_degree, amp=amp
+        model_id, export=True, batch_size=batch_size, num_cores=num_cores, auto_cast_type=auto_cast_type
     )
-    _check_neuron_model(model, batch_size, seq_length, tp_degree, amp)
+    _check_neuron_model(model, batch_size, num_cores, auto_cast_type)
 
 
 @is_inferentia_test

--- a/tests/test_modeling_decoder.py
+++ b/tests/test_modeling_decoder.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tempfile import TemporaryDirectory
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from optimum.neuron import NeuronModelForCausalLM
+from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
+from optimum.utils import logging
+
+from .exporters.exporters_utils import EXPORT_MODELS_TINY as MODEL_NAMES
+
+
+logger = logging.get_logger()
+
+
+DECODER_MODEL_ARCHITECTURES = ["gpt2"]
+
+
+@pytest.fixture(scope="module", params=[MODEL_NAMES[model_arch] for model_arch in DECODER_MODEL_ARCHITECTURES])
+def model_id(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def neuron_model_path(model_id):
+    # For now we need to use a batch_size of 2 because it fails with batch_size == 1
+    model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, batch_size=2)
+    model_dir = TemporaryDirectory()
+    model_path = model_dir.name
+    model.save_pretrained(model_path)
+    del model
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    tokenizer.save_pretrained(model_path)
+    del tokenizer
+    # Yield instead of returning to keep a reference to the temporary directory.
+    # It will go out of scope and be released only once all tests needing the fixture
+    # have been completed.
+    yield model_path
+
+
+def _check_neuron_model(neuron_model, batch_size=None, seq_length=None, tp_degree=None, amp=None):
+    neuron_config = getattr(neuron_model.config, "neuron", None)
+    assert neuron_config
+    neuron_kwargs = neuron_config.get("neuron_kwargs", None)
+    assert neuron_kwargs
+    if batch_size:
+        assert neuron_kwargs["batch_size"] == batch_size
+    if seq_length:
+        assert neuron_kwargs["n_positions"] == seq_length
+    if tp_degree:
+        assert neuron_kwargs["tp_degree"] == tp_degree
+    if amp:
+        assert neuron_kwargs["amp"] == amp
+
+
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.parametrize(
+    "batch_size, seq_length, tp_degree, amp",
+    [
+        pytest.param(1, 128, 2, "f32", marks=pytest.mark.skip(reason="Does not work with batch_size 1")),
+        [2, 128, 2, "f32"],
+        [2, 32, 2, "bf16"],
+    ],
+)
+def test_model_from_hub(model_id, batch_size, seq_length, tp_degree, amp):
+    model = NeuronModelForCausalLM.from_pretrained(
+        model_id, export=True, batch_size=batch_size, n_positions=seq_length, tp_degree=tp_degree, amp=amp
+    )
+    _check_neuron_model(model, batch_size, seq_length, tp_degree, amp)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_model_from_path(neuron_model_path):
+    model = NeuronModelForCausalLM.from_pretrained(neuron_model_path)
+    _check_neuron_model(model)
+
+
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.parametrize(
+    "gen_kwargs", [{"do_sample": True}, {"do_sample": True, "temperature": 0.7}], ids=["sample", "sample-with-temp"]
+)
+def test_model_generation(neuron_model_path, gen_kwargs):
+    model = NeuronModelForCausalLM.from_pretrained(neuron_model_path)
+    tokenizer = AutoTokenizer.from_pretrained(neuron_model_path)
+    neuron_config = getattr(model.config, "neuron", None)
+    batch_size = neuron_config["neuron_kwargs"]["batch_size"]
+    seq_length = neuron_config["neuron_kwargs"]["n_positions"]
+    prompt_text = "Hello, I'm a language model,"
+    prompts = [prompt_text for _ in range(batch_size)]
+    tokens = tokenizer(prompts, return_tensors="pt")
+    with torch.inference_mode():
+        sample_output = model.generate(**tokens, max_length=seq_length, **gen_kwargs)
+        assert sample_output.shape[0] == batch_size
+        assert sample_output.shape[1] == seq_length


### PR DESCRIPTION
This is a very preliminary integration of a `NeuronModelForCausalLM` generic class to wrap neuronx optimized models.

For now, only `gpt2` model type is supported.

The following features are available:

- instantiate (export + compile) a neuron model from a `transformers` model_id  (`from_pretrained`),
- save the exported model locally (`save_pretrained`),
- instantiate (export + reload compilation artifacts) a neuron model from a local directory (`from_pretrained`),
- generate outputs (`generate`).

What is missing:
- between two generations, a specific `reset_generation` method must be called: I plan to remove that in a subsequent pull-request,
- we should check the compiler version when instantiating from a local path,
- the export should be available through the CLI,
- the new model class should have a corresponding `text-generation` pipeline.

What could be added if this is a use case:
- use cache (is it even possible since the compilation happens behind the scene in transformers-neuronx ?),
- support recompilation with different parameters when instantiating from a local path,