### PR TITLE
flan-t5 fix: `T5Parallelizer`, `NeuronCacheCallback` and `NeuronHash` refactors

### DIFF
--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -310,7 +310,7 @@ class ParallelSelfAttention(ParallelLayer):
         setattr(
             layer,
             num_attention_heads_name,
-            normalized_config.num_attention_heads // parallel_state.get_tensor_model_parallel_size(),
+            getattr(layer, num_attention_heads_name) // parallel_state.get_tensor_model_parallel_size(),
         )
         setattr(
             layer,

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -223,7 +223,7 @@ class NeuronCacheCallback(TrainerCallback):
 
         key_args = (model, input_shapes, data_type)
         key_kwargs = {"tensor_parallel_size": args.tensor_parallel_size}
-        key = (id(model),) + key_args[1:] + tuple(key_kwargs.values())
+        key = key_args + tuple(key_kwargs.values())
         neuron_hash = self.neuron_hashes.get(key, None)
         if neuron_hash is None:
             neuron_hash = NeuronHash(*key_args, **key_kwargs)

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -91,9 +91,6 @@ _TMP_NEURON_CACHE_PATH: Optional[Path] = None
 _TCP_STORE_ADDRESS = "127.0.0.1"
 _TCP_STORE_PORT = 5000
 
-# TODO: remove that.
-os.environ["NEURON_CC_FLAGS"] = "--log_level=INFO"
-
 
 MODEL_PATCHING_SPECS = [
     ("config.layerdrop", 0),

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -51,7 +51,7 @@ from .utils import (
     is_torch_xla_available,
     patch_within_function,
 )
-from .utils.cache_utils import get_neuron_cache_path
+from .utils.cache_utils import NEURON_COMPILE_CACHE_NAME, get_neuron_cache_path, set_neuron_cache_path
 from .utils.training_utils import (
     TRANSFORMERS_MIN_VERSION_USE_ACCELERATE,
     get_model_param_count,
@@ -87,6 +87,12 @@ if KEEP_HF_HUB_PROGRESS_BARS is None:
 # Used for torch.distributed.
 _ORIGINAL_NEURON_CACHE_PATH: Optional[Path] = None
 _TMP_NEURON_CACHE_DIR: Optional[TemporaryDirectory] = None
+_TMP_NEURON_CACHE_PATH: Optional[Path] = None
+_TCP_STORE_ADDRESS = "127.0.0.1"
+_TCP_STORE_PORT = 5000
+
+# TODO: remove that.
+os.environ["NEURON_CC_FLAGS"] = "--log_level=INFO"
 
 
 MODEL_PATCHING_SPECS = [
@@ -104,8 +110,18 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
 
     if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):
         _ORIGINAL_NEURON_CACHE_PATH = get_neuron_cache_path()
+
         if not is_precompilation():
-            _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
+            if os.environ["RANK"] == "0":
+                _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
+                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=True)
+                store.set("tmp_neuron_cache_path", _TMP_NEURON_CACHE_DIR.name)
+                _TMP_NEURON_CACHE_PATH = Path(_TMP_NEURON_CACHE_DIR.name)
+            else:
+                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=False)
+                _TMP_NEURON_CACHE_PATH = Path(store.get("tmp_neuron_cache_path").decode("utf-8"))
+            set_neuron_cache_path(_TMP_NEURON_CACHE_PATH / NEURON_COMPILE_CACHE_NAME)
+
         torch.distributed.init_process_group(backend="xla")
         if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):
             raise AssertionError("Failed to initialize torch.distributed process group using XLA backend.")
@@ -150,10 +166,10 @@ class AugmentTrainerForNeuronMixin:
             logger.setLevel(logging.INFO)
 
         push = self.args.local_rank <= 0
