### PR TITLE
Bump Inference APIs to Neuron 2.13

### DIFF
--- a/docs/source/guides/export_model.mdx
+++ b/docs/source/guides/export_model.mdx
@@ -87,10 +87,12 @@ The Optimum Neuron export can be used through Optimum command-line:
 ```bash
 optimum-cli export neuron --help
 
-usage: optimum-cli export neuron [-h] -m MODEL [--task TASK] [--atol ATOL] [--cache_dir CACHE_DIR] [--trust-remote-code] [--disable-validation]
-                                 [--auto_cast {none,matmul,all}] [--auto_cast_type {bf16,fp16,tf32}] [--dynamic-batch-size]
-                                 [--batch_size BATCH_SIZE] [--sequence_length SEQUENCE_LENGTH] [--num_choices NUM_CHOICES]
-                                 [--num_channels NUM_CHANNELS] [--width WIDTH] [--height HEIGHT] [--num_image_per_prompt NUM_IMAGE_PER_PROMPT]
+usage: optimum-cli export neuron [-h] -m MODEL [--task TASK] [--atol ATOL] [--cache_dir CACHE_DIR]
+                                 [--trust-remote-code] [--disable-validation] [--auto_cast {none,matmul,all}]
+                                 [--auto_cast_type {bf16,fp16,tf32}] [--dynamic-batch-size]
+                                 [--batch_size BATCH_SIZE] [--sequence_length SEQUENCE_LENGTH]
+                                 [--num_choices NUM_CHOICES] [--num_channels NUM_CHANNELS] [--width WIDTH]
+                                 [--height HEIGHT] [--num_images_per_prompt NUM_IMAGES_PER_PROMPT]
                                  output
 
 optional arguments:
@@ -102,29 +104,32 @@ Required arguments:
   output                Path indicating the directory where to store generated Neuronx compiled TorchScript model.
 
 Optional arguments:
-  --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on the model. Available tasks
-                        depend on the model, but are among: ['conversational', 'feature-extraction', 'fill-mask', 'text-generation',
-                        'text2text-generation', 'text-classification', 'token-classification', 'multiple-choice', 'object-detection',
-                        'question-answering', 'image-classification', 'image-segmentation', 'mask-generation', 'masked-im', 'semantic-
-                        segmentation', 'automatic-speech-recognition', 'audio-classification', 'audio-frame-classification', 'audio-xvector',
-                        'image-to-text', 'stable-diffusion', 'stable-diffusion-xl', 'zero-shot-image-classification', 'zero-shot-object-
-                        detection'].
-  --atol ATOL           If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol for the model
-                        will be used.
+  --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on
+                        the model. Available tasks depend on the model, but are among: ['conversational', 'feature-
+                        extraction', 'fill-mask', 'text-generation', 'text2text-generation', 'text-classification',
+                        'token-classification', 'multiple-choice', 'object-detection', 'question-answering',
+                        'image-classification', 'image-segmentation', 'mask-generation', 'masked-im', 'semantic-
+                        segmentation', 'automatic-speech-recognition', 'audio-classification', 'audio-frame-
+                        classification', 'audio-xvector', 'image-to-text', 'stable-diffusion', 'stable-diffusion-
+                        xl', 'zero-shot-image-classification', 'zero-shot-object-detection'].
+  --atol ATOL           If specified, the absolute difference tolerance when validating the model. Otherwise, the
+                        default atol for the model will be used.
   --cache_dir CACHE_DIR
                         Path indicating where to store cache.
-  --trust-remote-code   Allow to use custom code for the modeling hosted in the model repository. This option should only be set for
-                        repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code
-                        present in the model repository.
-  --disable-validation  Whether to disable the validation of inference on neuron device compared to the outputs of original PyTorch model on
-                        CPU.
+  --trust-remote-code   Allow to use custom code for the modeling hosted in the model repository. This option
+                        should only be set for repositories you trust and in which you have read the code, as it
+                        will execute on your local machine arbitrary code present in the model repository.
+  --disable-validation  Whether to disable the validation of inference on neuron device compared to the outputs of
+                        original PyTorch model on CPU.
   --auto_cast {none,matmul,all}
-                        Whether to cast operations from FP32 to lower precision to speed up the inference. Can be `"none"`, `"matmul"` or
-                        `"all"`.
+                        Whether to cast operations from FP32 to lower precision to speed up the inference. Can be
+                        `"none"`, `"matmul"` or `"all"`.
   --auto_cast_type {bf16,fp16,tf32}
-                        The data type to cast FP32 operations to when auto-cast mode is enabled. Can be `"bf16"`, `"fp16"` or `"tf32"`.
-  --dynamic-batch-size  Enable dynamic batch size for neuron compiled model. If this option is enabled, the input batch size can be a multiple
-                        of the batch size during the compilation, but it comes with a potential tradeoff in terms of latency.
+                        The data type to cast FP32 operations to when auto-cast mode is enabled. Can be `"bf16"`,
+                        `"fp16"` or `"tf32"`.
+  --dynamic-batch-size  Enable dynamic batch size for neuron compiled model. If this option is enabled, the input
+                        batch size can be a multiple of the batch size during the compilation, but it comes with a
+                        potential tradeoff in terms of latency.
 
 Input shapes:
   --batch_size BATCH_SIZE
@@ -132,15 +137,18 @@ Input shapes:
   --sequence_length SEQUENCE_LENGTH
                         Sequence length that the Neuronx-cc compiler exported model will be able to take as input.
   --num_choices NUM_CHOICES
-                        Only for the multiple-choice task. Num choices that the Neuronx-cc compiler exported model will be able to take as
-                        input.
+                        Only for the multiple-choice task. Num choices that the Neuronx-cc compiler exported model
+                        will be able to take as input.
   --num_channels NUM_CHANNELS
-                        Image tasks only. Number of channels that the Neuronx-cc compiler exported model will be able to take as input.
-  --width WIDTH         Image tasks only. Width that the Neuronx-cc compiler exported model will be able to take as input.
-  --height HEIGHT       Image tasks only. Height that the Neuronx-cc compiler exported model will be able to take as input.
-  --num_image_per_prompt NUM_IMAGE_PER_PROMPT
-                        Stable diffusion only. Number of image per prompt that the Neuronx-cc compiler exported model will be able to take as
+                        Image tasks only. Number of channels that the Neuronx-cc compiler exported model will be
+                        able to take as input.
+  --width WIDTH         Image tasks only. Width that the Neuronx-cc compiler exported model will be able to take as
                         input.
+  --height HEIGHT       Image tasks only. Height that the Neuronx-cc compiler exported model will be able to take
+                        as input.
+  --num_images_per_prompt NUM_IMAGES_PER_PROMPT
+                        Stable diffusion only. Number of images per prompt that the Neuronx-cc compiler exported
+                        model will be able to take as input.
 
 ```
 

