### PR TITLE
Fixes the cache after update

### DIFF
--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -32,6 +32,7 @@ from .utils.cache_utils import (
     NEURON_COMPILE_CACHE_NAME,
     NeuronHash,
     download_cached_model_from_hub,
+    follows_new_cache_naming_convention,
     get_neuron_cache_path,
     list_files_in_neuron_cache,
     path_after_folder,
@@ -119,8 +120,8 @@ class NeuronCacheCallaback(TrainerCallback):
         return cache_stats
 
     @classmethod
-    def _insert_in_cache_stats(cls, cache_stats: Dict[str, Dict[str, Any]], path: Path):
-        path_in_cache = path_after_folder(path, NEURON_COMPILE_CACHE_NAME)
+    def _insert_in_cache_stats(cls, cache_stats: Dict[str, Dict[str, Any]], path: Path, cache_path: Path):
+        path_in_cache = path_after_folder(path, cache_path.name)
         cache_key = path_in_cache.parts[0]
         item = cache_stats.get(cache_key, {})
         if path.parent.as_posix() in item:
@@ -132,7 +133,7 @@ class NeuronCacheCallaback(TrainerCallback):
     def _update_cache_stats(cls, neuron_cache_path: Path):
         cache_stats = cls._load_cache_stats(neuron_cache_path)
         for path in list_files_in_neuron_cache(neuron_cache_path):
-            cls._insert_in_cache_stats(cache_stats, path)
+            cls._insert_in_cache_stats(cache_stats, path, neuron_cache_path)
         with open(neuron_cache_path / "cache_stats.json", "w") as fp:
             json.dump(cache_stats, fp)
 
@@ -145,8 +146,13 @@ class NeuronCacheCallaback(TrainerCallback):
         else:
             neuron_cache_files = []
 
-        set_neuron_cache_path(tmp_neuron_cache_path)
-        tmp_neuron_cache_path = tmp_neuron_cache_path / NEURON_COMPILE_CACHE_NAME
+        if follows_new_cache_naming_convention():
+            tmp_neuron_cache_path = tmp_neuron_cache_path / NEURON_COMPILE_CACHE_NAME
+            set_neuron_cache_path(tmp_neuron_cache_path)
+        else:
+            set_neuron_cache_path(tmp_neuron_cache_path)
+            tmp_neuron_cache_path = tmp_neuron_cache_path / NEURON_COMPILE_CACHE_NAME
+
         tmp_neuron_cache_path.mkdir()
 
         cache_stats_exists = False
@@ -158,12 +164,12 @@ class NeuronCacheCallaback(TrainerCallback):
         for cache_file in neuron_cache_files:
             if cache_file.name == "cache_stats.json":
                 continue
-            path_in_neuron_cache = path_after_folder(cache_file, NEURON_COMPILE_CACHE_NAME)
+            path_in_neuron_cache = path_after_folder(cache_file, neuron_cache_path.name)
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)
             tmp_cache_file.symlink_to(cache_file)
 
-            cls._insert_in_cache_stats(cache_stats, cache_file)
+            cls._insert_in_cache_stats(cache_stats, cache_file, neuron_cache_path)
 
         if not cache_stats_exists:
             with open(tmp_neuron_cache_path / "cache_stats.json", "w") as fp:
@@ -199,8 +205,8 @@ class NeuronCacheCallaback(TrainerCallback):
                 self.try_to_fetch_cached_model(neuron_hash)
         return neuron_hash
 
-    def full_path_to_path_in_cache(self, path: Path):
-        return path_after_folder(path, NEURON_COMPILE_CACHE_NAME)
+    def full_path_to_path_in_temporary_cache(self, path: Path):
+        return path_after_folder(path, self.tmp_neuron_cache_path.name)
 
     def try_to_fetch_cached_model(self, neuron_hash: NeuronHash) -> bool:
         # TODO: needs to be called ONLY when absolutely needed.
@@ -223,7 +229,7 @@ class NeuronCacheCallaback(TrainerCallback):
             self.tmp_neuron_cache_state += diff
             if self.use_neuron_cache:
                 for path in diff:
-                    path_in_cache = self.full_path_to_path_in_cache(path)
+                    path_in_cache = self.full_path_to_path_in_temporary_cache(path)
                     path_in_original_cache = self.neuron_cache_path / path_in_cache
                     path_in_original_cache.parent.mkdir(parents=True, exist_ok=True)
                     if path_in_original_cache.exists():