-        fetch = self.args.local_rank <= 0
+        fetch = self.args.local_rank <= 0 or self.args.tp_plugin.should_parallelize
 
         callback = NeuronCacheCallback(
-            tmp_neuron_cache=_TMP_NEURON_CACHE_DIR,
+            tmp_neuron_cache=_TMP_NEURON_CACHE_PATH,
             original_neuron_cache_path=_ORIGINAL_NEURON_CACHE_PATH,
             fetch=fetch,
             push=push,

--- a/optimum/neuron/training_args.py
+++ b/optimum/neuron/training_args.py
@@ -205,6 +205,34 @@ class NeuronTrainingArgumentsMixin:
             divisor = self.tp_plugin.tensor_parallel_size
         return super().world_size // divisor
 
+    @property
+    def train_batch_size(self) -> int:
+        """
+        The actual batch size for training (may differ from `per_gpu_train_batch_size` in distributed training).
+        """
+        if self.per_gpu_train_batch_size:
+            logger.warning(
+                "Using deprecated `--per_gpu_train_batch_size` argument which will be removed in a future "
+                "version. Using `--per_device_train_batch_size` is preferred."
+            )
+        per_device_batch_size = self.per_gpu_train_batch_size or self.per_device_train_batch_size
+        train_batch_size = per_device_batch_size * 1
+        return train_batch_size
+
+    @property
+    def eval_batch_size(self) -> int:
+        """
+        The actual batch size for evaluation (may differ from `per_gpu_eval_batch_size` in distributed training).
+        """
+        if self.per_gpu_eval_batch_size:
+            logger.warning(
+                "Using deprecated `--per_gpu_eval_batch_size` argument which will be removed in a future "
+                "version. Using `--per_device_eval_batch_size` is preferred."
+            )
+        per_device_batch_size = self.per_gpu_eval_batch_size or self.per_device_eval_batch_size
+        eval_batch_size = per_device_batch_size * max(1, self.n_gpu)
+        return eval_batch_size
+
 
 @dataclass
 class NeuronTrainingArguments(NeuronTrainingArgumentsMixin, TrainingArguments):

--- a/optimum/neuron/training_args.py
+++ b/optimum/neuron/training_args.py
@@ -205,34 +205,6 @@ class NeuronTrainingArgumentsMixin:
             divisor = self.tp_plugin.tensor_parallel_size
         return super().world_size // divisor
 
-    @property
-    def train_batch_size(self) -> int:
-        """
-        The actual batch size for training (may differ from `per_gpu_train_batch_size` in distributed training).
-        """
-        if self.per_gpu_train_batch_size:
-            logger.warning(
-                "Using deprecated `--per_gpu_train_batch_size` argument which will be removed in a future "
-                "version. Using `--per_device_train_batch_size` is preferred."
-            )
-        per_device_batch_size = self.per_gpu_train_batch_size or self.per_device_train_batch_size
-        train_batch_size = per_device_batch_size * 1
-        return train_batch_size
-
-    @property
-    def eval_batch_size(self) -> int:
-        """
-        The actual batch size for evaluation (may differ from `per_gpu_eval_batch_size` in distributed training).
-        """
-        if self.per_gpu_eval_batch_size:
-            logger.warning(
-                "Using deprecated `--per_gpu_eval_batch_size` argument which will be removed in a future "
-                "version. Using `--per_device_eval_batch_size` is preferred."
-            )
-        per_device_batch_size = self.per_gpu_eval_batch_size or self.per_device_eval_batch_size
-        eval_batch_size = per_device_batch_size * max(1, self.n_gpu)
-        return eval_batch_size
-
 
 @dataclass
 class NeuronTrainingArguments(NeuronTrainingArgumentsMixin, TrainingArguments):

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -326,7 +326,7 @@ def add_in_registry(repo_id: str, neuron_hash: "NeuronHash"):
     was_added = _ADDED_IN_REGISTRY.get((repo_id, neuron_hash), False)
     if was_added:
         return
-    model_name_or_path = _get_model_name_or_path(neuron_hash.model.config)
+    model_name_or_path = neuron_hash._model_name_or_path
     if model_name_or_path is None:
         model_name_or_path = "null"
 
@@ -564,6 +564,7 @@ class NeuronHash:
     tensor_parallel_size: Union[int, _UnspecifiedHashAttribute] = field(
         default_factory=_UnspecifiedHashAttribute.with_args(min_optimum_neuron_version="0.0.8", default=1)
     )
+    _model_name_or_path: Optional[str] = None
     _is_private: Optional[bool] = None
     _model_type: Optional[str] = None
     _hash: _MutableHashAttribute = field(default_factory=_MutableHashAttribute)
@@ -584,7 +585,8 @@ class NeuronHash:
             is_private = is_private_repo(model_name_or_path)
 
         # Using object.__setattr__ to change the field value because NeuronHash is supposed to be frozen.
-        # Not very clear, but it should work here.
+        # Not very clean, but it should work here.
+        super().__setattr__("_model_name_or_path", model_name_or_path)
         super().__setattr__("_is_private", is_private)
         super().__setattr__("_model_type", model.config.model_type)
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ EXTRAS_REQUIRE = {
         "transformers-neuronx",
         "torch==1.13.1.*",
         "torchvision==0.14.*",
-        "neuronx_distributed",
+        "neuronx_distributed >= 0.2.0",
     ],
     "diffusers": ["diffusers"],
 }


### PR DESCRIPTION
This PR includes:

- [x] An embedding that is not the vocabulary embedding that is parallelized, and with data available in the checkpoint ends-up re-initialized as unparallelized. This is the case of the `relative_attention_bias` in T5. This is fixed here.  
- [x] Fixes `T5Parallelizer`. The way T5 was parallized was producing different graphs per tp ranks, and was incorrect. This is fixed here. (cc @aws-rhsoln)
- [x] A temporary directory was created by each worker as a temporary neuron cache. Now rank 0 creates a temporary neuron cache, and the other workers use it. All of this setup is done before `torch.distributed.init_process_group` for it to be taken into account by the Neuron compiler. The share of information is done by a `torch.distributed.TCPStore`.
- [x] `NeuronHash` refactor. The fact that a `NeuronHash` stored an instance of the model was causing issues during compilation for `flan-t5`. It is also unnecessary to keep a reference of the model instance inside each `NeuronHash`. Now:
     - A `NeuronHash` is instantiated with a model instance but it is not an attribute anymore
     - Instead we store private attributes that were before deduced from the model: `_model_name_or_path`, `_is_private` (could be inferred from `_model_name_or_path`) and `_model_type`.

Fixes: #193 