--- a/docs/source/guides/export_model.mdx
+++ b/docs/source/guides/export_model.mdx
@@ -87,10 +87,10 @@ The Optimum Neuron export can be used through Optimum command-line:
 ```bash
 optimum-cli export neuron --help
 
-usage: optimum-cli export neuron [-h] -m MODEL [--task TASK] [--atol ATOL] [--cache_dir CACHE_DIR] [--trust-remote-code]
-                                 [--auto_cast {none,matmul,all}] [--auto_cast_type {bf16,fp16,mixed,tf32}]
-                                 [--disable-fast-relayout] [--disable-fallback] [--dynamic-batch-size] [--batch_size BATCH_SIZE]
-                                 [--sequence_length SEQUENCE_LENGTH] [--num_choices NUM_CHOICES]
+usage: optimum-cli export neuron [-h] -m MODEL [--task TASK] [--atol ATOL] [--cache_dir CACHE_DIR] [--trust-remote-code] [--disable-validation]
+                                 [--auto_cast {none,matmul,all}] [--auto_cast_type {bf16,fp16,tf32}] [--dynamic-batch-size]
+                                 [--batch_size BATCH_SIZE] [--sequence_length SEQUENCE_LENGTH] [--num_choices NUM_CHOICES]
+                                 [--num_channels NUM_CHANNELS] [--width WIDTH] [--height HEIGHT] [--num_image_per_prompt NUM_IMAGE_PER_PROMPT]
                                  output
 
 optional arguments:
@@ -99,45 +99,48 @@ optional arguments:
 Required arguments:
   -m MODEL, --model MODEL
                         Model ID on huggingface.co or path on disk to load model from.
-  output                Path indicating the directory where to store generated Neuron compiled TorchScript model.
+  output                Path indicating the directory where to store generated Neuronx compiled TorchScript model.
 
 Optional arguments:
-  --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on the model.
-                        Available tasks depend on the model, but are among: ['conversational', 'feature-extraction', 'fill-
-                        mask', 'text-generation', 'text2text-generation', 'text-classification', 'token-classification',
-                        'multiple-choice', 'object-detection', 'question-answering', 'image-classification', 'image-
-                        segmentation', 'masked-im', 'semantic-segmentation', 'automatic-speech-recognition', 'audio-
-                        classification', 'audio-frame-classification', 'audio-xvector', 'image-to-text', 'stable-diffusion',
-                        'zero-shot-image-classification', 'zero-shot-object-detection'].
-  --atol ATOL           If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol
-                        for the model will be used.
+  --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on the model. Available tasks
+                        depend on the model, but are among: ['conversational', 'feature-extraction', 'fill-mask', 'text-generation',
+                        'text2text-generation', 'text-classification', 'token-classification', 'multiple-choice', 'object-detection',
+                        'question-answering', 'image-classification', 'image-segmentation', 'mask-generation', 'masked-im', 'semantic-
+                        segmentation', 'automatic-speech-recognition', 'audio-classification', 'audio-frame-classification', 'audio-xvector',
+                        'image-to-text', 'stable-diffusion', 'stable-diffusion-xl', 'zero-shot-image-classification', 'zero-shot-object-
+                        detection'].
+  --atol ATOL           If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol for the model
+                        will be used.
   --cache_dir CACHE_DIR
                         Path indicating where to store cache.
-  --trust-remote-code   Allow to use custom code for the modeling hosted in the model repository. This option should only be set
-                        for repositories you trust and in which you have read the code, as it will execute on your local machine
-                        arbitrary code present in the model repository.
+  --trust-remote-code   Allow to use custom code for the modeling hosted in the model repository. This option should only be set for
+                        repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code
+                        present in the model repository.
+  --disable-validation  Whether to disable the validation of inference on neuron device compared to the outputs of original PyTorch model on
+                        CPU.
   --auto_cast {none,matmul,all}
-                        Whether to cast operations from FP32 to lower precision to speed up the inference. Can be `"none"`,
-                        `"matmul"` or `"all"`.
-  --auto_cast_type {bf16,fp16,mixed,tf32}
-                        The data type to cast FP32 operations to when auto-cast mode is enabled. Can be `"bf16"`, `"fp16"`,
-                        `"mixed"` or `"tf32"`.
-  --disable-fast-relayout
-                        Whether to disable fast relayout optimization which improves performance by using the matrix multiplier
-                        for tensor transpose. (inf1 only)
-  --disable-fallback    Whether to disable CPU partitioning to force operations to Neuron. Defaults to `False`, as without
-                        fallback, there could be some compilation failures or performance problems. (inf1 only)
-  --dynamic-batch-size  Enable dynamic batch size for neuron compiled model. If this option is enabled, the input batch size can
-                        be dynamic during the inference, but it comes with a potential tradeoff in terms of latency.
+                        Whether to cast operations from FP32 to lower precision to speed up the inference. Can be `"none"`, `"matmul"` or
+                        `"all"`.
+  --auto_cast_type {bf16,fp16,tf32}
+                        The data type to cast FP32 operations to when auto-cast mode is enabled. Can be `"bf16"`, `"fp16"` or `"tf32"`.
+  --dynamic-batch-size  Enable dynamic batch size for neuron compiled model. If this option is enabled, the input batch size can be a multiple
+                        of the batch size during the compilation, but it comes with a potential tradeoff in terms of latency.
 
 Input shapes:
   --batch_size BATCH_SIZE
-                        Batch size that the Neuron-cc compiler exported model will be able to take as input.
+                        Batch size that the Neuronx-cc compiler exported model will be able to take as input.
   --sequence_length SEQUENCE_LENGTH
-                        Sequence length that the Neuron-cc compiler exported model will be able to take as input.
+                        Sequence length that the Neuronx-cc compiler exported model will be able to take as input.
   --num_choices NUM_CHOICES
-                        Only for the multiple-choice task. Num choices that the Neuron-cc compiler exported model will be able
-                        to take as input.
+                        Only for the multiple-choice task. Num choices that the Neuronx-cc compiler exported model will be able to take as
+                        input.
+  --num_channels NUM_CHANNELS
+                        Image tasks only. Number of channels that the Neuronx-cc compiler exported model will be able to take as input.
+  --width WIDTH         Image tasks only. Width that the Neuronx-cc compiler exported model will be able to take as input.
+  --height HEIGHT       Image tasks only. Height that the Neuronx-cc compiler exported model will be able to take as input.
+  --num_image_per_prompt NUM_IMAGE_PER_PROMPT
+                        Stable diffusion only. Number of image per prompt that the Neuronx-cc compiler exported model will be able to take as
+                        input.
 
 ```
 
