### PR TITLE
Fix inferral of dynamic batch size from the config & Be compatible with transformers 4.32

### DIFF
--- a/optimum/neuron/modeling_base.py
+++ b/optimum/neuron/modeling_base.py
@@ -413,7 +413,7 @@ class NeuronBaseModel(OptimizedModel):
 
         return neuron_config_constructor(
             config,
-            dynamic_batch_size=getattr(config, "dynamic_batch_size", False),
+            dynamic_batch_size=neuron_configs.get("dynamic_batch_size", False),
             compiler_type=compiler_type,
             compiler_version=compiler_version,
             **compile_shapes,

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -92,7 +92,7 @@ def load_pipeline(
     input_shapes={},
     export=False,
     subfolder: str = "",
-    use_auth_token: Optional[Union[bool, str]] = None,
+    token: Optional[Union[bool, str]] = None,
     revision: str = "main",
     model_kwargs: Optional[Dict[str, Any]] = None,
     config: AutoConfig = None,
@@ -151,7 +151,7 @@ def pipeline(
     use_fast: bool = True,
     export: bool = False,
     input_shapes: Optional[Dict[str, int]] = None,
-    use_auth_token: Optional[Union[str, bool]] = None,
+    token: Optional[Union[str, bool]] = None,
     revision: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
     *model_kwargs,
@@ -165,7 +165,7 @@ def pipeline(
     # copied from transformers.pipelines.__init__.py
     hub_kwargs = {
         "revision": revision,
-        "use_auth_token": use_auth_token,
+        "token": token,
         "trust_remote_code": trust_remote_code,
         "_commit_hash": None,
     }
@@ -227,6 +227,7 @@ def pipeline(
         supported_tasks=NEURONX_SUPPORTED_TASKS,
         config=config,
         hub_kwargs=hub_kwargs,
+        token=token,
         *model_kwargs,
         **kwargs,
     )
@@ -242,6 +243,5 @@ def pipeline(
         tokenizer=tokenizer,
         feature_extractor=feature_extractor,
         use_fast=use_fast,
-        use_auth_token=use_auth_token,
         **kwargs,
     )

--- a/tests/inference/inference_utils.py
+++ b/tests/inference/inference_utils.py
@@ -98,7 +98,7 @@ class NeuronModelTestMixin(unittest.TestCase):
         """
         model_arch = model_args["model_arch"]
         model_arch_and_params = model_args["test_name"]
-        dynamic_batch_size = getattr(model_args, "dynamic_batch_size", False)
+        dynamic_batch_size = model_args.get("dynamic_batch_size", False)
 
         if model_arch_and_params not in self.neuron_model_dirs:
             # model_args will contain kwargs to pass to NeuronBaseModel.from_pretrained()

--- a/tests/inference/test_modeling.py
+++ b/tests/inference/test_modeling.py
@@ -191,7 +191,7 @@ class NeuronModelForFeatureExtractionIntegrationTest(NeuronModelTestMixin):
         transformers_model = AutoModel.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        text = "This is a sample output"
+        text = ["This is a sample output"] * 2
         tokens = tokenizer(text, return_tensors="pt")
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)
@@ -360,7 +360,7 @@ class NeuronModelForMaskedLMIntegrationTest(NeuronModelTestMixin):
         transformers_model = AutoModelForMaskedLM.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        text = f"The capital of France is {tokenizer.mask_token}."
+        text = [f"The capital of France is {tokenizer.mask_token}."] * 2
         tokens = tokenizer(text, return_tensors="pt")
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)
@@ -530,7 +530,7 @@ class NeuronModelForQuestionAnsweringIntegrationTest(NeuronModelTestMixin):
         transformers_model = AutoModelForQuestionAnswering.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        text = "This is a sample output"
+        text = ["This is a sample output"] * 2
         tokens = tokenizer(text, return_tensors="pt")
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)
@@ -705,7 +705,7 @@ class NeuronModelForSequenceClassificationIntegrationTest(NeuronModelTestMixin):
                 "hf-internal-testing/tiny-random-t5", from_transformers=True, **self.STATIC_INPUTS_SHAPES
             )
 
-        self.assertIn("Unrecognized configuration class", str(context.exception))
+        self.assertIn("is not supported yet", str(context.exception))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     @requires_neuronx
@@ -730,7 +730,7 @@ class NeuronModelForSequenceClassificationIntegrationTest(NeuronModelTestMixin):
         transformers_model = AutoModelForSequenceClassification.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        text = "This is a sample output"
+        text = ["This is a sample output"] * 2
         tokens = tokenizer(text, return_tensors="pt")
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)
@@ -899,7 +899,7 @@ class NeuronModelForTokenClassificationIntegrationTest(NeuronModelTestMixin):
         transformers_model = AutoModelForTokenClassification.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        text = "This is a sample output"
+        text = ["This is a sample output"] * 2
         tokens = tokenizer(text, return_tensors="pt")
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)


### PR DESCRIPTION
Fixes #189 
- [x] Fix dynamic batching inferral error
- [x] Enhance dyn batch test (test with diff batch size)
- [x] Fix failed tests due to the transformers 4.32 release