### PR TITLE
Fix unet export when using optimized attn score

### DIFF
--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -210,6 +210,12 @@ You can also accelerate the inference of stable diffusion on neuronx devices (in
 
 The export can be done either with the CLI or with `NeuronStableDiffusionPipeline` API. Here is an example of exporting stable diffusion components with `NeuronStableDiffusionPipeline`:
 
+<Tip>
+
+To apply optimized compute of Unet's attention score, please configure your environment variable with `export NEURON_FUSE_SOFTMAX=1`.
+
+</Tip>
+
 ```python
 >>> from optimum.neuron import NeuronStableDiffusionPipeline
 

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -19,8 +19,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from ...exporters import TasksManager
+from ...utils import is_diffusers_available
 from ..base import BaseOptimumCLICommand, CommandInfo
 
+
+if is_diffusers_available():
+    # Mandatory for applying optimized attention score of Stable Diffusion
+    import os
+
+    os.environ["NEURON_FUSE_SOFTMAX"] = "1"
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction

--- a/optimum/exporters/neuron/utils.py
+++ b/optimum/exporters/neuron/utils.py
@@ -15,6 +15,7 @@
 """Utility functions for neuron export."""
 
 import copy
+import os
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
 import torch
@@ -28,7 +29,6 @@ from ...neuron.utils import (
     DIFFUSION_MODEL_VAE_ENCODER_NAME,
     get_attention_scores,
 )
-from ...neuron.utils.version_utils import get_neuronxcc_version
 from ...utils import (
     DIFFUSERS_MINIMUM_VERSION,
     check_if_diffusers_greater,
@@ -236,11 +236,11 @@ def _get_submodels_for_export_stable_diffusion(
     # https://github.com/huggingface/diffusers/blob/v0.18.2/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py#L571
     pipeline.unet.config.requires_aesthetics_score = getattr(pipeline.config, "requires_aesthetics_score", False)
 
-    compiler_version = get_neuronxcc_version()
-    if version.parse(compiler_version) < version.parse("2.7"):
-        # Replace original cross-attention module with custom cross-attention module for better performance
-        # the optimized function is not working so far for `neuronx-cc >= 2.7`
-        Attention.get_attention_scores = get_attention_scores
+    # Replace original cross-attention module with custom cross-attention module for better performance
+    if not os.environ.get("NEURON_FUSE_SOFTMAX") == "1":
+        os.environ["NEURON_FUSE_SOFTMAX"] = "1"
+
+    Attention.get_attention_scores = get_attention_scores
     models_for_export["unet"] = copy.deepcopy(pipeline.unet)
 
     # VAE Encoder

--- a/optimum/exporters/neuron/utils.py
+++ b/optimum/exporters/neuron/utils.py
@@ -242,9 +242,8 @@ def _get_submodels_for_export_stable_diffusion(
         Attention.get_attention_scores = get_attention_scores
     else:
         logger.warning(
-            "We are not applying optimized attention score computation, which will harm the latency."
-            " If you want better performance, please set the environment variable with `export NEURON_FUSE_SOFTMAX=1`"
-            " and recompile the unet model again."
+            "You are not applying optimized attention score computation. If you want better performance, please"
+            " set the environment variable with `export NEURON_FUSE_SOFTMAX=1` and recompile the unet model."
         )
     models_for_export["unet"] = copy.deepcopy(pipeline.unet)
 


### PR DESCRIPTION
Configure the environment variable `NEURON_FUSE_SOFTMAX` to compile the unet with optimized attention score.

Context here: https://github.com/aws-neuron/aws-neuron-sdk/issues/702#issuecomment-1668024596