@@ -216,6 +219,8 @@ So far, we support the export of following components in the pipeline:
 
 "These blocks are chosen because they represent the bulk of the compute in the pipeline, and performance benchmarking has shown that running them on Neuron yields significant performance benefit."
 
+Besides, don't hesitate to tweak the compilation configuration to find the best tradeoff between performance v.s accuracy in your use case. By default, we suggest casting FP32 matrix multiplication operations to BF16 which offers good performance with moderate sacrifice of the accuracy. Check out the guide from [AWS Neuron documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/appnotes/neuronx-cc/neuronx-cc-training-mixed-precision.html#neuronx-cc-training-mixed-precision) to better understand the options for your compilation.
+
 </Tip>
 
 Exporting a stable diffusion checkpoint can be done using the CLI:
@@ -226,6 +231,7 @@ optimum-cli export neuron --model stabilityai/stable-diffusion-2-1-base \
   --batch_size 1 \
   --height 512 `# height in pixels of generated image, eg. 512, 768` \
   --width 512 `# width in pixels of generated image, eg. 512, 768` \
+  --num_image_per_prompt 4 `# number of images to generate per prompt, defaults to 1` \
   --auto_cast matmul `# cast only matrix multiplication operations` \
   --auto_cast_type bf16 `# cast operations from FP32 to BF16` \
   sd_neuron/

