### PR TITLE
Enable exporter on non INF instances

### DIFF
--- a/optimum/commands/export/neuron.py
+++ b/optimum/commands/export/neuron.py
@@ -61,7 +61,7 @@ def parse_args_neuron(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--disable-validation",
         action="store_true",
-        help="Whether to disable the validation of inference on neuron device compared to the outputs of original PyTorch model on CPU.",
+        help="Whether to disable the validation of the exported model on neuron device compared to the outputs of original PyTorch model on CPU.",
     )
     optional_group.add_argument(
         "--auto_cast",

--- a/optimum/commands/export/neuron.py
+++ b/optimum/commands/export/neuron.py
@@ -59,9 +59,9 @@ def parse_args_neuron(parser: "ArgumentParser"):
         help="Allow to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository.",
     )
     optional_group.add_argument(
-        "--do-validation",
+        "--disable-validation",
         action="store_true",
-        help="Whether validate the inference on neuron device compared to the outputs of original PyTorch model on CPU.",
+        help="Whether to disable the validation of inference on neuron device compared to the outputs of original PyTorch model on CPU.",
     )
     optional_group.add_argument(
         "--auto_cast",

--- a/optimum/commands/export/neuron.py
+++ b/optimum/commands/export/neuron.py
@@ -59,6 +59,11 @@ def parse_args_neuron(parser: "ArgumentParser"):
         help="Allow to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository.",
     )
     optional_group.add_argument(
+        "--do-validation",
+        action="store_true",
+        help="Whether validate the inference on neuron device compared to the outputs of original PyTorch model on CPU.",
+    )
+    optional_group.add_argument(
         "--auto_cast",
         type=str,
         default=None,

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -66,6 +66,11 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help="Allow to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository.",
     )
     optional_group.add_argument(
+        "--do-validation",
+        action="store_true",
+        help="Whether validate the inference on neuron device compared to the outputs of original PyTorch model on CPU.",
+    )
+    optional_group.add_argument(
         "--auto_cast",
         type=str,
         default=None,

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -66,9 +66,9 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help="Allow to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository.",
     )
     optional_group.add_argument(
-        "--do-validation",
+        "--disable-validation",
         action="store_true",
-        help="Whether validate the inference on neuron device compared to the outputs of original PyTorch model on CPU.",
+        help="Whether to disable the validation of inference on neuron device compared to the outputs of original PyTorch model on CPU.",
     )
     optional_group.add_argument(
         "--auto_cast",

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -292,6 +292,7 @@ def main():
         atol=args.atol,
         cache_dir=args.cache_dir,
         trust_remote_code=args.trust_remote_code,
+        do_validation=args.do_validation,
         **input_shapes,
     )
 

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -292,7 +292,7 @@ def main():
         atol=args.atol,
         cache_dir=args.cache_dir,
         trust_remote_code=args.trust_remote_code,
-        do_validation=args.do_validation,
+        do_validation=not args.disable_validation,
         **input_shapes,
     )
 


### PR DESCRIPTION
Add the possibility to disable the validation in `optimum-cli` for better export experience on CPU only instances.

* Use the flag `--disable-validation` when export with no neuron devices
```
optimum-cli export neuron --model yiyanghkust/finbert-tone --disable-validation --sequence_length 128 --batch_size 1 test_issue/
``` 