### PR TITLE
Bump optimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 INSTALL_REQUIRES = [
     "transformers >= 4.28.0",
     "accelerate >= 0.20.1",
-    "optimum",
+    "optimum >= 1.8.8",
     "huggingface_hub >= 0.14.0",
     "numpy>=1.18.5, <=1.21.6",
     "protobuf<4",


### PR DESCRIPTION
optimum 1.8.8 is required for TaskManager exports.