--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -201,10 +201,10 @@ with torch.inference_mode():
 Optimum extends 🤗`Diffusers` to support inference on Neuron. To get started, make sure you have installed Diffusers:
 
 ```bash
-pip install diffusers>=0.17.0
+pip install diffusers>=0.20.0
 ```
 
-You can also accelerate the inference of stable diffusion on neuronx devices (inf / trn1). There are three components which need to be exported to the `.neuron` format to boost the performance:
+You can also accelerate the inference of stable diffusion on neuronx devices (inf2 / trn1). There are four components which need to be exported to the `.neuron` format to boost the performance:
 
 * Text encoder
 * U-Net
@@ -215,7 +215,7 @@ The export can be done either with the CLI or with `NeuronStableDiffusionPipelin
 
 <Tip>
 
-To apply optimized compute of Unet's attention score, please configure your environment variable with `export NEURON_FUSE_SOFTMAX=1`.
+To apply optimized compute of Unet's attention score, please configure your environment variable with `export NEURON_FUSE_SOFTMAX=1`. Besides, don't hesitate to tweak the compilation configuration to find the best tradeoff of performance v.s accuracy in your use case. By default, we suggest casting FP32 matrix multiplication operations to BF16. Check out the guide from [AWS Neuron documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/appnotes/neuronx-cc/neuronx-cc-training-mixed-precision.html#neuronx-cc-training-mixed-precision) to better understand the options for your compilation.
 
 </Tip>
 

--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -215,7 +215,9 @@ The export can be done either with the CLI or with `NeuronStableDiffusionPipelin
 
 <Tip>
 
