### PR TITLE
Add proper documentation for decoder models

### DIFF
--- a/docs/source/package_reference/configuration.mdx
+++ b/docs/source/package_reference/configuration.mdx
@@ -49,6 +49,7 @@ Since many architectures share similar properties for their Neuron configuration
 | DistilBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | ELECTRA                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | FlauBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| GPT2                   | text-generation                                                                                                                               |
 | MobileBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | MPNet                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | RoBERTa                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |

--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -16,13 +16,20 @@ limitations under the License.
 
 # Models
 
-## Generic model class
-
-The following `NeuronBaseModel` class is available for instantiating a base Neuron model without a specific head.
+## Generic model classes
 
 ### NeuronBaseModel
 
+The `NeuronBaseModel` class is available for instantiating a base Neuron model without a specific head.
+It is used as the base class for all tasks but text generation.
+
 [[autodoc]] modeling_base.NeuronBaseModel
+
+### NeuronDecoderModel
+
+The `NeuronDecoderModel` class is the base class for text generation models.
+
+[[autodoc]] modeling_decoder.NeuronDecoderModel
 
 ## Natural Language Processing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,21 @@
-# 🤗 Transformers example scripts on AWS Trainium with Optimum Neuron
+# 🤗 Transformers example scripts on AWS Trainium/Inferentia with Optimum Neuron
 
