### PR TITLE
`neuron_parallel_compile`, `ParallelLoader` and Zero-1 fixes for torchneuron 8+

### DIFF
--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -27,6 +27,7 @@ import torch
 from accelerate import Accelerator
 from accelerate.checkpointing import save_accelerator_state, save_custom_state
 from accelerate.utils import DistributedType
+from packaging import version
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
@@ -37,6 +38,7 @@ from ..distributed import Parallelizer, ParallelizersManager
 from ..distributed.utils import ZeroRedundancyOptimizerCompatibleWithTensorParallelism
 from ..utils import Patcher, is_neuronx_distributed_available, is_torch_xla_available, patch_within_function
 from ..utils.misc import args_and_kwargs_to_kwargs_only
+from ..utils.version_utils import get_torch_xla_version
 from .optimizer import NeuronAcceleratedOptimizer
 from .scheduler import NeuronAcceleratedScheduler
 from .state import NeuronAcceleratorState
@@ -58,6 +60,7 @@ if TYPE_CHECKING:
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
+    from torch_xla.distributed.parallel_loader import ParallelLoader
 else:
     xm = None
 
@@ -159,10 +162,10 @@ class NeuronAccelerator(Accelerator):
     def prepare_data_loader(self, data_loader: DataLoader, device_placement: Optional[bool] = None):
         if self.state.distributed_type is NeuronDistributedType.TENSOR_PARALLELISM:
             data_loader = self._prepare_data_loader_for_tp(data_loader)
-        else:
-            # TODO: fix that.
-            return data_loader
-        return super().prepare_data_loader(data_loader, device_placement=device_placement)
+        data_loader = ParallelLoader(data_loader, [self.device]).per_device_loader(self.device)
+        return data_loader
+        # TODO: fix that.
+        # return super().prepare_data_loader(data_loader, device_placement=device_placement)
 
     def _prepare_optimizer_for_tp(self, optimizer: torch.optim.Optimizer, device_placement=None):
         cpu_parameters_to_xla = collections.ChainMap(*self._model_cpu_parameters_to_xla.values())
@@ -192,13 +195,44 @@ class NeuronAccelerator(Accelerator):
             params = args[0]
             defaults = args_and_kwargs_to_kwargs_only(optimizer.__class__, args[1:], kwargs)
 