-To apply optimized compute of Unet's attention score, please configure your environment variable with `export NEURON_FUSE_SOFTMAX=1`. Besides, don't hesitate to tweak the compilation configuration to find the best tradeoff of performance v.s accuracy in your use case. By default, we suggest casting FP32 matrix multiplication operations to BF16. Check out the guide from [AWS Neuron documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/appnotes/neuronx-cc/neuronx-cc-training-mixed-precision.html#neuronx-cc-training-mixed-precision) to better understand the options for your compilation.
+To apply optimized compute of Unet's attention score, please configure your environment variable with `export NEURON_FUSE_SOFTMAX=1`. 
+
+Besides, don't hesitate to tweak the compilation configuration to find the best tradeoff between performance v.s accuracy in your use case. By default, we suggest casting FP32 matrix multiplication operations to BF16 which offers good performance with moderate sacrifice of the accuracy. Check out the guide from [AWS Neuron documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/appnotes/neuronx-cc/neuronx-cc-training-mixed-precision.html#neuronx-cc-training-mixed-precision) to better understand the options for your compilation.
 
 </Tip>
 

--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -201,7 +201,7 @@ with torch.inference_mode():
 Optimum extends 🤗`Diffusers` to support inference on Neuron. To get started, make sure you have installed Diffusers:
 
 ```bash
-pip install diffusers>=0.20.0
+pip install optimum-neuron[diffusers]
 ```
 
 You can also accelerate the inference of stable diffusion on neuronx devices (inf2 / trn1). There are four components which need to be exported to the `.neuron` format to boost the performance:

--- a/docs/source/guides/models.mdx
+++ b/docs/source/guides/models.mdx
@@ -201,7 +201,7 @@ with torch.inference_mode():
 Optimum extends 🤗`Diffusers` to support inference on Neuron. To get started, make sure you have installed Diffusers:
 
 ```bash
-pip install optimum-neuron[diffusers]
+pip install "optimum[neuronx, diffusers]"
 ```
 
 You can also accelerate the inference of stable diffusion on neuronx devices (inf2 / trn1). There are four components which need to be exported to the `.neuron` format to boost the performance:

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -123,7 +123,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help=f"Image tasks only. Height {doc_input}",
     )
     input_group.add_argument(
-        "--num_image_per_prompt",
+        "--num_images_per_prompt",
         type=int,
         default=1,
         help=f"Stable diffusion only. Number of image per prompt {doc_input}",

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -126,7 +126,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         "--num_images_per_prompt",
         type=int,
         default=1,
-        help=f"Stable diffusion only. Number of image per prompt {doc_input}",
+        help=f"Stable diffusion only. Number of images per prompt {doc_input}",
     )
 
 

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -124,8 +124,8 @@ def normalize_stable_diffusion_input_shapes(
             f"Shape of {mandatory_axes} are mandatory for neuron compilation, while {mandatory_axes.difference(args.keys())} are not given."
         )
     mandatory_shapes = {name: args[name] for name in mandatory_axes}
-    if "num_image_per_prompt" in args and args["num_image_per_prompt"] > 1:
-        batch_size = args["num_image_per_prompt"] * args["batch_size"]
+    if "num_images_per_prompt" in args and args["num_images_per_prompt"] > 1:
+        batch_size = args["num_images_per_prompt"] * args["batch_size"]
         mandatory_shapes["batch_size"] = batch_size
     input_shapes = build_stable_diffusion_components_mandatory_shapes(**mandatory_shapes)
     return input_shapes

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -71,8 +71,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self,
         text_encoder: torch.jit._script.ScriptModule,
         unet: torch.jit._script.ScriptModule,
-        # TODO: Fix vae encoder export
-        # vae_encoder: torch.jit._script.ScriptModule,
+        vae_encoder: torch.jit._script.ScriptModule,
         vae_decoder: torch.jit._script.ScriptModule,
         config: Dict[str, Any],
         tokenizer: CLIPTokenizer,
@@ -133,13 +132,12 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         self.unet = NeuronModelUnet(
             unet, self, self.configs[DIFFUSION_MODEL_UNET_NAME], self.neuron_configs[DIFFUSION_MODEL_UNET_NAME]
         )
-        # TODO: Fix vae encoder export
-        # self.vae_encoder = NeuronModelVaeEncoder(
-        #     vae_encoder,
-        #     self,
-        #     self.configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
-        #     self.neuron_configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
-        # )
+        self.vae_encoder = NeuronModelVaeEncoder(
+            vae_encoder,
+            self,
+            self.configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
+            self.neuron_configs[DIFFUSION_MODEL_VAE_ENCODER_NAME],
+        )
         self.vae_decoder = NeuronModelVaeDecoder(
             vae_decoder,
             self,
@@ -154,7 +152,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         sub_models = {
             DIFFUSION_MODEL_TEXT_ENCODER_NAME: self.text_encoder,
             DIFFUSION_MODEL_UNET_NAME: self.unet,
-            # DIFFUSION_MODEL_VAE_ENCODER_NAME: self.vae_encoder,
+            DIFFUSION_MODEL_VAE_ENCODER_NAME: self.vae_encoder,
             DIFFUSION_MODEL_VAE_DECODER_NAME: self.vae_decoder,
         }
         for name in sub_models.keys():
@@ -291,11 +289,10 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / unet_file_name,
                 new_model_save_dir / DIFFUSION_MODEL_UNET_NAME / cls.sub_component_config_name,
             ),
