### PR TITLE
Prevent recompilation during greedy search

### DIFF
--- a/optimum/neuron/generation/utils.py
+++ b/optimum/neuron/generation/utils.py
@@ -1275,7 +1275,7 @@ class NeuronGenerationMixin(GenerationMixin):
 
             # pre-process distribution
             # Move to cpu to handle arbitrary logits_processor
-            next_tokens_scores = logits_processor(input_ids[:, :seq_length].to("cpu"), next_token_logits.to("cpu"))
+            next_tokens_scores = logits_processor(input_ids.to("cpu")[:, :seq_length], next_token_logits.to("cpu"))
             next_tokens_scores = next_tokens_scores.to(input_ids.device)
 
             # Store scores, attentions and hidden_states when required


### PR DESCRIPTION
Before moving tensors to the CPU to be processed by the `logit_processor` in greedy search, we dynamically slice it to `seq_length`. Since with each iteration of generating the next tokens this variable increases, recompilation is triggered. This PR changes the order and moves the tensor to CPU before slicing it to prevent recompilation.