-            zero_1_optimizer = ZeroRedundancyOptimizerCompatibleWithTensorParallelism(
-                params,
-                optimizer.__class__,
-                optimizer_dtype=optimizer_dtype,
-                pin_layout=False,
-                **defaults,
-            )
+            # Prior to 1.13.1+torchneuron8, the vanilla ZeroRedundancyOptimizer was not designed for TP.
+            full_torch_xla_version = get_torch_xla_version()
+            torch_xla_version, torchneuron_version = full_torch_xla_version.split("+")
+            torch_xla_version = version.parse(torch_xla_version)
+            if torch_xla_version <= version.parse("1.13.1") and int(torchneuron_version[-1]) < 8:
+                zero_1_optimizer = ZeroRedundancyOptimizerCompatibleWithTensorParallelism(
+                    params,
+                    optimizer.__class__,
+                    optimizer_dtype=optimizer_dtype,
+                    pin_layout=False,
+                    **defaults,
+                )
+            # Exception to make sure `ZeroRedundancyOptimizerCompatibleWithTensorParallelism` is removed in 3 releases.
+            elif torch_xla_version <= version.parse("1.13.1") and int(torchneuron_version[-1]) >= 11:
+                raise RuntimeError(
+                    "ZeroRedundancyOptimizerCompatibleWithTensorParallelism is deprecated and should be removed from "
+                    "`optimum-neuron`"
+                )
+            else:
+                from neuronx_distributed.parallel_layers.parallel_state import (
+                    get_data_parallel_group,
+                    model_parallel_is_initialized,
+                )
+                from torch_xla.distributed.zero_redundancy_optimizer import ZeroRedundancyOptimizer
+
+                if not is_neuronx_distributed_available() or not model_parallel_is_initialized():
+                    cc_op_groups = None
+                else:
+                    cc_op_groups = get_data_parallel_group(as_list=True)
+
+                zero_1_optimizer = ZeroRedundancyOptimizer(
+                    params,
+                    optimizer.__class__,
+                    optimizer_dtype=optimizer_dtype,
+                    pin_layout=False,
+                    cc_op_groups=cc_op_groups,
+                    **defaults,
+                )
             del optimizer
         else:
             logger.warning(

--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -484,3 +484,7 @@ class NeuronAccelerator(Accelerator):
         elif self.distributed_type is NeuronDistributedType.TENSOR_PARALLELISM:
             return self.save_state_for_tp(output_dir=output_dir, **save_model_func_kwargs)
         return super().save_state(output_dir=output_dir, **save_model_func_kwargs)
+
+    @patch_within_function(("accelerate.utils.operations.xm", xm), ignore_missing_attributes=True)
+    def gather_for_metrics(self, tensor):
+        return super().gather_for_metrics(tensor)

--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
-    from torch_xla.distributed.parallel_loader import ParallelLoader
+    from torch_xla.distributed.parallel_loader import MpDeviceLoader
 else:
     xm = None
 
@@ -162,7 +162,8 @@ class NeuronAccelerator(Accelerator):
     def prepare_data_loader(self, data_loader: DataLoader, device_placement: Optional[bool] = None):
         if self.state.distributed_type is NeuronDistributedType.TENSOR_PARALLELISM:
             data_loader = self._prepare_data_loader_for_tp(data_loader)
-        data_loader = ParallelLoader(data_loader, [self.device]).per_device_loader(self.device)
+        if self.state.num_processes > 1:
+            data_loader = MpDeviceLoader(data_loader, self.device)
         return data_loader
         # TODO: fix that.
         # return super().prepare_data_loader(data_loader, device_placement=device_placement)

--- a/optimum/neuron/accelerate/optimizer.py
+++ b/optimum/neuron/accelerate/optimizer.py
@@ -76,8 +76,7 @@ class NeuronAcceleratedOptimizer(AcceleratedOptimizer):
                 self.optimizer.step(closure)
             elif self.accelerator_state.distributed_type is DistributedType.TPU:
                 optimizer_args = {"closure": closure} if closure is not None else {}
-                # By default barrier=False, but making sure it's the case here since we xm.mark_step() at the end of
-                # this method.
+                # By default barrier=False, but making sure it's the case here since we use ParalleLoader.
                 xm.optimizer_step(self.optimizer, optimizer_args=optimizer_args, barrier=False)
             elif self.accelerator_state.distributed_type is NeuronDistributedType.XLA_FSDP:
                 self.optimizer.step(closure)
@@ -97,7 +96,6 @@ class NeuronAcceleratedOptimizer(AcceleratedOptimizer):
                 self._is_overflow = scale_after < scale_before
             else:
                 self.optimizer.step(closure)
-            xm.mark_step()
 
     def __getstate__(self):
         return {

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import torch
 from transformers import TrainerCallback, TrainerState
 
+from optimum.neuron.utils.training_utils import is_precompilation
+
 from ..utils import logging
 from .utils import is_torch_xla_available
 from .utils.cache_utils import (
@@ -93,7 +95,13 @@ class NeuronCacheCallback(TrainerCallback):
         self.neuron_cache_path.mkdir(parents=True, exist_ok=True)
 
         # Temporary Neuron compile cache.
-        if tmp_neuron_cache is None:
+        if is_precompilation():
+            # When doing precompilation, the graph will be compiled after than the script is done.
+            # By setting `self.tmp_neuron_cache` to `self.neuron_cache_path`, `neuron_parallel_compile` will extract
+            # the very same graphs than the one created during real training, while not doing any synchronization
+            # during training since the compiled files will not be there yet.
+            self.tmp_neuron_cache = self.neuron_cache_path
+        elif tmp_neuron_cache is None:
             self.tmp_neuron_cache = self.create_temporary_neuron_cache(self.neuron_cache_path)
         else:
             self.tmp_neuron_cache = tmp_neuron_cache
@@ -272,7 +280,6 @@ class NeuronCacheCallback(TrainerCallback):
             for path in files:
                 push_to_cache_on_hub(neuron_hash, path, local_path_to_path_in_repo=local_path_to_path_in_repo)
                 if self.use_neuron_cache:
-                    # path_in_cache = self.full_path_to_path_in_temporary_cache(path)
                     path_in_cache = self.full_path_to_path_in_temporary_cache(path)
                     target_file = self.neuron_cache_path / path_in_cache
                     target_file.parent.mkdir(parents=True, exist_ok=True)

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -149,19 +149,18 @@ class AugmentTrainerForNeuronMixin:
         if self.args.local_rank <= 0:
             logger.setLevel(logging.INFO)
 
-        if not is_precompilation():
-            push = self.args.local_rank <= 0
-            fetch = self.args.local_rank <= 0
+        push = self.args.local_rank <= 0
+        fetch = self.args.local_rank <= 0
 
-            callback = NeuronCacheCallback(
-                tmp_neuron_cache=_TMP_NEURON_CACHE_DIR,
-                original_neuron_cache_path=_ORIGINAL_NEURON_CACHE_PATH,
-                fetch=fetch,
-                push=push,
-                wait_for_everyone_on_fetch=False,
-                wait_for_everyone_on_push=True,
-            )
-            self.add_callback(callback)
+        callback = NeuronCacheCallback(
+            tmp_neuron_cache=_TMP_NEURON_CACHE_DIR,
+            original_neuron_cache_path=_ORIGINAL_NEURON_CACHE_PATH,
+            fetch=fetch,
+            push=push,
+            wait_for_everyone_on_fetch=False,
+            wait_for_everyone_on_push=True,
+        )
+        self.add_callback(callback)
 
         # Make the model Neuron-compatible for generation.
         patch_generation_mixin_to_neuron_generation_mixin(self.model)
@@ -177,9 +176,6 @@ class AugmentTrainerForNeuronMixin:
         if args.num_train_epochs != 1:
             logger.info("Setting the number of epochs for precompilation to 1.")
             args.num_train_epochs = 1
-        if args.max_steps is not None:
-            logger.info("Disabling max_steps for precompilation.")
-            args.nax_steps = None
         if args.do_eval is True:
             logger.info("Disabling evaluation during precompilation as this is not well supported yet.")
             args.do_eval = False

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -297,33 +297,6 @@ class AugmentTrainerForNeuronMixin:
             ignore_keys_for_eval=ignore_keys_for_eval,
         )
 
-    # def _nested_gather_for_xla_fsdp(self, tensors, name=None):
-    #     # if isinstance(tensors, (list, tuple)):
-    #     #     return type(tensors)(self._nested_gather_for_xla_fsdp(t, f"{name}_{i}") for i, t in enumerate(tensors))
-    #     # if isinstance(tensors, dict):
-    #     #     return type(tensors)(
-    #     #         {k: self._nested_gather_for_xla_fsdp(t, f"{name}_{i}") for i, (k, t) in enumerate(tensors.items())}
-    #     #     )
-
-    #     # tensors = atleast_1d(tensors)
-    #     # return xm.mesh_reduce(name, tensors, torch.cat)
-    #     if isinstance(tensors, (tuple, list)):
-    #         return type(tensors)(self._nested_gather_for_xla_fsdp(t) for t in tensors)
-    #     elif isinstance(tensors, dict):
-    #         return type(tensors)({k: self._nested_gather_for_xla_fsdp(t) for k, t in tensors.items()})
-    #     tensors = atleast_1d(tensors)
-    #     # result = torch.empty((self.args.world_size,), device=self.args.device, dtype=tensors.dtype)
-    #     # print("tensors", tensors)
-    #     # print("result", result)
-    #     result = xm.all_gather(tensors, dim=0)
-    #     # print("gathered result", result)
-    #     return result
-
-    # def _nested_gather(self, tensors, name=None):
-    #     if self.is_fsdp_enabled:
-    #         return self._nested_gather_for_xla_fsdp(tensors, name="nested_gather_for_xla_fsdp")
-    #     return super()._nested_gather(tensors, name=name)
-
     def _save_checkpoint_with_accelerator(self, model, trial, metrics=None):
         if self.accelerator.distributed_type is NeuronDistributedType.XLA_FSDP and not self.is_fsdp_enabled:
             # TODO: handle this case better?

--- a/optimum/neuron/utils/version_utils.py
+++ b/optimum/neuron/utils/version_utils.py
@@ -22,6 +22,7 @@ from .import_utils import is_neuron_available, is_neuronx_available
 
 _neuronxcc_version: Optional[str] = None
 _neuroncc_version: Optional[str] = None
+_torch_xla_version: Optional[str] = None
 
 
 def get_neuronxcc_version() -> str:
@@ -46,6 +47,18 @@ def get_neuroncc_version() -> str:
         raise ValueError("Neuron Compiler python package is not installed.")
     _neuroncc_version = neuroncc.__version__
     return _neuroncc_version
+
+
+def get_torch_xla_version() -> str:
+    global _torch_xla_version
+    if _torch_xla_version is not None:
+        return _torch_xla_version
+    try:
+        import torch_xla
+    except ImportError:
+        raise ValueError("`torch_xla` python package is not installed.")
+    _torch_xla_version = torch_xla.__version__
+    return _torch_xla_version
 
 
 def check_compiler_compatibility(compiler_type: str, compiler_version: str):


### PR DESCRIPTION
- [x] The cache system in `optimum-neuron` can use pre-compiled files generated by `neuron_parallel_compile`. Fixes #157 
- [x] Use `MpDeviceLoader` instead of regular data-loaders. This will take care of sending the data to the device asynchronously and to call `xm.mark_step()` everytime data is fetched (Fixes #196 )
- [x] Updates the Zero-1 optimizer in conjunction to TP