-            # TODO: Fix vae encoder export
-            # "vae_encoder": (
-            #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / vae_encoder_file_name,
-            #     new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / cls.sub_component_config_name,
-            # ),
+            "vae_encoder": (
+                new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / vae_encoder_file_name,
+                new_model_save_dir / DIFFUSION_MODEL_VAE_ENCODER_NAME / cls.sub_component_config_name,
+            ),
             "vae_decoder": (
                 new_model_save_dir / DIFFUSION_MODEL_VAE_DECODER_NAME / vae_decoder_file_name,
                 new_model_save_dir / DIFFUSION_MODEL_VAE_DECODER_NAME / cls.sub_component_config_name,
@@ -321,8 +318,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
             )
         else:
             unet = cls.load_model(model_and_config_save_paths["unet"][0])
-        # TODO: Fix vae encoder export
-        # vae_encoder = cls.load_model(model_and_config_save_paths["vae_encoder"][0])
+        vae_encoder = cls.load_model(model_and_config_save_paths["vae_encoder"][0])
         vae_decoder = cls.load_model(model_and_config_save_paths["vae_decoder"][0])
 
         if model_save_dir is None:
@@ -331,8 +327,7 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         return cls(
             text_encoder=text_encoder,
             unet=unet,
-            # TODO: Fix vae encoder export
-            # vae_encoder=vae_encoder,
+            vae_encoder=vae_encoder,
             vae_decoder=vae_decoder,
             config=config,
             tokenizer=sub_models["tokenizer"],

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
@@ -154,14 +154,14 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         latents = latents * self.scheduler.init_noise_sigma
         return latents
 
-    def check_num_image_per_prompt(self, prompt_batch_size: int, neuron_batch_size: int, num_images_per_prompt: int):
+    def check_num_images_per_prompt(self, prompt_batch_size: int, neuron_batch_size: int, num_images_per_prompt: int):
         if self.dynamic_batch_size:
             return prompt_batch_size, num_images_per_prompt
         if neuron_batch_size != prompt_batch_size * num_images_per_prompt:
             raise ValueError(
                 f"Models in the pipeline were compiled with `batch_size` {neuron_batch_size} which does not equal the number of"
-                f" prompt({prompt_batch_size}) multiplied by `num_image_per_prompt`({num_images_per_prompt}). You need to enable"
-                " `dynamic_batch_size` or precisely configure `num_image_per_prompt` during the compilation."
+                f" prompt({prompt_batch_size}) multiplied by `num_images_per_prompt`({num_images_per_prompt}). You need to enable"
+                " `dynamic_batch_size` or precisely configure `num_images_per_prompt` during the compilation."
             )
         else:
             return prompt_batch_size, num_images_per_prompt
@@ -203,7 +203,7 @@ class StableDiffusionPipelineMixin(StableDiffusionPipeline):
         else:
             prompt_batch_size = prompt_embeds.shape[0]
         neuron_batch_size = self.unet.config.neuron["static_batch_size"]
-        batch_size, num_images_per_prompt = self.check_num_image_per_prompt(
+        batch_size, num_images_per_prompt = self.check_num_images_per_prompt(
             prompt_batch_size, neuron_batch_size, num_images_per_prompt
         )
 

--- a/optimum/neuron/utils/optimization_utils.py
+++ b/optimum/neuron/utils/optimization_utils.py
@@ -37,10 +37,7 @@ def get_attention_scores(self, query, key, attn_mask):
         if self.upcast_softmax:
             attention_scores = attention_scores.float()
 
-        # attention_probs = attention_scores.softmax(dim=1).permute(0, 2, 1)
-        attention_probs = torch.nn.functional.softmax(attention_scores, dim=1).permute(
-            0, 2, 1
-        )  # workaround, to replace after neuronx-cc 2.12 release
+        attention_probs = attention_scores.softmax(dim=1).permute(0, 2, 1)
         attention_probs = attention_probs.to(dtype)
 
     else:
@@ -49,10 +46,7 @@ def get_attention_scores(self, query, key, attn_mask):
         if self.upcast_softmax:
             attention_scores = attention_scores.float()
 
-        # attention_probs = attention_scores.softmax(dim=-1)
-        attention_probs = torch.nn.functional.softmax(
-            attention_scores, dim=-1
-        )  # workaround, to replace after neuronx-cc 2.12 release
+        attention_probs = attention_scores.softmax(dim=-1)
         attention_probs = attention_probs.to(dtype)
 
     return attention_probs

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ TESTS_REQUIRE = [
     "sentencepiece",
     "datasets",
     "sacremoses",
-    "diffusers>=0.17.0",
+    "diffusers >= 0.20.0",
     "safetensors",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers >= 4.28.0",
+    "transformers >= 4.32.1",
     "accelerate >= 0.20.1",
-    "optimum >= 1.8.8",
+    "optimum >= 1.12.0",
     "huggingface_hub >= 0.14.0",
     "numpy>=1.18.5, <=1.21.6",
     "protobuf<4",

--- a/tests/cli/test_export_cli.py
+++ b/tests/cli/test_export_cli.py
@@ -175,7 +175,7 @@ class TestExportCLI(unittest.TestCase):
                     "64",
                     "--width",
                     "64",
-                    "--num_image_per_prompt",
+                    "--num_images_per_prompt",
                     "4",
                     tempdir,
                 ],

--- a/tests/inference/test_stable_diffusion_pipeline.py
+++ b/tests/inference/test_stable_diffusion_pipeline.py
@@ -50,9 +50,9 @@ class NeuronModelForMultipleChoiceIntegrationTest(unittest.TestCase):
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     def test_export_and_inference_non_dyn(self, model_arch):
-        num_image_per_prompt = 4
+        num_images_per_prompt = 4
         input_shapes = copy.deepcopy(self.STATIC_INPUTS_SHAPES)
-        input_shapes.update({"num_image_per_prompt": num_image_per_prompt})
+        input_shapes.update({"num_images_per_prompt": num_images_per_prompt})
         neuron_pipeline = self.NEURON_MODEL_CLASS.from_pretrained(
             MODEL_NAMES[model_arch],
             export=True,
@@ -71,7 +71,7 @@ class NeuronModelForMultipleChoiceIntegrationTest(unittest.TestCase):
             image = neuron_pipeline(prompt).images[0]
         self.assertIn("pipeline were compiled with", str(context.exception))
 
-        prompts = ["sailing ship in storm by Leonardo da Vinci"] * num_image_per_prompt
+        prompts = ["sailing ship in storm by Leonardo da Vinci"] * num_images_per_prompt
         image = neuron_pipeline(prompts).images[0]
         self.assertIsInstance(image, PIL.Image.Image)
 
@@ -87,5 +87,5 @@ class NeuronModelForMultipleChoiceIntegrationTest(unittest.TestCase):
         )
 
         prompts = ["sailing ship in storm by Leonardo da Vinci"] * 2
-        image = neuron_pipeline(prompts).images[0]
+        image = neuron_pipeline(prompts, num_images_per_prompt=2).images[0]
         self.assertIsInstance(image, PIL.Image.Image)

--- a/tests/inference/test_stable_diffusion_pipeline.py
+++ b/tests/inference/test_stable_diffusion_pipeline.py
@@ -63,8 +63,7 @@ class NeuronModelForMultipleChoiceIntegrationTest(unittest.TestCase):
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.unet, NeuronModelUnet)
-        # #TODO: activate the checker once the encoder export fixed (2.13 release)
-        # self.assertIsInstance(neuron_pipeline.vae_encoder, NeuronModelVaeEncoder)
+        self.assertIsInstance(neuron_pipeline.vae_encoder, NeuronModelVaeEncoder)
         self.assertIsInstance(neuron_pipeline.vae_decoder, NeuronModelVaeDecoder)
 
         prompt = "sailing ship in storm by Leonardo da Vinci"

--- a/tests/inference/test_stable_diffusion_pipeline.py
+++ b/tests/inference/test_stable_diffusion_pipeline.py
@@ -76,7 +76,6 @@ class NeuronModelForMultipleChoiceIntegrationTest(unittest.TestCase):
         self.assertIsInstance(image, PIL.Image.Image)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
-    @unittest.skip("The dynamic batching is not well supported for stable diffusion for now.")
     def test_export_and_inference_dyn(self, model_arch):
         neuron_pipeline = self.NEURON_MODEL_CLASS.from_pretrained(
             MODEL_NAMES[model_arch],


### PR DESCRIPTION
- [x] Unblock VAE encoder
- [x] Remove optimized cross-attention score workaround
- [x] Unblock dynamic batching test
- [x] Update documentation