### PR TITLE
Rename to Trainium references to Neuron

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,7 +17,7 @@
     - local: guides/setup_aws_instance
       title: Set up AWS Trainium instance            
     - local: guides/cache_system
-      title: Trainium model cache
+      title: Neuron model cache
     - local: guides/fine_tune
       title: Fine-tune Transformers with AWS Trainium
     - local: guides/export_model
@@ -29,7 +29,7 @@
     title: How-To Guides
   - sections:
     - local: package_reference/trainer
-      title: Trainium Trainer
+      title: Neuron Trainer
     - local: package_reference/export
       title: Inferentia Exporter
     - local: package_reference/configuration

--- a/docs/source/guides/cache_system.mdx
+++ b/docs/source/guides/cache_system.mdx
@@ -10,20 +10,20 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Trainium Model Cache
+# Neuron Model Cache
 
-The Trainium Model Cache is a remote cache for compiled Trainium models in the `neff` format. 
-It is integrated into the [`TrainiumTrainer`] class to enable loading pretrained models from the cache instead of compiling them locally. 
+The Neuron Model Cache is a remote cache for compiled Neuron models in the `neff` format. 
+It is integrated into the [`NeuronTrainer`] class to enable loading pretrained models from the cache instead of compiling them locally. 
 This can speed up the training process by about –3x.
 