@@ -244,12 +250,15 @@ class NeuronCacheCallaback(TrainerCallback):
         for neuron_hash, files in self.neuron_hash_to_files.items():
 
             def local_path_to_path_in_repo(path):
-                return path_after_folder(path, f"USER_neuroncc-{neuron_hash.neuron_compiler_version}")
+                if follows_new_cache_naming_convention():
+                    return path_after_folder(path, f"neuronxcc-{neuron_hash.neuron_compiler_version}")
+                else:
+                    return path_after_folder(path, f"USER_neuroncc-{neuron_hash.neuron_compiler_version}")
 
             for path in files:
                 push_to_cache_on_hub(neuron_hash, path, local_path_to_path_in_repo=local_path_to_path_in_repo)
                 if self.use_neuron_cache:
-                    path_in_cache = self.full_path_to_path_in_cache(path)
+                    path_in_cache = self.full_path_to_path_in_temporary_cache(path)
                     target_file = self.neuron_cache_path / path_in_cache
                     target_file.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy(path, self.neuron_cache_path / path_in_cache)

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -23,7 +23,6 @@ import shutil
 import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
-from packaging import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -40,6 +39,7 @@ from huggingface_hub import (
     hf_hub_download,
 )
 from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
+from packaging import version
 
 from ...utils import logging
 from ...utils.logging import warn_once
@@ -81,16 +81,18 @@ _ADDED_IN_REGISTRY: Dict[Tuple[str, "NeuronHash"], bool] = {}
 
 _NEW_CACHE_NAMING_CONVENTION_NEURONXCC_VERSION = "2.7.0.40+f7c6cf2a3"
 
+
 def follows_new_cache_naming_convention(neuronxcc_version: Optional[str] = None) -> bool:
     """
     The ways the cache is handled differs starting from `_NEW_CACHE_NAMING_CONVENTION_NEURONXCC_VERSION`.
-    This helper functions returns `True` if `neuronxcc_version` follows the new way the cache is handled and `False` 
+    This helper functions returns `True` if `neuronxcc_version` follows the new way the cache is handled and `False`
     otherwise.
     """
     if neuronxcc_version is None:
         neuronxcc_version = get_neuronxcc_version()
     neuronxcc_version = version.parse(neuronxcc_version)
     return neuronxcc_version >= version.parse(_NEW_CACHE_NAMING_CONVENTION_NEURONXCC_VERSION)
