### PR TITLE
Another patch for stable diffusion when using neuronx-cc >= 2.7

### DIFF
--- a/docs/source/guides/export_model.mdx
+++ b/docs/source/guides/export_model.mdx
@@ -224,9 +224,8 @@ Exporting a stable diffusion checkpoint can be done using the CLI:
 optimum-cli export neuron --model stabilityai/stable-diffusion-2-1-base \
   --task stable-diffusion \
   --batch_size 1 \
-  --num_channels 4 \
-  --height 64 \
-  --width 64 \
+  --height 512 \  # height in pixels of generated image, eg. 512, 768
+  --width 512 \  # width in pixels of generated image, eg. 512, 768
   sd_neuron/
 ```
 

--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -214,7 +214,7 @@ The export can be done either with the CLI or with `NeuronStableDiffusionPipelin
 >>> from optimum.neuron import NeuronStableDiffusionPipeline
 
 >>> model_id = "runwayml/stable-diffusion-v1-5"
->>> input_shapes = {"batch_size": 1, "height": 64, "width": 64}
+>>> input_shapes = {"batch_size": 1, "height": 512, "width": 512}  
 
 >>> stable_diffusion = NeuronStableDiffusionPipeline.from_pretrained(model_id, export=True, **input_shapes)
 


### PR DESCRIPTION
The unet attn score patch will not work for neuronx-cc compiler version higher than 2.7, thus this patch.