-The Trainium Model Cache is hosted on the [Hugging Face Hub](https://huggingface.co/aws-neuron/optimum-neuron-cache) and includes compiled files for all popular and supported pre-trained models `optimum-neuron`.
+The Neuron Model Cache is hosted on the [Hugging Face Hub](https://huggingface.co/aws-neuron/optimum-neuron-cache) and includes compiled files for all popular and supported pre-trained models `optimum-neuron`.
 
 When training a Transformers or Diffusion model with vanilla [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx), the models needs to be first compiled. The compiled version is stored in a local directory, usually `/var/tmp/neuron-compile-cache`. 
 This means that every time you train a new model in a new environment, you need to recompile it, which takes a lot of time. 
 
-We created the Trainium Model Cache to solve this limitation by providing a public cache of precompiled available models and a private cache to create your private, secured, remote model cache.
+We created the Neuron Model Cache to solve this limitation by providing a public cache of precompiled available models and a private cache to create your private, secured, remote model cache.
 
-The Trainium Model Cache plugs into the local cache directory of the Hugging Face Hub. During training, the [`TrainiumTrainer`] will check if compilation files are available on the Hub and download them if they are found, allowing you to save both time and cost by skipping the compilation phase.
+The Neuron Model Cache plugs into the local cache directory of the Hugging Face Hub. During training, the [`NeuronTrainer`] will check if compilation files are available on the Hub and download them if they are found, allowing you to save both time and cost by skipping the compilation phase.
 
 ## How the caching system works
 
@@ -39,11 +39,11 @@ Many factors can trigger compilation among which:
 
 These parameters are used to compute a hash. This hash is then used to compare local hashes for our training session against hashes stored on the Hugging Face Hub, and act accordingly (download or push).
 
-### How to use the Trainium model cache
+### How to use the Neuron model cache
 
-The Public model cache will be used when your training script uses the [`TrainiumTrainer`]. There are no additional changes needed.
+The Public model cache will be used when your training script uses the [`NeuronTrainer`]. There are no additional changes needed.
 
-### How to use a private Trainium model cache
+### How to use a private Neuron model cache
 
 The repository for the public cache is `aws-neuron/optimum-neuron-cache`. This repository includes all precompiled files for commonly used models so that it is publicly available and free to use for everyone. But there are two limitations:
 
@@ -56,11 +56,11 @@ To alleviate that you can create your own private cache repository using the `op
 
 The Optimum CLI offers 2 subcommands for cache creation and setting: 
 
-- `create`: To create a new cache repository that you can use as a private Trainium Model cache. 
-- `set`: To set the name of the Trainium cache repository locally, the repository needs to exists 
+- `create`: To create a new cache repository that you can use as a private Neuron Model cache. 
+- `set`: To set the name of the Nueron cache repository locally, the repository needs to exists 
 and will be used by default by `optimum-neuron`.
 
-Create a new Trainium cache repository:
+Create a new Neuron cache repository:
 
 ```
 optimum-cli neuron cache create --help
@@ -74,15 +74,15 @@ optional arguments:
 
 ```
 
-The `-n` / `--name` option allows you to specify a name for the Trainium cache repo, if not set the default name will be used. The `--public` flag allows you to make your Trainium cache public as it will be created as a private repository by default.
+The `-n` / `--name` option allows you to specify a name for the Neuron cache repo, if not set the default name will be used. The `--public` flag allows you to make your Neuron cache public as it will be created as a private repository by default.
 
 Example:
 
 ```
 optimum-cli neuron cache create
 
-Trainium cache created on the Hugging Face Hub: michaelbenayoun/optimum-neuron-cache [private].
-Trainium cache name set locally to michaelbenayoun/optimum-neuron-cache in /home/michael/.cache/huggingface/optimum_neuron_custom_cache.
+Neuron cache created on the Hugging Face Hub: michaelbenayoun/optimum-neuron-cache [private].
+Neuron cache name set locally to michaelbenayoun/optimum-neuron-cache in /home/michael/.cache/huggingface/optimum_neuron_custom_cache.
 ```
 
 Set a different Trainiun cache repository:
@@ -102,7 +102,7 @@ Example:
 ```
 optimum-cli neuron cache set michaelbenayoun/optimum-neuron-cache
 
-Trainium cache name set locally to michaelbenayoun/optimum-neuron-cache in /home/michael/.cache/huggingface/optimum_neuron_custom_cache
+Neuron cache name set locally to michaelbenayoun/optimum-neuron-cache in /home/michael/.cache/huggingface/optimum_neuron_custom_cache
 ```
 
 <Tip>
@@ -139,11 +139,11 @@ You have to be [logged into the Hugging Face Hub](https://huggingface.co/docs/hu
 </p>
 
 
-At each the beginning of each training step, the  [`TrainiumTrainer`] computes a `NeuronHash` and checks the cache repo(s) (official and custom) on the Hugging Face Hub to see if there are compiled files associated to this hash. 
+At each the beginning of each training step, the  [`NeuronTrainer`] computes a `NeuronHash` and checks the cache repo(s) (official and custom) on the Hugging Face Hub to see if there are compiled files associated to this hash. 
 If that is the case, the files are downloaded directly to the local cache directory and no compilation is needed. Otherwise compilation is performed.
 
 
-Just as for downloading compiled files, the [`TrainiumTrainer`] will keep track of the newly created compilation files at each training step, and upload them to the Hugging Face Hub at save time or when training ends. This assumes that you have writing access to the cache repo, otherwise nothing will be pushed. 
+Just as for downloading compiled files, the [`NeuronTrainer`] will keep track of the newly created compilation files at each training step, and upload them to the Hugging Face Hub at save time or when training ends. This assumes that you have writing access to the cache repo, otherwise nothing will be pushed. 
 
 
 ## Optimum CLI
@@ -156,7 +156,7 @@ usage: optimum-cli neuron cache [-h] {create,set,add,list} ...
 positional arguments:
   {create,set,add,list}
     create              Create a model repo on the Hugging Face Hub to store Neuron X compilation files.
-    set                 Set the name of the Trainium cache repo to use locally.
+    set                 Set the name of the Neuron cache repo to use locally.
     add                 Add a model to the cache of your choice.
     list                List models in a cache repo.
 
@@ -178,7 +178,7 @@ usage: optimum-cli neuron cache add [-h] -m MODEL --task TASK --train_batch_size
 When running this command a small training session will be run and the resulting compilation files will be pushed.
 
 <Tip warning={true}>
-Make sure that the Trainium cache repo to use is set up locally, this can be done by running the `optimum-cli neuron cache set` command. 
+Make sure that the Neuron cache repo to use is set up locally, this can be done by running the `optimum-cli neuron cache set` command. 
 You also need to make sure that you are logged in to the Hugging Face Hub and that you have the writing rights for the specified cache repo,
 this can be done via the `huggingface-cli login` command.
 
@@ -200,7 +200,7 @@ optimum-cli neuron cache add \
   --precision bf16
 ```
 
-This will push compilation files for the `prajjwal1/bert-tiny` model on the Trainium cache repo that was set up for the specified parameters.
+This will push compilation files for the `prajjwal1/bert-tiny` model on the Neuron cache repo that was set up for the specified parameters.
 
 ### List a cache repo
 

--- a/docs/source/guides/fine_tune.mdx
+++ b/docs/source/guides/fine_tune.mdx
@@ -18,7 +18,7 @@ limitations under the License.
 
 Training on AWS Trainium is as simple as in Transformers:
 
-- You need to replace the Transformers' [`Trainer`](https://huggingface.co/docs/transformers/main_classes/trainer) class with the [`TrainiumTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer) class.
+- You need to replace the Transformers' [`Trainer`](https://huggingface.co/docs/transformers/main_classes/trainer) class with the [`NeuronTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer) class.
 
 You can find several examples in the official repository for the following tasks:
 

--- a/docs/source/guides/overview.mdx
+++ b/docs/source/guides/overview.mdx
@@ -21,7 +21,7 @@ These guides tackle more advanced topics and will show you how to easily get the
 
 - [How to setup AWS Trainium instance](./setup_aws_instance)
 - [How to fine-tune a Transformers model with AWS Trainium](./fine_tune)
-- [Trainium model cache](./cache_system)
+- [Neuron model cache](./cache_system)
 - [Export a model to Inferentia](./export_model)
 - [Neuron Model Inference](./models)
 - [Inference pipelines with AWS Neuron (Inf2/Trn1)](./pipelines)

--- a/docs/source/package_reference/trainer.mdx
+++ b/docs/source/package_reference/trainer.mdx
@@ -14,24 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# TrainiumTrainer
+# NeuronTrainer
 
-The [`TrainiumTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.TrainiumTrainer) class provides an extended API for the feature-complete [Transformers Trainer](https://huggingface.co/docs/transformers/main_classes/trainer). It is used in all the [example scripts](https://github.com/huggingface/optimum-neuron/tree/main/examples).
+The [`NeuronTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.NeuronTrainer) class provides an extended API for the feature-complete [Transformers Trainer](https://huggingface.co/docs/transformers/main_classes/trainer). It is used in all the [example scripts](https://github.com/huggingface/optimum-neuron/tree/main/examples).
 
 <Tip warning={true}>
 
-The [`TrainiumTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.TrainiumTrainer) class is optimized for 🤗 Transformers models running on AWS Trainium.
+The [`NeuronTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.NeuronTrainer) class is optimized for 🤗 Transformers models running on AWS Trainium.
 
 </Tip>
 
-Here is an example of how to customize [`TrainiumTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.TrainiumTrainer) to use a weighted loss (useful when you have an unbalanced training set):
+Here is an example of how to customize [`NeuronTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.NeuronTrainer) to use a weighted loss (useful when you have an unbalanced training set):
 
 ```python
 from torch import nn
-from optimum.neuron import TrainiumTrainer
+from optimum.neuron import NeuronTrainer
 
 
-class CustomTrainiumTrainer(TrainiumTrainer):
+class CustomNeuronTrainer(NeuronTrainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         labels = inputs.get("labels")
         # forward pass
@@ -43,10 +43,10 @@ class CustomTrainiumTrainer(TrainiumTrainer):
         return (loss, outputs) if return_outputs else loss
 ```
 
-Another way to customize the training loop behavior for the PyTorch [`TrainiumTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.TrainiumTrainer) is to use [callbacks](https://huggingface.co/docs/transformers/main_classes/callback) that can inspect the training loop state (for progress reporting, logging on TensorBoard or other ML platforms...) and take decisions (like early stopping).
+Another way to customize the training loop behavior for the PyTorch [`NeuronTrainer`](https://huggingface.co/docs/optimum/neuron/package_reference/trainer#optimum.neuron.NeuronTrainer) is to use [callbacks](https://huggingface.co/docs/transformers/main_classes/callback) that can inspect the training loop state (for progress reporting, logging on TensorBoard or other ML platforms...) and take decisions (like early stopping).
 
-## TrainiumTrainer
+## NeuronTrainer
 
-[[autodoc]] trainers.TrainiumTrainer
+[[autodoc]] trainers.NeuronTrainer
 
-[[autodoc]] trainers.Seq2SeqTrainiumTrainer
+[[autodoc]] trainers.Seq2SeqNeuronTrainer

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -19,10 +19,10 @@ limitations under the License.
 🤗 Optimum Neuron was designed with one goal in mind: **to make training and inference straightforward for any 🤗 Transformers user while leveraging the complete power of AWS Accelerators**.
 There are two main classes one needs to know:
 
-- TrainiumArgumentParser: inherits the original [HfArgumentParser](https://huggingface.co/docs/transformers/main/en/internal/trainer_utils#transformers.HfArgumentParser) in Transformers with additional checks on the argument values to make sure that they will work well with AWS Trainium instances.
-- [TrainiumTrainer](https://huggingface.co/docs/optimum/neuron/package_reference/trainer): the trainer class that takes care of compiling and distributing the model to run on Trainium Chips, and performing training and evaluation.
+- NeuronArgumentParser: inherits the original [HfArgumentParser](https://huggingface.co/docs/transformers/main/en/internal/trainer_utils#transformers.HfArgumentParser) in Transformers with additional checks on the argument values to make sure that they will work well with AWS Trainium instances.
+- [NeuronTrainer](https://huggingface.co/docs/optimum/neuron/package_reference/trainer): the trainer class that takes care of compiling and distributing the model to run on Trainium Chips, and performing training and evaluation.
 
-The [TrainiumTrainer](https://huggingface.co/docs/optimum/neuron/package_reference/trainer) is very similar to the [🤗 Transformers Trainer](https://huggingface.co/docs/transformers/main_classes/trainer), and adapting a script using the Trainer to make it work with Trainium will mostly consist in simply swapping the `Trainer` class for the `TrainiumTrainer` one.
+The [NeuronTrainer](https://huggingface.co/docs/optimum/neuron/package_reference/trainer) is very similar to the [🤗 Transformers Trainer](https://huggingface.co/docs/transformers/main_classes/trainer), and adapting a script using the Trainer to make it work with Trainium will mostly consist in simply swapping the `Trainer` class for the `NeuronTrainer` one.
 That's how most of the [example scripts](https://github.com/huggingface/optimum-neuron/tree/main/examples) were adapted from their [original counterparts](https://github.com/huggingface/transformers/tree/main/examples/pytorch).
 
 modifications:
@@ -30,7 +30,7 @@ modifications:
 ```diff
 from transformers import TrainingArguments
 -from transformers import Trainer
-+from optimum.neuron import TrainiumTrainer as Trainer
++from optimum.neuron import NeuronTrainer as Trainer
 training_args = TrainingArguments(
   # training arguments...
 )

--- a/docs/source/tutorials/fine_tune_bert.mdx
+++ b/docs/source/tutorials/fine_tune_bert.mdx
@@ -140,20 +140,20 @@ tokenized_dataset["test"].save_to_disk(os.path.join(save_dataset_path,"eval"))
 
 Normally you would use the [Trainer](https://huggingface.co/docs/transformers/v4.19.4/en/main_classes/trainer#transformers.Trainer) and [TrainingArguments](https://huggingface.co/docs/transformers/v4.19.4/en/main_classes/trainer#transformers.TrainingArguments) to fine-tune PyTorch-based transformer models.
 
-But together with AWS, we have developed a `TrainiumTrainer` to improve performance, robustness, and safety when training on Trainium instances. The `TrainiumTrainer` also comes with a [model cache](https://www.notion.so/Getting-started-with-AWS-Trainium-and-Hugging-Face-Transformers-8428c72556194aed9c393de101229dcf), which allows us to use precompiled models and configuration from Hugging Face Hub to skip the compilation step, which would be needed at the beginning of training. This can reduce the training time by ~3x.
+But together with AWS, we have developed a `NeuronTrainer` to improve performance, robustness, and safety when training on Trainium instances. The `NeuronTrainer` also comes with a [model cache](https://www.notion.so/Getting-started-with-AWS-Trainium-and-Hugging-Face-Transformers-8428c72556194aed9c393de101229dcf), which allows us to use precompiled models and configuration from Hugging Face Hub to skip the compilation step, which would be needed at the beginning of training. This can reduce the training time by ~3x.
 
-The `TrainiumTrainer` is part of the `optimum-neuron` library and can be used as a 1-to-1 replacement for the `Trainer`. You only have to adjust the import in your training script.
+The `NeuronTrainer` is part of the `optimum-neuron` library and can be used as a 1-to-1 replacement for the `Trainer`. You only have to adjust the import in your training script.
 
 ```diff
 - from transformers import Trainer
-+ from optimum.neuron import TrainiumTrainer as Trainer
++ from optimum.neuron import NeuronTrainer as Trainer
 ```
 
-We prepared a simple [train.py](https://github.com/philschmid/aws-neuron-samples/blob/main/training/scripts/train.py) training script based on the ["Getting started with Pytorch 2.0 and Hugging Face Transformers”](https://www.philschmid.de/getting-started-pytorch-2-0-transformers#3-fine-tune--evaluate-bert-model-with-the-hugging-face-trainer) blog post with the `TrainiumTrainier`. Below is an excerpt
+We prepared a simple [train.py](https://github.com/philschmid/aws-neuron-samples/blob/main/training/scripts/train.py) training script based on the ["Getting started with Pytorch 2.0 and Hugging Face Transformers”](https://www.philschmid.de/getting-started-pytorch-2-0-transformers#3-fine-tune--evaluate-bert-model-with-the-hugging-face-trainer) blog post with the `NeuronTrainer`. Below is an excerpt
 
 ```python
 from transformers import TrainingArguments
-from optimum.neuron import TrainiumTrainer as Trainer
+from optimum.neuron import NeuronTrainer as Trainer
 
 def parse_args():
 	...

--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -45,9 +45,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 """ Fine-tuning a 🤗 Transformers model for image classification"""

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -49,9 +49,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -47,9 +47,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -41,9 +41,9 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import PaddingStrategy, check_min_version, send_example_telemetry
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -44,8 +44,8 @@ from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 from utils_qa import postprocess_qa_predictions
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/question-answering/run_seq2seq_qa.py
+++ b/examples/question-answering/run_seq2seq_qa.py
@@ -40,8 +40,8 @@ from transformers.trainer_utils import EvalLoopOutput, EvalPrediction, get_last_
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import Seq2SeqTrainiumTrainingArguments as Seq2SeqTrainingArguments
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import Seq2SeqNeuronTrainingArguments as Seq2SeqTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/question-answering/trainer_qa.py
+++ b/examples/question-answering/trainer_qa.py
@@ -21,7 +21,7 @@ import time
 from transformers import is_torch_tpu_available
 from transformers.trainer_utils import PredictionOutput, speed_metrics
 
-from optimum.neuron import TrainiumTrainer as Trainer
+from optimum.neuron import NeuronTrainer as Trainer
 
 
 if is_torch_tpu_available(check_device=False):

--- a/examples/question-answering/trainer_seq2seq_qa.py
+++ b/examples/question-answering/trainer_seq2seq_qa.py
@@ -23,7 +23,7 @@ from torch.utils.data import Dataset
 from transformers import is_torch_tpu_available
 from transformers.trainer_utils import PredictionOutput, speed_metrics
 
-from optimum.neuron import Seq2SeqTrainiumTrainer as Seq2SeqTrainer
+from optimum.neuron import Seq2SeqNeuronTrainer as Seq2SeqTrainer
 
 
 if is_torch_tpu_available(check_device=False):

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -46,9 +46,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, is_offline_mode, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import Seq2SeqTrainiumTrainer as Seq2SeqTrainer
-from optimum.neuron import Seq2SeqTrainiumTrainingArguments as Seq2SeqTrainingArguments
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import Seq2SeqNeuronTrainer as Seq2SeqTrainer
+from optimum.neuron import Seq2SeqNeuronTrainingArguments as Seq2SeqTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -42,9 +42,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -42,9 +42,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -43,9 +43,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
-from optimum.neuron import TrainiumTrainer as Trainer
-from optimum.neuron import TrainiumTrainingArguments as TrainingArguments
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronTrainer as Trainer
+from optimum.neuron import NeuronTrainingArguments as TrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/translation/run_translation.py
+++ b/examples/translation/run_translation.py
@@ -46,9 +46,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from optimum.neuron import Seq2SeqTrainiumTrainer as Seq2SeqTrainer
-from optimum.neuron import Seq2SeqTrainiumTrainingArguments as Seq2SeqTrainingArguments
-from optimum.neuron import TrainiumHfArgumentParser as HfArgumentParser
+from optimum.neuron import NeuronHfArgumentParser as HfArgumentParser
+from optimum.neuron import Seq2SeqNeuronTrainer as Seq2SeqTrainer
+from optimum.neuron import Seq2SeqNeuronTrainingArguments as Seq2SeqTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/optimum/commands/neuron/base.py
+++ b/optimum/commands/neuron/base.py
@@ -28,7 +28,7 @@ class NeuronCommand(BaseOptimumCLICommand):
     SUBCOMMANDS = (
         CommandInfo(
             name="cache",
-            help="Manage the Trainium cache.",
+            help="Manage the Neuron cache.",
             subcommand_class=CustomCacheRepoCommand,
         ),
     )

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Defines the command line related to dealing with the Trainium cache repo."""
+"""Defines the command line related to dealing with the Neuron cache repo."""
 
 from typing import TYPE_CHECKING
 
@@ -55,8 +55,8 @@ class CreateCustomCacheRepoCommand(BaseOptimumCLICommand):
     def run(self):
         repo_url = create_custom_cache_repo(repo_id=self.args.name, private=not self.args.public)
         public_or_private = "public" if self.args.public else "private"
-        logger.info(f"Trainium cache created on the Hugging Face Hub: {repo_url.repo_id} [{public_or_private}].")
-        logger.info(f"Trainium cache name set locally to {repo_url.repo_id} in {HF_HOME_CACHE_REPO_FILE}.")
+        logger.info(f"Neuron cache created on the Hugging Face Hub: {repo_url.repo_id} [{public_or_private}].")
+        logger.info(f"Neuron cache name set locally to {repo_url.repo_id} in {HF_HOME_CACHE_REPO_FILE}.")
 
 
 class SetCustomCacheRepoCommand(BaseOptimumCLICommand):
@@ -66,7 +66,7 @@ class SetCustomCacheRepoCommand(BaseOptimumCLICommand):
 
     def run(self):
         set_custom_cache_repo_name_in_hf_home(self.args.name)
-        logger.info(f"Trainium cache name set locally to {self.args.name} in {HF_HOME_CACHE_REPO_FILE}.")
+        logger.info(f"Neuron cache name set locally to {self.args.name} in {HF_HOME_CACHE_REPO_FILE}.")
 
 
 class AddToCacheRepoCommand(BaseOptimumCLICommand):
@@ -217,7 +217,7 @@ class CustomCacheRepoCommand(BaseOptimumCLICommand):
         ),
         CommandInfo(
             name="set",
-            help="Set the name of the Trainium cache repo to use locally.",
+            help="Set the name of the Neuron cache repo to use locally.",
             subcommand_class=SetCustomCacheRepoCommand,
         ),
         CommandInfo(

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -19,9 +19,9 @@ from transformers.utils import _LazyModule
 
 
 _import_structure = {
-    "hf_argparser": ["TrainiumHfArgumentParser"],
-    "trainers": ["TrainiumTrainer", "Seq2SeqTrainiumTrainer"],
-    "training_args": ["TrainiumTrainingArguments", "Seq2SeqTrainiumTrainingArguments"],
+    "hf_argparser": ["NeuronHfArgumentParser"],
+    "trainers": ["NeuronTrainer", "Seq2SeqNeuronTrainer"],
+    "training_args": ["NeuronTrainingArguments", "Seq2SeqNeuronTrainingArguments"],
     "modeling_base": ["NeuronBaseModel"],
     "modeling": [
         "NeuronModelForFeatureExtraction",
@@ -41,7 +41,7 @@ _import_structure = {
 
 if TYPE_CHECKING:
     from .accelerate import NeuronAccelerator, NeuronAcceleratorState, NeuronPartialState
-    from .hf_argparser import TrainiumHfArgumentParser
+    from .hf_argparser import NeuronHfArgumentParser
     from .modeling import (
         NeuronModelForFeatureExtraction,
         NeuronModelForMaskedLM,
@@ -52,8 +52,8 @@ if TYPE_CHECKING:
     )
     from .modeling_base import NeuronBaseModel
     from .pipelines import pipeline
-    from .trainers import Seq2SeqTrainiumTrainer, TrainiumTrainer
-    from .training_args import Seq2SeqTrainiumTrainingArguments, TrainiumTrainingArguments
+    from .trainers import NeuronTrainer, Seq2SeqNeuronTrainer
+    from .training_args import NeuronTrainingArguments, Seq2SeqNeuronTrainingArguments
 else:
     import sys
 

--- a/optimum/neuron/hf_argparser.py
+++ b/optimum/neuron/hf_argparser.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Customizes the HfArgumentParser to add checks for AWS Tranium instances."""
+"""Customizes the HfArgumentParser to add checks for AWS Neuron instances."""
 
 from transformers import HfArgumentParser
 
 from .utils.argument_utils import validate_arg
 
 
-class TrainiumHfArgumentParser(HfArgumentParser):
+class NeuronHfArgumentParser(HfArgumentParser):
     def validate_args(self, args):
         validate_arg(
             args,

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Defines custom Trainer callbacks specific to AWS Trainium instances."""
+"""Defines custom Trainer callbacks specific to AWS Neuron instances."""
 
 import inspect
 import json

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Defines Trainer subclasses to perform training on AWS Trainium instances."""
+"""Defines Trainer subclasses to perform training on AWS Neuron instances."""
 
 import contextlib
 import glob
@@ -101,7 +101,7 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
             raise AssertionError("Failed to initialize torch.distributed process group using XLA backend.")
 
 
-class AugmentTrainerForTrainiumMixin:
+class AugmentTrainerForNeuronMixin:
     def __init__(self, *args, **kwargs):
         if not isinstance(self, Trainer):
             raise TypeError(f"{self.__class__.__name__} can only be mixed with Trainer subclasses.")
@@ -386,13 +386,13 @@ class AugmentTrainerForTrainiumMixin:
         )
 
 
-class TrainiumTrainer(AugmentTrainerForTrainiumMixin, Trainer):
+class NeuronTrainer(AugmentTrainerForNeuronMixin, Trainer):
     """
     Trainer that is suited for performing training on AWS Tranium instances.
     """
 
 
-class Seq2SeqTrainiumTrainer(AugmentTrainerForTrainiumMixin, Seq2SeqTrainer):
+class Seq2SeqNeuronTrainer(AugmentTrainerForNeuronMixin, Seq2SeqTrainer):
     """
     Seq2SeqTrainer that is suited for performing training on AWS Tranium instances.
     """

--- a/optimum/neuron/training_args.py
+++ b/optimum/neuron/training_args.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Defines a TrainingArguments class compatible with Trainium."""
+"""Defines a TrainingArguments class compatible with Neuron."""
 
 import io
 import json
@@ -49,7 +49,7 @@ if is_sagemaker_mp_enabled():
 logger = logging.get_logger(__name__)
 
 
-class TrainiumTrainingArgumentsMixin:
+class NeuronTrainingArgumentsMixin:
     def __post_init__(self):
         # Patches accelerate.utils.imports.is_tpu_available to match `is_torch_xla_available`
         patch_accelerate_is_tpu_available()
@@ -187,14 +187,14 @@ class TrainiumTrainingArgumentsMixin:
 
 
 @dataclass
-class TrainiumTrainingArguments(TrainiumTrainingArgumentsMixin, TrainingArguments):
+class NeuronTrainingArguments(NeuronTrainingArgumentsMixin, TrainingArguments):
     tensor_parallel_size: int = field(
         default=1, metadata={"help": "The number of replicas the model will be sharded on."}
     )
 
 
 @dataclass
-class Seq2SeqTrainiumTrainingArguments(TrainiumTrainingArgumentsMixin, Seq2SeqTrainingArguments):
+class Seq2SeqNeuronTrainingArguments(NeuronTrainingArgumentsMixin, Seq2SeqTrainingArguments):
     tensor_parallel_size: int = field(
         default=1, metadata={"help": "The number of replicas the model will be sharded on."}
     )

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -110,7 +110,7 @@ def set_custom_cache_repo_name_in_hf_home(repo_id: str, hf_home: str = HF_HOME, 
             HfApi().repo_info(repo_id, repo_type="model")
         except Exception as e:
             raise ValueError(
-                f"Could not save the custom Trainium cache repo to be {repo_id} because it does not exist or is "
+                f"Could not save the custom Neuron cache repo to be {repo_id} because it does not exist or is "
                 f"private to you. Complete exception message: {e}."
             )
 
@@ -175,9 +175,9 @@ def get_hf_hub_cache_repos():
     if saved_custom_cache_repo is None:
         warn_once(
             logger,
-            "No Trainium cache name is saved locally. This means that only the official Trainium cache, and "
-            "potentially a cache defined in $CUSTOM_CACHE_REPO will be used. You can create a Trainium cache repo by "
-            "running the following command: `optimum-cli neuron cache create`. If the Trainium cache already exists "
+            "No Neuron cache name is saved locally. This means that only the official Neuron cache, and "
+            "potentially a cache defined in $CUSTOM_CACHE_REPO will be used. You can create a Neuron cache repo by "
+            "running the following command: `optimum-cli neuron cache create`. If the Neuron cache already exists "
             "you can set it by running the following command: `optimum-cli neuron cache set -n [name]`.",
         )
     else:
@@ -205,7 +205,7 @@ def get_hf_hub_cache_repos():
         warn_once(
             logger,
             f"You do not have write access to {hf_hub_repos[0]} so you will not be able to push any cached compilation "
-            "files. Please log in and/or use a custom Trainium cache.",
+            "files. Please log in and/or use a custom Neuron cache.",
         )
     return hf_hub_repos
 

--- a/optimum/neuron/utils/compilation_utils.py
+++ b/optimum/neuron/utils/compilation_utils.py
@@ -285,9 +285,9 @@ class ExampleRunner:
         custom_cache_repo = os.environ.get("CUSTOM_CACHE_REPO", None)
         if saved_custom_cache_repo is None and custom_cache_repo is None:
             logger.warning(
-                "No custom Trainium cache repo set which means that the official Trainium cache repo will be used. If "
+                "No custom Neuron cache repo set which means that the official Neuron cache repo will be used. If "
                 "you are not a member of the Optimum Neuron Team, this means that you will not be able to push to the "
-                "Hub. Follow the instructions here to set you custom Trainium cache: "
+                "Hub. Follow the instructions here to set you custom Neuron cache: "
                 "https://huggingface.co/docs/optimum-neuron/guides/cache_system#how-to-use-a-private-trainium-model-cache"
             )
 

--- a/tests/cli/test_neuron_cache_cli.py
+++ b/tests/cli/test_neuron_cache_cli.py
@@ -95,7 +95,7 @@ class TestNeuronCacheCLI(StagingTestMixin, TestCase):
             self.assertEqual(
                 repo_id,
                 load_custom_cache_repo_name_from_hf_home(hf_home_cache_repo_file),
-                f"Saved local Trainium cache name should be equal to {repo_id}.",
+                f"Saved local Neuron cache name should be equal to {repo_id}.",
             )
 
     def test_optimum_neuron_cache_create_with_default_name(self):
@@ -123,7 +123,7 @@ class TestNeuronCacheCLI(StagingTestMixin, TestCase):
             self.assertEqual(
                 self.repo_id,
                 load_custom_cache_repo_name_from_hf_home(hf_home_cache_repo_file),
-                f"Saved local Trainium cache name should be equal to {self.repo_id}.",
+                f"Saved local Neuron cache name should be equal to {self.repo_id}.",
             )
 
     def test_optimum_neuron_cache_add(self):

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -29,7 +29,7 @@ from huggingface_hub.utils import RepositoryNotFoundError
 from transformers import BertConfig, BertModel, BertTokenizer, TrainingArguments
 from transformers.testing_utils import is_staging_test
 
-from optimum.neuron.trainers import TrainiumTrainer
+from optimum.neuron.trainers import NeuronTrainer
 from optimum.neuron.utils.cache_utils import (
     get_neuron_cache_path,
     list_files_in_neuron_cache,
@@ -50,7 +50,7 @@ from .utils import (
 
 @is_trainium_test
 @is_staging_test
-class StagingTrainiumTrainerTestCase(StagingTestMixin, TestCase):
+class StagingNeuronTrainerTestCase(StagingTestMixin, TestCase):
     def test_train_and_eval(self):
         os.environ["CUSTOM_CACHE_REPO"] = self.CUSTOM_PRIVATE_CACHE_REPO
 
@@ -86,7 +86,7 @@ class StagingTrainiumTrainerTestCase(StagingTestMixin, TestCase):
                 save_steps=10,
                 num_train_epochs=2,
             )
-            trainer = TrainiumTrainer(
+            trainer = NeuronTrainer(
                 model,
                 args,
                 train_dataset=dummy_train_dataset,
@@ -122,7 +122,7 @@ class StagingTrainiumTrainerTestCase(StagingTestMixin, TestCase):
                 save_steps=10,
                 num_train_epochs=2,
             )
-            trainer = TrainiumTrainer(
+            trainer = NeuronTrainer(
                 clone,
                 args,
                 train_dataset=dummy_train_dataset,
@@ -311,7 +311,7 @@ class StagingTrainiumTrainerTestCase(StagingTestMixin, TestCase):
 
 
 @is_trainium_test
-class TrainiumTrainerTestCase(TestCase):
+class NeuronTrainerTestCase(TestCase):
     def _test_training_with_fsdp_mode(self, fsdp_mode: str):
         model_name = "prajjwal1/bert-tiny"
         task_name = "sst2"

--- a/tools/create_examples_from_transformers.py
+++ b/tools/create_examples_from_transformers.py
@@ -65,11 +65,11 @@ TORCH_REQUIREMENT_PATTERN = re.compile(r"torch[\w\s]*([<>=!]=?\s*[\d\.]+)?\n")
 
 
 AWS_CODE = {
-    "Trainer": "TrainiumTrainer as Trainer",
-    "Seq2SeqTrainer": "Seq2SeqTrainiumTrainer as Seq2SeqTrainer",
-    "HfArgumentParser": "TrainiumHfArgumentParser as HfArgumentParser",
-    "TrainingArguments": "TrainiumTrainingArguments as TrainingArguments",
-    "Seq2SeqTrainingArguments": "Seq2SeqTrainiumTrainingArguments as Seq2SeqTrainingArguments",
+    "Trainer": "NeuronTrainer as Trainer",
+    "Seq2SeqTrainer": "Seq2SeqNeuronTrainer as Seq2SeqTrainer",
+    "HfArgumentParser": "NeuronHfArgumentParser as HfArgumentParser",
+    "TrainingArguments": "NeuronTrainingArguments as TrainingArguments",
+    "Seq2SeqTrainingArguments": "Seq2SeqNeuronTrainingArguments as Seq2SeqTrainingArguments",
 }
 
 


### PR DESCRIPTION
Renames everything called with "Trainium" to "Neuron" as agreed during offline meetings.