+
 
 def load_custom_cache_repo_name_from_hf_home(
     hf_home_cache_repo_file: Union[str, Path] = HF_HOME_CACHE_REPO_FILE
@@ -153,12 +155,12 @@ def has_write_access_to_repo(repo_id: str) -> bool:
     with tempfile.NamedTemporaryFile() as fp:
         tmpfilename = Path(fp.name)
         try:
-            add_file = CommitOperationAdd(tmpfilename.name, tmpfilename.as_posix())
+            add_file = CommitOperationAdd(f"write_access_test/{tmpfilename.name}", tmpfilename.as_posix())
             HfApi().create_commit(repo_id, operations=[add_file], commit_message="Check write access")
         except (HfHubHTTPError, RepositoryNotFoundError):
             pass
         else:
-            delete_file = CommitOperationDelete(tmpfilename.name)
+            delete_file = CommitOperationDelete(f"write_access_test/{tmpfilename.name}")
             HfApi().create_commit(repo_id, operations=[delete_file], commit_message="Check write access [DONE]")
             has_access = True
 
@@ -280,6 +282,7 @@ def path_after_folder(path: Path, folder: Union[str, Path], include_folder: bool
         index = len(path.parts)
     index = index + 1 if not include_folder else index
     return Path("").joinpath(*path.parts[index:])
+
 
 def remove_ip_adress_from_path(path: Path) -> Path:
     return Path().joinpath(*(re.sub(_IP_PATTERN, "", part) for part in path.parts))
@@ -405,9 +408,9 @@ def _list_in_registry_dict(
     if neuron_compiler_version is not None:
         registry = registry.get(neuron_compiler_version, {})
     else:
-        for version in registry:
+        for version_ in registry:
             entries += _list_in_registry_dict(
-                registry, model_name_or_path_or_hash=model_name_or_path_or_hash, neuron_compiler_version=version
+                registry, model_name_or_path_or_hash=model_name_or_path_or_hash, neuron_compiler_version=version_
             )
         return entries
 
@@ -491,10 +494,44 @@ class _MutableHashAttribute:
     def __hash__(self):
         return hash(f"{self.model_hash}_{self.overall_hash}")
 
-@dataclass
-class _HashAttribute:
-    pass
 
+@dataclass(frozen=True)
+class _UnspecifiedHashAttribute:
+    min_optimum_neuron_version: Optional[str] = None
+    min_neuron_compiler_version: Optional[str] = None
+    default: Optional[Any] = None
+
+    @classmethod
+    def with_args(
+        cls,
+        min_optimum_neuron_version: Optional[str] = None,
+        min_neuron_compiler_version: Optional[str] = None,
+        default: Optional[Any] = None,
+    ) -> Callable[[], "_UnspecifiedHashAttribute"]:
+        def constructor():
+            return cls(
+                min_optimum_neuron_version=min_optimum_neuron_version,
+                min_neuron_compiler_version=min_neuron_compiler_version,
+                default=default,
+            )
+
+        return constructor
+
+    def check_requirements_are_met(self, neuron_compiler_version: str):
+        from ..version import __version__
+
+        optimum_neuron_requirement = True
+        if self.min_optimum_neuron_version is not None:
+            if version.parse(__version__) >= version.parse(self.min_optimum_neuron_version):
+                optimum_neuron_requirement = self.default is not None
+
+        neuron_compiler_requirement = True
+        if self.min_neuron_compiler_version is not None:
+            if version.parse(neuron_compiler_version) >= version.parse(self.min_neuron_compiler_version):
+                neuron_compiler_requirement = self.default is not None
+
+        if not optimum_neuron_requirement or not neuron_compiler_requirement:
+            raise ValueError("A default value must be specified.")
 
 
 @dataclass(frozen=True)
@@ -504,10 +541,31 @@ class NeuronHash:
     data_type: torch.dtype
     num_neuron_cores: int = field(default_factory=get_num_neuron_cores_used)
     neuron_compiler_version: str = field(default_factory=get_neuronxcc_version)
+    fsdp: Union[int, _UnspecifiedHashAttribute] = field(
+        default_factory=_UnspecifiedHashAttribute.with_args(min_optimum_neuron_version="0.0.8", default=False)
+    )
+    tensor_parallel_size: Union[int, _UnspecifiedHashAttribute] = field(
+        default_factory=_UnspecifiedHashAttribute.with_args(min_optimum_neuron_version="0.0.8", default=1)
+    )
     _hash: _MutableHashAttribute = field(default_factory=_MutableHashAttribute)
 
     def __post_init__(self):
+        for attr in self.__dict__.values():
+            if isinstance(attr, _UnspecifiedHashAttribute):
+                attr.check_requirements_are_met(self.neuron_compiler_version)
         self.compute_hash()
+
+    def _insert_potential_unspecified_hash_attribute(
+        self, attribute_name: str, attribute: Any, hash_dict: Dict[str, Any]
+    ):
+        """
+        Inserts `attribute` in `hash_dict` only if it is a specified attribute or if it has a default value.
+        """
+        if isinstance(attribute, _UnspecifiedHashAttribute):
+            if attribute.default is not None:
+                hash_dict[attribute_name] = attribute
+        else:
+            hash_dict[attribute_name] = attribute
 
     @property
     def hash_dict(self) -> Dict[str, Any]:
@@ -516,6 +574,10 @@ class NeuronHash:
         hash_dict["_model_class"] = self.model.__class__
         hash_dict["_is_model_training"] = self.model.training
         hash_dict.pop("_hash")
+
+        self._insert_potential_unspecified_hash_attribute("tensor_parallel_size", self.tensor_parallel_size, hash_dict)
+        self._insert_potential_unspecified_hash_attribute("fsdp", self.fsdp, hash_dict)
+
         return hash_dict
 
     def state_dict_to_bytes(self, state_dict: Dict[str, torch.Tensor]) -> bytes:

--- a/optimum/neuron/utils/version_utils.py
+++ b/optimum/neuron/utils/version_utils.py
@@ -13,19 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Version utilities."""
+from typing import Optional
 
+_neuronxcc_version: Optional[str] = None
+_neuroncc_version: Optional[str] = None
 
 def get_neuronxcc_version() -> str:
+    global _neuronxcc_version
+    if _neuronxcc_version is not None:
+        return _neuronxcc_version
     try:
         import neuronxcc
     except ImportError:
         raise ValueError("NeuronX Compiler python package is not installed.")
-    return neuronxcc.__version__
+    _neuronxcc_version =  neuronxcc.__version__
+    return _neuronxcc_version
 
 
 def get_neuroncc_version() -> str:
+    global _neuroncc_version
+    if _neuroncc_version is not None:
+        return _neuroncc_version
     try:
         import neuroncc
     except ImportError:
         raise ValueError("Neuron Compiler python package is not installed.")
-    return neuroncc.__version__
+    _neuroncc_version = neuroncc.__version__
+    return _neuroncc_version

--- a/optimum/neuron/utils/version_utils.py
+++ b/optimum/neuron/utils/version_utils.py
@@ -15,8 +15,10 @@
 """Version utilities."""
 from typing import Optional
 
+
 _neuronxcc_version: Optional[str] = None
 _neuroncc_version: Optional[str] = None
+
 
 def get_neuronxcc_version() -> str:
     global _neuronxcc_version
@@ -26,7 +28,7 @@ def get_neuronxcc_version() -> str:
         import neuronxcc
     except ImportError:
         raise ValueError("NeuronX Compiler python package is not installed.")
-    _neuronxcc_version =  neuronxcc.__version__
+    _neuronxcc_version = neuronxcc.__version__
     return _neuronxcc_version
 
 

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -40,6 +40,7 @@ from optimum.neuron.utils.cache_utils import (
     add_in_registry,
     create_registry_file_if_does_not_exist,
     download_cached_model_from_hub,
+    follows_new_cache_naming_convention,
     get_cached_model_on_the_hub,
     get_neuron_cache_path,
     get_num_neuron_cores_used,
@@ -81,23 +82,35 @@ class NeuronUtilsTestCase(TestCase):
         os.environ[
             "NEURON_CC_FLAGS"
         ] = f"--some --parameters --here --cache_dir={custom_cache_dir_name} --other --paremeters --here"
-        self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name / NEURON_COMPILE_CACHE_NAME)
+        if follows_new_cache_naming_convention():
+            self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name)
+        else:
+            self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name / NEURON_COMPILE_CACHE_NAME)
 
         os.environ["NEURON_CC_FLAGS"] = "--some --parameters --here --other --paremeters --here"
-        self.assertEqual(get_neuron_cache_path(), Path("/var/tmp") / NEURON_COMPILE_CACHE_NAME)
+        if follows_new_cache_naming_convention():
+            self.assertEqual(get_neuron_cache_path(), Path("/var/tmp"))
+        else:
+            self.assertEqual(get_neuron_cache_path(), Path("/var/tmp") / NEURON_COMPILE_CACHE_NAME)
 
     def _test_set_neuron_cache_path(self, new_cache_path):
         os.environ["NEURON_CC_FLAGS"] = "--some --parameters --here --no-cache --other --paremeters --here"
         with self.assertRaisesRegex(ValueError, expected_regex=r"Cannot set the neuron compile cache"):
             set_neuron_cache_path(new_cache_path)
         set_neuron_cache_path(new_cache_path, ignore_no_cache=True)
-        self.assertEqual(get_neuron_cache_path(), Path(new_cache_path) / NEURON_COMPILE_CACHE_NAME)
+        if follows_new_cache_naming_convention():
+            self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
+        else:
+            self.assertEqual(get_neuron_cache_path(), Path(new_cache_path) / NEURON_COMPILE_CACHE_NAME)
 
         os.environ[
             "NEURON_CC_FLAGS"
         ] = "--some --parameters --here --cache_dir=original_cache_dir --other --paremeters"
         set_neuron_cache_path(new_cache_path)
-        self.assertEqual(get_neuron_cache_path(), Path(new_cache_path) / NEURON_COMPILE_CACHE_NAME)
+        if follows_new_cache_naming_convention():
+            self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
+        else:
+            self.assertEqual(get_neuron_cache_path(), Path(new_cache_path) / NEURON_COMPILE_CACHE_NAME)
 
     def test_set_neuron_cache_path(self):
         new_cache_path_str = "path/to/my/custom/cache"

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -63,6 +63,7 @@ from .utils import MyTinyModel, StagingTestMixin, get_random_string
 DUMMY_COMPILER_VERSION = "1.2.3"
 
 
+@is_trainium_test
 class NeuronUtilsTestCase(TestCase):
     def test_load_custom_cache_repo_name_from_hf_home(self):
         with TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
This PR:

- Fixes the cache after the 2.11 update
- Adds the possibility to add attributes to the `NeuronHash` as new features come without losing the ability to compute the hash for previous versions
- Takes care of checking for write access in a directory to not accumulate temporary files in the root dir of the cache repo