### PR TITLE
Enhance robustness of stable diffusion inference

### DIFF
--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -130,8 +130,10 @@ def infer_stable_diffusion_shapes_from_diffusers(
 ):
     sequence_length = model.tokenizer.model_max_length
     unet_num_channels = model.unet.config.in_channels
-    vae_num_channels = model.vae.config.latent_channels
-    vae_scale_factor = 2 ** (len(model.vae.config.block_out_channels) - 1) or 8
+    vae_encoder_num_channels = model.vae.config.in_channels
+    vae_decoder_num_channels = model.vae.config.latent_channels
+    # vae_scale_factor = 2 ** (len(model.vae.config.block_out_channels) - 1) or 8
+    vae_scale_factor = 8
     height = input_shapes["unet_input_shapes"]["height"] // vae_scale_factor
     width = input_shapes["unet_input_shapes"]["width"] // vae_scale_factor
 
@@ -140,10 +142,10 @@ def infer_stable_diffusion_shapes_from_diffusers(
         {"sequence_length": sequence_length, "num_channels": unet_num_channels, "height": height, "width": width}
     )
     input_shapes["vae_encoder_input_shapes"].update(
-        {"num_channels": vae_num_channels, "height": height, "width": width}
+        {"num_channels": vae_encoder_num_channels, "height": height, "width": width}
     )
     input_shapes["vae_decoder_input_shapes"].update(
-        {"num_channels": vae_num_channels, "height": height, "width": width}
+        {"num_channels": vae_decoder_num_channels, "height": height, "width": width}
     )
 
 

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -132,8 +132,7 @@ def infer_stable_diffusion_shapes_from_diffusers(
     unet_num_channels = model.unet.config.in_channels
     vae_encoder_num_channels = model.vae.config.in_channels
     vae_decoder_num_channels = model.vae.config.latent_channels
-    # vae_scale_factor = 2 ** (len(model.vae.config.block_out_channels) - 1) or 8
-    vae_scale_factor = 8
+    vae_scale_factor = 2 ** (len(model.vae.config.block_out_channels) - 1) or 8
     height = input_shapes["unet_input_shapes"]["height"] // vae_scale_factor
     width = input_shapes["unet_input_shapes"]["width"] // vae_scale_factor
 

--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -340,7 +340,7 @@ def export_models(
 
     # remove models failed to export
     for i, model_name in failed_models:
-        output_file_names.pop(i)
+        output_file_names.pop(model_name)
         models_and_neuron_configs.pop(model_name)
 
     outputs = list(map(list, zip(*outputs)))
@@ -426,8 +426,10 @@ def export_neuronx(
         compiler_args = ["--auto-cast", "none"]
 
     # diffusers specific
-    if hasattr(config._config, "_class_name") and "unet" in config._config._class_name.lower():
-        compiler_args.extend(["--model-type", "unet-inference"])
+    if hasattr(config._config, "_class_name"):
+        if "unet" in config._config._class_name.lower():
+            compiler_args.extend(["--model-type=unet-inference"])
+        compiler_args.extend(["--enable-fast-loading-neuron-binaries"])
 
     neuron_model = neuronx.trace(checked_model, dummy_inputs_tuple, compiler_args=compiler_args)
 

--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -426,20 +426,40 @@ def export_neuronx(
         compiler_args = ["--auto-cast", "none"]
 
     # diffusers specific
-    if hasattr(config._config, "_class_name"):
-        if "unet" in config._config._class_name.lower():
-            compiler_args.extend(["--model-type=unet-inference"])
-        compiler_args.extend(["--enable-fast-loading-neuron-binaries"])
+    prepare_stable_diffusion_compilation(config, compiler_args)
 
     neuron_model = neuronx.trace(checked_model, dummy_inputs_tuple, compiler_args=compiler_args)
 
     if config.dynamic_batch_size is True:
         neuron_model = neuronx.dynamic_batch(neuron_model)
 
+    # diffusers specific
+    improve_stable_diffusion_loading(config, neuron_model)
+
     torch.jit.save(neuron_model, output)
     del neuron_model
 
     return config.inputs, config.outputs
+
+
+def prepare_stable_diffusion_compilation(config, compiler_args):
+    if hasattr(config._config, "_name_or_path"):
+        sd_components = ["text_encoder", "unet", "vae", "vae_encoder", "vae_decoder"]
+        if any(component in config._config._name_or_path.lower() for component in sd_components):
+            compiler_args.extend(["--enable-fast-loading-neuron-binaries"])
+        # unet
+        if "unet" in config._config._name_or_path.lower():
+            compiler_args.extend(["--model-type=unet-inference"])
+
+
+def improve_stable_diffusion_loading(config, neuron_model):
+    if hasattr(config._config, "_name_or_path"):
+        sd_components = ["text_encoder", "unet", "vae", "vae_encoder", "vae_decoder"]
+        if any(component in config._config._name_or_path.lower() for component in sd_components):
+            neuronx.async_load(neuron_model)
+        # unet
+        if "unet" in config._config._name_or_path.lower():
+            neuronx.lazy_load(neuron_model)
 
 
 def export_neuron(

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -71,6 +71,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self,
         text_encoder: torch.jit._script.ScriptModule,
         unet: torch.jit._script.ScriptModule,
+        # TODO: Fix vae encoder export
         # vae_encoder: torch.jit._script.ScriptModule,
         vae_decoder: torch.jit._script.ScriptModule,
         config: Dict[str, Any],
@@ -128,6 +129,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self.unet = NeuronModelUnet(
             unet, self, self.configs[DIFFUSION_MODEL_UNET_NAME], self.neuron_configs[DIFFUSION_MODEL_UNET_NAME]
         )
+        # TODO: Fix vae encoder export
         # self.vae_encoder = NeuronModelVaeEncoder(
         #     vae_encoder,
         #     self,
@@ -285,6 +287,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / unet_file_name,
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / cls.sub_component_config_name,
             ),
+            # TODO: Fix vae encoder export
             # "vae_encoder": (
             #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / vae_encoder_file_name,
             #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / cls.sub_component_config_name,
@@ -312,6 +315,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
             )
         else:
             unet = cls.load_model(model_and_config_save_paths["unet"][0])
+        # TODO: Fix vae encoder export
         # vae_encoder = cls.load_model(model_and_config_save_paths["vae_encoder"][0])
         vae_decoder = cls.load_model(model_and_config_save_paths["vae_decoder"][0])
 
@@ -321,6 +325,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         return cls(
             text_encoder=text_encoder,
             unet=unet,
+            # TODO: Fix vae encoder export
             # vae_encoder=vae_encoder,
             vae_decoder=vae_decoder,
             config=config,

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -71,7 +71,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self,
         text_encoder: torch.jit._script.ScriptModule,
         unet: torch.jit._script.ScriptModule,
-        vae_encoder: torch.jit._script.ScriptModule,
+        # vae_encoder: torch.jit._script.ScriptModule,
         vae_decoder: torch.jit._script.ScriptModule,
         config: Dict[str, Any],
         tokenizer: CLIPTokenizer,
@@ -125,12 +125,12 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self.unet = NeuronModelUnet(
             unet, self, self.configs[DIFFUSION_MODEL_UNET_NAME], self.neuron_configs[DIFFUSION_MODEL_UNET_NAME]
         )
-        self.vae_encoder = NeuronModelVaeEncoder(
-            vae_encoder,
-            self,
-            self.configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
-            self.neuron_configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
-        )
+        # self.vae_encoder = NeuronModelVaeEncoder(
+        #     vae_encoder,
+        #     self,
+        #     self.configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
+        #     self.neuron_configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
+        # )
         self.vae_decoder = NeuronModelVaeDecoder(
             vae_decoder,
             self,
@@ -145,7 +145,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         sub_models = {
             DIFFUSION_MODEL_TEXT_ENCODER_NAME: self.text_encoder,
             DIFFUSION_MODEL_UNET_NAME: self.unet,
-            DIFFUSION_MODEL_VAE_ENCODER_NAME: self.vae_encoder,
+            # DIFFUSION_MODEL_VAE_ENCODER_NAME: self.vae_encoder,
             DIFFUSION_MODEL_VAE_DECODER_NAME: self.vae_decoder,
         }
         for name in sub_models.keys():
@@ -282,10 +282,10 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / unet_file_name,
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / cls.sub_component_config_name,
             ),
-            "vae_encoder": (
-                new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / vae_encoder_file_name,
-                new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / cls.sub_component_config_name,
-            ),
+            # "vae_encoder": (
+            #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / vae_encoder_file_name,
+            #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / cls.sub_component_config_name,
+            # ),
             "vae_decoder": (
                 new_model_save_dir / DIFFUSION_MODEL_VAE_DECODER_NAME / vae_decoder_file_name,
                 new_model_save_dir / DIFFUSION_MODEL_VAE_DECODER_NAME / cls.sub_component_config_name,
@@ -309,7 +309,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
             )
         else:
             unet = cls.load_model(model_and_config_save_paths["unet"][0])
-        vae_encoder = cls.load_model(model_and_config_save_paths["vae_encoder"][0])
+        # vae_encoder = cls.load_model(model_and_config_save_paths["vae_encoder"][0])
         vae_decoder = cls.load_model(model_and_config_save_paths["vae_decoder"][0])
 
         if model_save_dir is None:
@@ -318,7 +318,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         return cls(
             text_encoder=text_encoder,
             unet=unet,
-            vae_encoder=vae_encoder,
+            # vae_encoder=vae_encoder,
             vae_decoder=vae_decoder,
             config=config,
             tokenizer=sub_models["tokenizer"],

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -115,6 +115,9 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self._internal_dict = config
         self.configs = configs
         self.neuron_configs = neuron_configs
+        self.dynamic_batch_size = all(
+            neuron_config._config.neuron["dynamic_batch_size"] for neuron_config in self.neuron_configs.values()
+        )
 
         self.text_encoder = NeuronModelTextEncoder(
             text_encoder,

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
@@ -22,6 +22,7 @@ from diffusers import StableDiffusionPipeline
 from diffusers.loaders import LoraLoaderMixin, TextualInversionLoaderMixin
 from diffusers.pipelines.stable_diffusion import StableDiffusionPipelineOutput
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg
+from diffusers.utils import randn_tensor
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,6 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
     def _encode_prompt(
         self,
         prompt,
-        device,
         num_images_per_prompt,
         do_classifier_free_guidance,
         negative_prompt=None,
@@ -136,6 +136,24 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
 
         return prompt_embeds
 
+    # Adapted from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.prepare_latents
+    def prepare_latents(self, batch_size, num_channels_latents, height, width, dtype, generator, latents=None):
+        shape = (batch_size, num_channels_latents, height // self.vae_scale_factor, width // self.vae_scale_factor)
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
+        if latents is None:
+            latents = randn_tensor(shape, generator=generator, dtype=dtype)
+        elif latents.shape != shape:
+            raise ValueError(f"Unexpected latents shape, got {latents.shape}, expected {shape}")
+
+        # scale the initial noise by the standard deviation required by the scheduler
+        latents = latents * self.scheduler.init_noise_sigma
+        return latents
+
     # Adapted from https://github.com/huggingface/diffusers/blob/v0.18.2/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L566
     def __call__(
         self,
@@ -175,7 +193,6 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         else:
             batch_size = prompt_embeds.shape[0]
 
-        device = self._execution_device
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
@@ -187,7 +204,6 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         )
         prompt_embeds = self._encode_prompt(
             prompt,
-            device,
             num_images_per_prompt,
             do_classifier_free_guidance,
             negative_prompt,
@@ -197,7 +213,7 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         )
 
         # 4. Prepare timesteps
-        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        self.scheduler.set_timesteps(num_inference_steps)
         timesteps = self.scheduler.timesteps
 
         # 5. Prepare latent variables
@@ -208,7 +224,6 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
             height,
             width,
             prompt_embeds.dtype,
-            device,
             generator,
             latents,
         )
@@ -253,7 +268,7 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         if not output_type == "latent":
             # [Modified] Replace with pre-compiled
             image = self.vae_decoder(latents / getattr(self.vae_decoder.config, "scaling_factor", 0.18215))[0]
-            image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
+            image, has_nsfw_concept = self.run_safety_checker(image, prompt_embeds.dtype)
         else:
             image = latents
             has_nsfw_concept = None
@@ -273,3 +288,17 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
             return (image, has_nsfw_concept)
 
         return StableDiffusionPipelineOutput(images=image, nsfw_content_detected=has_nsfw_concept)
+
+    def run_safety_checker(self, image, dtype):
+        if self.safety_checker is None:
+            has_nsfw_concept = None
+        else:
+            if torch.is_tensor(image):
+                feature_extractor_input = self.image_processor.postprocess(image, output_type="pil")
+            else:
+                feature_extractor_input = self.image_processor.numpy_to_pil(image)
+            safety_checker_input = self.feature_extractor(feature_extractor_input, return_tensors="pt")
+            image, has_nsfw_concept = self.safety_checker(
+                images=image, clip_input=safety_checker_input.pixel_values.to(dtype)
+            )
+        return image, has_nsfw_concept

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
@@ -196,7 +196,10 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0
+        if guidance_scale > 1.0 and self.dynamic_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            do_classifier_free_guidance = False
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/utils/optimization_utils.py
+++ b/optimum/neuron/utils/optimization_utils.py
@@ -37,7 +37,7 @@ def get_attention_scores(self, query, key, attn_mask):
         if self.upcast_softmax:
             attention_scores = attention_scores.float()
 
-        # attention_probs = attention_scores.softmax(dim=1).permute(0, 2, 1)
+        # attention_probs = attention_scores.softmax(dim=1).permute(0,2,1)
         attention_probs = torch.nn.functional.softmax(attention_scores, dim=1).permute(
             0, 2, 1
         )  # workaround, to replace after neuronx-cc 2.12 release

--- a/optimum/neuron/utils/optimization_utils.py
+++ b/optimum/neuron/utils/optimization_utils.py
@@ -37,7 +37,7 @@ def get_attention_scores(self, query, key, attn_mask):
         if self.upcast_softmax:
             attention_scores = attention_scores.float()
 
-        # attention_probs = attention_scores.softmax(dim=1).permute(0,2,1)
+        # attention_probs = attention_scores.softmax(dim=1).permute(0, 2, 1)
         attention_probs = torch.nn.functional.softmax(attention_scores, dim=1).permute(
             0, 2, 1
         )  # workaround, to replace after neuronx-cc 2.12 release


### PR DESCRIPTION
* Improve the loading of models
* Fix all weakness reported in #153 
* Improve documentation

------
### Environment
```
aws-neuronx-runtime-discovery 2.9
libneuronxla                  0.5.391
neuronx-cc                    2.8.0.25+a3ad0f342
neuronx-hwm                   2.8.0.3+2b7c6da39
optimum-neuron                0.0.9.dev0
torch                         1.13.1
torch-neuronx                 1.13.1.1.9.0
torch-xla                     1.13.1+torchneuron8
torchvision                   0.14.1
```

```
aws-neuronx-collectives/unknown,now 2.15.13.0-db4e2d9a9 amd64 [installed]
aws-neuronx-dkms/unknown,now 2.11.9.0 amd64 [installed]
aws-neuronx-runtime-lib/unknown,now 2.15.11.0-f168cb23b amd64 [installed]
aws-neuronx-tools/unknown,now 2.12.2.0 amd64 [installed]
```

------
### Reproduction

(Following works on my end)

* Export sd models

```bash
optimum-cli export neuron --model stabilityai/stable-diffusion-2-1-base --task stable-diffusion --batch_size 1 --height 512 --width 512 --dynamic-batch-size sd_neuron_dynamic/
```

* Inference

```python
from optimum.neuron import NeuronStableDiffusionPipeline

model_id = "sd_neuron_dynamic/"
stable_diffusion = NeuronStableDiffusionPipeline.from_pretrained(model_id) 

prompt = "sailing ship in storm by Leonardo da Vinci"
image = stable_diffusion(prompt).images[0]
```

------
### Caveat

* Export of vae encoder is not working any more due to some compilation errors since neuronx-cc 2.8, need to dig further what is going wrong now. But it won't impact the inference so far.
* The optimized attn score compute is not working for neither neuronx-cc 2.7 nor 2.8

Related issue: https://github.com/aws-neuron/aws-neuron-sdk/issues/702