### PR TITLE
Add mark step after optimizer step

### DIFF
--- a/optimum/neuron/accelerate/optimizer.py
+++ b/optimum/neuron/accelerate/optimizer.py
@@ -76,8 +76,8 @@ class NeuronAcceleratedOptimizer(AcceleratedOptimizer):
                 self.optimizer.step(closure)
             elif self.accelerator_state.distributed_type is DistributedType.TPU:
                 optimizer_args = {"closure": closure} if closure is not None else {}
-                # By default barrier=False, but making sure it's the case here since we xm.mark_step() at the end of the
-                # function call.
+                # By default barrier=False, but making sure it's the case here since we xm.mark_step() at the end of
+                # this method.
                 xm.optimizer_step(self.optimizer, optimizer_args=optimizer_args, barrier=False)
             elif self.accelerator_state.distributed_type is NeuronDistributedType.XLA_FSDP:
                 self.optimizer.step(closure)


### PR DESCRIPTION
There was no XLA barrier call after the optimizer step. This PR fixes that.

It (partially or fully) addresses the third point in #193.

Fixes: #166 