-The following example scripts have been taken from the [official 🤗 Transformers example directory](https://github.com/huggingface/transformers/tree/main/examples/pytorch) and adapted to use the `NeuronTrainer`:
+Most of the following example scripts have been taken from the [official 🤗 Transformers example directory](https://github.com/huggingface/transformers/tree/main/examples/pytorch).
+
+## Training
+
+The training scripts for the following tasks have been adapted to use the `NeuronTrainer`:
+
+- image-classification,
+- language-modeling,
+- multiple-choice,
+- question-answering,
+- summarization,
+- text-classification,
+- token-classification,
+- translation.
+
+The required change is as simple as:
 
 ```diff
 - from transformers import Trainer
@@ -18,3 +33,9 @@ While this is not *mandatory*, using the `NeuronTrainer` over the regular `Train
 
 That being said, you can use those examples exactly as you would use the official examples from the 🤗 Transformers library.
 Feel free to check there if you have any usage related questions!
+
+## Inference
+
+The inference scripts for the following tasks have been adapted to use Neuron models:
+
+- text-generation.

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -1,0 +1,86 @@
+import argparse
+import os
+import time
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from optimum.neuron import NeuronModelForCausalLM
+
+
+def load_llm_optimum(model_id_or_path, batch_size, seq_length, num_cores, auto_cast_type):
+    export = not os.path.isdir(model_id_or_path)
+
+    # Load and convert the Hub model to Neuron format
+    return NeuronModelForCausalLM.from_pretrained(
+        model_id_or_path,
+        export=export,
+        low_cpu_mem_usage=True,
+        # These are parameters required for the conversion
+        batch_size=batch_size,
+        n_positions=seq_length,
+        num_cores=num_cores,
+        auto_cast_type=auto_cast_type,
+    )
+
+
+def generate(model, tokenizer, prompts, length, temperature):
+    # Specifiy padding options
+    tokenizer.pad_token_id = tokenizer.eos_token_id
+
+    # Encode tokens and generate using temperature
+    tokens = tokenizer(prompts, return_tensors="pt")
+    start = time.time()
+    with torch.inference_mode():
+        sample_output = model.generate(
+            **tokens,
+            do_sample=True,
+            min_length=length,
+            max_length=length,
+            temperature=temperature,
+        )
+    end = time.time()
+    outputs = [tokenizer.decode(tok) for tok in sample_output]
+    return outputs, (end - start)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model", type=str, help="The HF Hub model id or a local directory.")
+    parser.add_argument("--prompt", type=str, default="One of my fondest memory is", help="The starting prompt.")
+    parser.add_argument("--length", type=int, default=128, help="The number of tokens in the generated sequences.")
+    parser.add_argument(
+        "--batch_size", type=int, default=1, help="If > 1, the prompt will be duplicated to test model throughput."
+    )
+    parser.add_argument(
+        "--num_cores", type=int, default=2, help="The number of cores on which the model should be split."
+    )
+    parser.add_argument("--auto_cast_type", type=str, default="f32", help="One of f32, f16, bf16.")
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=1.0,
+        help="The temperature to generate. 1.0 has no effect, lower tend toward greedy sampling.",
+    )
+    parser.add_argument(
+        "--save_dir", type=str, help="The save directory. Allows to avoid recompiling the model every time."
+    )
+    parser.add_argument("--compare", action="store_true", help="Compare with the genuine transformers model on CPU.")
+    args = parser.parse_args()
+    # Load llm model and tokenizer
+    model = load_llm_optimum(args.model, args.batch_size, args.length, args.num_cores, args.auto_cast_type)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    # We need to replicate the text if batch_size is not 1
+    prompts = [args.prompt for _ in range(args.batch_size)]
+    outputs, latency = generate(model, tokenizer, prompts, args.length, args.temperature)
+    print(outputs)
+    print(f"Outputs generated using Neuron model in {latency:.4f} s")
+    if args.compare:
+        cpu_model = AutoModelForCausalLM.from_pretrained("gpt2")
+        outputs, latency = generate(cpu_model, tokenizer, prompts, args.length, args.temperature)
+        print(outputs)
+        print(f"Outputs generated using pytorch model in {latency:.4f} s")
+
+    if args.save_dir:
+        model.save_pretrained(args.save_dir)
+        tokenizer.save_pretrained(args.save_dir)

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -527,7 +527,19 @@ class NeuronModelForMultipleChoice(NeuronBaseModel):
         return MultipleChoiceModelOutput(logits=logits)
 
 
-NEURON_CAUSALLM_MODEL_DOCSTRING = r"""
+NEURON_CAUSALLM_MODEL_START_DOCSTRING = r"""
+    This model inherits from [`~neuron.modeling.NeuronDecoderModel`]. Check the superclass documentation for the generic methods the
+    library implements for all its model (such as downloading or saving)
+
+    Args:
+        model (`torch.nn.Module`): [torch.nn.Module](https://pytorch.org/docs/stable/generated/torch.nn.Module.html) is the neuron decoder graph.
+        config (`transformers.PretrainedConfig`): [PretrainedConfig](https://huggingface.co/docs/transformers/main_classes/configuration#transformers.PretrainedConfig) is the Model configuration class with all the parameters of the model.
+        model_path (`Path`): The directory where the compiled artifacts for the model are stored.
+            It can be a temporary directory if the model has never been saved locally before.
+        generation_config (`transformers.GenerationConfig`): [GenerationConfig](https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig) holds the configuration for the model generation task.
+"""
+
+NEURON_CAUSALLM_MODEL_FORWARD_DOCSTRING = r"""
     Args:
         input_ids (`torch.LongTensor`):
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, sequence_length)`.
@@ -556,15 +568,11 @@ TEXT_GENERATION_EXAMPLE = r"""
 
 @add_start_docstrings(
     r"""
-    This is a generic Neuron model class that will be instantiated as one of the model classes of the
-    library (with a causal language modeling head) when created with the from_pretrained() class method.
-    """
+    Neuron model with a causal language modeling head for inference on Neuron devices.
+    """,
+    NEURON_CAUSALLM_MODEL_START_DOCSTRING,
 )
 class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
-    """
-    Neuron model with a causal language modeling head for inference on Neuron devices.
-    """
-
     auto_model_class = AutoModelForCausalLM
     main_input_name = "input_ids"
 
@@ -586,7 +594,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
         self.cur_len = 0
 
     @add_start_docstrings_to_model_forward(
-        NEURON_CAUSALLM_MODEL_DOCSTRING
+        NEURON_CAUSALLM_MODEL_FORWARD_DOCSTRING
         + TEXT_GENERATION_EXAMPLE.format(
             processor_class="AutoTokenizer",
             model_class="NeuronModelForCausalLM",
@@ -742,7 +750,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
             `return_dict_in_generate=True` or a [`~generation.SampleEncoderDecoderOutput`] if
             `model.config.is_encoder_decoder=True`.
 
-        ```"""
+        """
         # We don't support all parameters
         if synced_gpus:
             raise ValueError("Neuron models cannot run on GPUs.")


### PR DESCRIPTION
This adds some of the missing documentation for NeuronModelForCausalLM, and an example script.

The guide for text-generation inference is still missing because it requires alignment with the other tasks when explaining the static shapes parameters (to be discussed).
