### PR TITLE
Restrict generation to sampling and greedy search

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -2,7 +2,7 @@ import argparse
 import time
 
 import torch
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, set_seed
 
 from optimum.neuron import NeuronModelForCausalLM
 
@@ -68,7 +68,10 @@ if __name__ == "__main__":
         "--save_dir", type=str, help="The save directory. Allows to avoid recompiling the model every time."
     )
     parser.add_argument("--compare", action="store_true", help="Compare with the genuine transformers model on CPU.")
+    parser.add_argument("--seed", type=int, default=None, help="Pass a seed for reproducibility.")
     args = parser.parse_args()
+    if args.seed:
+        set_seed(args.seed)
     prompts = args.prompts.split("|")
     batch_size = len(prompts)
     model = load_llm_optimum(args.model, batch_size, args.num_cores, args.auto_cast_type)

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -35,7 +35,6 @@ def generate(model, tokenizer, prompts, length, temperature):
         sample_output = model.generate(
             **tokens,
             do_sample=True,
-            min_length=length,
             max_length=length,
             temperature=temperature,
         )

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     parser.add_argument("--compare", action="store_true", help="Compare with the genuine transformers model on CPU.")
     parser.add_argument("--seed", type=int, default=None, help="Pass a seed for reproducibility.")
     args = parser.parse_args()
-    if args.seed:
+    if args.seed is not None:
         set_seed(args.seed)
     prompts = args.prompts.split("|")
     batch_size = len(prompts)

--- a/tests/inference/test_modeling_decoder.py
+++ b/tests/inference/test_modeling_decoder.py
@@ -115,7 +115,14 @@ def _test_model_generation(model, tokenizer, batch_size, input_length, **gen_kwa
 
 
 @pytest.mark.parametrize(
-    "gen_kwargs", [{"do_sample": True}, {"do_sample": True, "temperature": 0.7}], ids=["sample", "sample-with-temp"]
+    "gen_kwargs",
+    [
+        {"do_sample": True},
+        {"do_sample": True, "temperature": 0.7},
+        {"do_sample": False},
+        {"do_sample": False, "repetition_penalty": 1.2},
+    ],
+    ids=["sample", "sample-with-temp", "greedy", "greedy_no-repeat"],
 )
 @is_inferentia_test
 @requires_neuronx


### PR DESCRIPTION
This refactors the `NeuronModelCausalLM` class to override the `generate` method, allowing to restrict the generation to actually supported configurations.
This also introduces a simpler generation loop for sampling and greedy search, preparing  the integration into TGI.