### PR TITLE
test_examples uses ExampleRunner

### DIFF
--- a/.github/workflows/test_trainium_examples.yml
+++ b/.github/workflows/test_trainium_examples.yml
@@ -3,8 +3,8 @@ name: Optimum Neuron - Test Example Scripts
 on:
   workflow_dispatch:
     inputs: 
-      priority: 
-        description: The priority of the models to test, useful to perform filtering
+      coverage: 
+        description: The coverage of the models to test, useful to perform filtering
         options:
           - all
           - high

--- a/.github/workflows/test_trainium_examples.yml
+++ b/.github/workflows/test_trainium_examples.yml
@@ -1,12 +1,22 @@
-name: Optimum Neuron - Example scripts test on Trainium
+name: Optimum Neuron - Test Example Scripts
 
 on:
-  push:
-    branches:
-      - main
-  schedule:
-    # At the end of everyday
-    - cron: 0 22 * * *
+  workflow_dispatch:
+    inputs: 
+      priority: 
+        description: The priority of the models to test, useful to perform filtering
+        options:
+          - all
+          - high
+          - middle
+          - low
+        required: true
+      model_size: 
+        description: The size of the models to tests
+        options:
+          - regular
+          - tiny
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -55,16 +65,15 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     env:
       AWS_REGION: us-east-1
+      RUN_TINY: ${{ github.event.inputs.model_size == "tiny" && "1" || "0" }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Python dependencies
         run: pip install .[tests,neuronx]
-      - name: Install python3.8-venv
-        run: sudo apt update; sudo apt install -y python3.8-venv
       - name: Run example tests on Neuron cores
         run: |
-          HF_TOKEN_OPTIMUM_NEURON_CI=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV="false" RUN_SLOW=1 pytest -m "is_trainium_test" tests/test_examples.py -v
+          HF_TOKEN_OPTIMUM_NEURON_CI=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV="false" PRIORITY=${{ github.event.inputs.priority }} RUN_TINY=$RUN_TINY RUN_SLOW=1 pytest -m "is_trainium_test" tests/test_examples.py -v
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/test_trainium_examples.yml
+++ b/.github/workflows/test_trainium_examples.yml
@@ -73,7 +73,7 @@ jobs:
         run: pip install .[tests,neuronx]
       - name: Run example tests on Neuron cores
         run: |
-          HF_TOKEN_OPTIMUM_NEURON_CI=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV="false" PRIORITY=${{ github.event.inputs.priority }} RUN_TINY=$RUN_TINY RUN_SLOW=1 pytest -m "is_trainium_test" tests/test_examples.py -v
+          HF_TOKEN_OPTIMUM_NEURON_CI=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV=false COVERAGE=${{ github.event.inputs.priority }} RUN_TINY=$RUN_TINY RUN_SLOW=1 pytest -m "is_trainium_test" tests/test_examples.py -v
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -24,7 +24,7 @@ from ...neuron.utils.cache_utils import (
     load_custom_cache_repo_name_from_hf_home,
     set_custom_cache_repo_name_in_hf_home,
 )
-from ...neuron.utils.compilation_utils import ExampleRunner
+from ...neuron.utils.runner import ExampleRunner
 from ...utils import logging
 from ..base import BaseOptimumCLICommand, CommandInfo
 

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -192,7 +192,9 @@ class NeuronCacheCallback(TrainerCallback):
                 path_in_neuron_cache = path_after_folder(path_in_neuron_cache, NEURON_COMPILE_CACHE_NAME)
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)
-            tmp_cache_file.symlink_to(cache_file)
+            # TODO: investigate why it is needed. Minor issue.
+            if not tmp_cache_file.exists():
+                tmp_cache_file.symlink_to(cache_file)
 
             cls._insert_in_cache_stats(cache_stats, cache_file, path_in_neuron_cache)
 

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -150,7 +150,7 @@ def convert_checkpoint_to_safetensors(
     if not already_exists and (not is_distributed or is_main_process):
         if log:
             logger.info(f"Converting {weight_file} to safetensors")
-        checkpoint = torch.load(weight_file)
+        checkpoint = torch.load(weight_file, map_location=torch.device("cpu"))
         data_pointers = set()
         for k, v in checkpoint.items():
             if v.data_ptr() in data_pointers:

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -44,6 +44,20 @@ from .require_utils import requires_safetensors
 logger = logging.get_logger()
 
 
+# From https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
+def string_to_bool(v: Union[str, bool]) -> bool:
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise TypeError(
+            f"Truthy value expected: got {v} but expected one of yes/no, true/false, t/f, y/n, 1/0 (case insensitive)."
+        )
+
+
 def args_and_kwargs_to_kwargs_only(
     f: Callable,
     args: Optional[Tuple[Any, ...]] = None,

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -150,7 +150,7 @@ class ExampleRunner:
                 "--target_lang en",
                 "--pad_to_max_length",
                 "--prediction_loss_only",
-                {"t5": "--source_prefix 'Translate Romanian to Enligsh: '"},
+                {"t5": "--source_prefix 'Translate Romanian to English: '"},
             ],
         },
         "image-classification": {

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -340,19 +340,12 @@ class ExampleRunner:
 
         config = AutoConfig.from_pretrained(directory)
 
-        # config_cls = config.__class__
-        # parameters = inspect.signature(config_cls).parameters
-        # new_kwargs = {k: v for k, v in config.to_dict().items() if k in parameters}
-
         for name, value in config_overrides.items():
             type_of_attribute = type(getattr(config, name))
             if type(value) is not type_of_attribute:
                 value = type_of_attribute(value)
             setattr(config, name, value)
-            # new_kwargs[name] = value
 
-        # new_config = config_cls(**new_kwargs)
-        # new_config.save_pretrained(directory)
         config.save_pretrained(directory)
 
         return directory

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -136,7 +136,6 @@ class ExampleRunner:
             "set_max_target_length": True,
             "extra_command_line_arguments": [
                 "--pad_to_max_length",
-                "--pad_to_max_length",
                 "--prediction_loss_only",
                 {"t5": "--source_prefix 'summarize: '"},
             ],

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 """Utilities to be able to perform model compilation easily."""
 
-import os
 import codecs
+import os
 import re
 import subprocess
 from enum import Enum

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ TESTS_REQUIRE = [
     "sentencepiece",
     "datasets",
     "sacremoses",
-    "diffusers >= 0.20.0",
+    "diffusers==0.20.2",
     "safetensors",
 ]
 
@@ -58,7 +58,7 @@ EXTRAS_REQUIRE = {
         "transformers-neuronx>=0.6.106",
         "torch==1.13.1.*",
         "torchvision==0.14.*",
-        "neuronx_distributed >= 0.3.0",
+        "neuronx_distributed>=0.3.0",
     ],
     "diffusers": ["diffusers"],
 }

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ EXTRAS_REQUIRE = {
         "transformers-neuronx>=0.6.106",
         "torch==1.13.1.*",
         "torchvision==0.14.*",
-        "neuronx_distributed >= 0.3.0",
+        "neuronx_distributed>=0.3.0",
     ],
     "diffusers": ["diffusers"],
 }

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ TESTS_REQUIRE = [
     "sentencepiece",
     "datasets",
     "sacremoses",
-    "diffusers==0.20.2",
+    "diffusers >= 0.20.0",
     "safetensors",
 ]
 
@@ -58,7 +58,7 @@ EXTRAS_REQUIRE = {
         "transformers-neuronx>=0.6.106",
         "torch==1.13.1.*",
         "torchvision==0.14.*",
-        "neuronx_distributed>=0.3.0",
+        "neuronx_distributed >= 0.3.0",
     ],
     "diffusers": ["diffusers"],
 }

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -19,7 +19,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
 
 import torch
 from parameterized import parameterized
@@ -183,18 +183,6 @@ class ModelParallelizationTestCase(unittest.TestCase):
 
             cmd = ["torchrun", f"--nproc_per_node={num_neuron_cores}", f"{tmpdirname}/code.py"]
 
-            def get_outputs_from_process(process) -> Tuple[str, str]:
-                stdout, stderr = process.communicate()
-
-                stdout = stdout.decode("utf-8")
-                stderr = stderr.decode("utf-8")
-
-                if stdout == "":
-                    stdout = "N/A"
-                if stderr == "":
-                    stderr = "N/A"
-                return stdout, stderr
-
             # When running the test in parallel, we need 2 rendez-vous endpoints: one for the script running the
             # original model and one for the script running the parallel model.
             rdzv_endpoint_host = "localhost"
@@ -207,12 +195,13 @@ class ModelParallelizationTestCase(unittest.TestCase):
                 cmd.insert(1, f"--rdzv_endpoint={rdzv_endpoint_host}:{rdzv_endpoint_port}")
                 env["NEURON_RT_VISIBLE_CORES"] = f"0-{num_neuron_cores - 1}"
 
-            p_original = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+            p_original = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
 
             # When running tests in parallel, synchronization is done after both processes started.
             if not run_test_in_parallel:
-                stdout, stderr = get_outputs_from_process(p_original)
-                full_output = f"Original model standard output:\n{stdout}\nOriginal model standard error:\n{stderr}"
+                stdout, _ = p_original.communicate()
+                stdout = stdout.decode("utf-8")
+                full_output = f"Original model standard output:\n{stdout}"
                 print(full_output)
 
             # Parallel model.
@@ -221,15 +210,17 @@ class ModelParallelizationTestCase(unittest.TestCase):
                 # Updating the rendez-vous endpoint for the parallel model process.
                 cmd[1] = f"--rdzv_endpoint={rdzv_endpoint_host}:{rdzv_endpoint_port + 1}"
                 env["NEURON_RT_VISIBLE_CORES"] = f"{num_neuron_cores}-{2 * num_neuron_cores - 1}"
-            p_parallel = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+            p_parallel = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
 
             if run_test_in_parallel:
-                stdout, stderr = get_outputs_from_process(p_original)
-                full_output = f"Original model standard output:\n{stdout}\nOriginal model standard error:\n{stderr}"
+                stdout, _ = p_original.communicate()
+                stdout = stdout.decode("utf-8")
+                full_output = f"Original model standard output:\n{stdout}"
                 print(full_output)
 
-            stdout, stderr = get_outputs_from_process(p_parallel)
-            full_output = f"Parallel model standard output:\n{stdout}\nParallel model standard error:\n{stderr}"
+            stdout, _ = p_parallel.communicate()
+            stdout = stdout.decode("utf-8")
+            full_output = f"Parallel model standard output:\n{stdout}"
             print(full_output)
 
             temporary_dir = Path(tmpdirname)
@@ -239,9 +230,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
                 if not isinstance(t, torch.Tensor):
                     continue
                 print(t, original_model_outputs[name])
-                torch.testing.assert_close(
-                    t, original_model_outputs[name]
-                )  # , msg=f"Input called {name} do not match.")
+                torch.testing.assert_close(t, original_model_outputs[name])
 
     @parameterized.expand(MODELS_TO_TEST)
     def test_model_parallel_from_config_without_lazy_load(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,7 +21,7 @@ import sys
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
 from unittest import TestCase
 
 from huggingface_hub import HfFolder
@@ -49,11 +49,8 @@ from optimum.neuron.utils.testing_utils import is_trainium_test
 path_tests = Path(__file__).parent
 sys.path.insert(0, str(path_tests))
 
-# T =  TypeVar("T")
-# TypeOrDictOfType = Union[T, Dict[str, T]]
-# class TypeOrDictOfType(Generic[T]):  # This is fine
-#     pass
-# TypeOrDictOfType[
+T = TypeVar("T")
+TypeOrDictOfType = Union[T, Dict[str, T]]
 
 
 TOKEN = HfFolder.get_token()
@@ -353,7 +350,7 @@ class ExampleTestMeta(type):
             )
 
             with TemporaryDirectory() as tmpdirname:
-                returncode, stdout, stderr = runner.run(
+                returncode, stdout, _ = runner.run(
                     self.NUM_CORES,
                     "bf16",
                     train_batch_size,
@@ -412,11 +409,11 @@ class ExampleTesterBase(TestCase):
     NUM_EPOCHS: int = 1
     MAX_STEPS: Optional[int] = None
 
-    LEARNING_RATE: float = 1e-4
-    TRAIN_BATCH_SIZE: int = 2
-    EVAL_BATCH_SIZE: int = 2
-    GRADIENT_ACCUMULATION_STEPS: int = 1
-    SEQUENCE_LENGTH: Optional[Union[int, Tuple[int, int]]] = None
+    LEARNING_RATE: TypeOrDictOfType[float] = 1e-4
+    TRAIN_BATCH_SIZE: TypeOrDictOfType[int] = 2
+    EVAL_BATCH_SIZE: TypeOrDictOfType[int] = 2
+    GRADIENT_ACCUMULATION_STEPS: TypeOrDictOfType[int] = 1
+    SEQUENCE_LENGTH: TypeOrDictOfType[Optional[Union[int, Tuple[int, int]]]] = None
 
     NUM_CORES: int = 32
     LOGGING_STEPS: int = 1
@@ -424,13 +421,13 @@ class ExampleTesterBase(TestCase):
 
     TRAIN_LOSS_THRESHOLD: float
     TRAIN_LOSS_THRESHOLD_FOR_TINY: float
-    CHECK_THAT_LOSS_IS_DECREASING: bool = True
+    CHECK_THAT_LOSS_IS_DECREASING: TypeOrDictOfType[bool] = True
 
     # Camembert is pretrained on French.
-    DO_EVAL: bool
+    DO_EVAL: TypeOrDictOfType[bool]
     MAX_EVAL_SAMPLES: Optional[int] = None
-    EVAL_SCORE_THRESHOLD: float
-    EVAL_SCORE_THRESHOLD_FOR_TINY: float
+    EVAL_SCORE_THRESHOLD: TypeOrDictOfType[float]
+    EVAL_SCORE_THRESHOLD_FOR_TINY: TypeOrDictOfType[float]
     EVAL_SCORE_GREATER_IS_BETTER: bool
     SCORE_NAME: str
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,16 +16,16 @@
 
 import json
 import os
-import re
 import subprocess
 import sys
-from datetime import date
 from pathlib import Path
+from enum import Enum
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, Generic, TypeVar
 from unittest import TestCase
 
 from huggingface_hub import HfFolder
+from parameterized import parameterized
 from transformers import (
     CONFIG_MAPPING,
     MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING,
@@ -41,18 +41,19 @@ from transformers import (
 )
 from transformers.testing_utils import slow
 
-from optimum.neuron.utils.cache_utils import (
-    load_custom_cache_repo_name_from_hf_home,
-    set_custom_cache_repo_name_in_hf_home,
-    set_neuron_cache_path,
-)
+from optimum.neuron.utils.runner import ExampleRunner
 from optimum.neuron.utils.testing_utils import is_trainium_test
 
 
 # Doing it this way to be able to use this file in tools.
 path_tests = Path(__file__).parent
 sys.path.insert(0, str(path_tests))
-from utils import MODELS_TO_TEST_MAPPING  # noqa: E402
+
+# T =  TypeVar("T")
+# TypeOrDictOfType = Union[T, Dict[str, T]]
+# class TypeOrDictOfType(Generic[T]):  # This is fine
+#     pass
+# TypeOrDictOfType[
 
 
 TOKEN = HfFolder.get_token()
@@ -60,6 +61,52 @@ if os.environ.get("HF_TOKEN_OPTIMUM_NEURON_CI", None) is not None:
     TOKEN = os.environ.get("HF_TOKEN_OPTIMUM_NEURON_CI")
 
 CACHE_REPO_NAME = "optimum-internal-testing/optimum-neuron-cache-for-testing"
+
+USE_VENV = False # os.environ.get("USE_VENV", "true") == "true"
+
+class TPSupport(str, Enum):
+    """
+    Describes the support for Tensor Parallelism for a given model:
+        
+        - full: The model can be fully parallelized (embeddings + blocks + cross-entropy loss when it makes sense).
+        - partial: The model can be parallelized but not the embeddings. Usually because the vocabulary size is not 
+        divisible by the tensor parallel size (2 here).
+        - none: The model cannot be parallelized, either for shape mismatch as in the partial case, or because the 
+        tensor parallelism support for this model type has not been added.
+    """
+    FULL = "full"
+    PARTIAL = "partial"
+    NONE = "none"
+
+class Priority(str, Enum):
+    LOW = "low"
+    MIDDLE = "middle"
+    HIGH = "high"
+    ALL = "all"
+    
+PRIORITY = Priority(os.environ.get("PRIORITY", "all"))
+
+
+MODELS_TO_TEST_MAPPING = {
+    "albert": ("albert-base-v2", TPSupport.NONE, Priority.LOW),
+    "bart": ("facebook/bart-base", TPSupport.NONE, Priority.MIDDLE),
+    "bert": ("bert-base-uncased", TPSupport.FULL, Priority.MIDDLE),
+    "camembert": ("camembert-base", TPSupport.NONE, Priority.LOW),
+    "distilbert": ("distilbert-base-uncased", TPSupport.NONE, Priority.LOW),
+    "electra": ("google/electra-base-discriminator", TPSupport.NONE, Priority.LOW),
+    "gpt2": ("gpt2", TPSupport.NONE, Priority.HIGH),
+    "gpt_neo": ("EleutherAI/gpt-neo-125M", TPSupport.PARTIAL, Priority.HIGH),
+    "marian": ("Helsinki-NLP/opus-mt-en-ro", TPSupport.NONE, Priority.MIDDLE),
+    "roberta": ("roberta-base", TPSupport.PARTIAL, Priority.MIDDLE),
+    "t5": ("t5-small", TPSupport.FULL, Priority.HIGH),
+    "vit": ("google/vit-base-patch16-224-in21k", TPSupport.NONE, Priority.LOW),
+    "xlm-roberta": ("xlm-roberta-base", TPSupport.NONE, Priority.LOW),
+    # TODO: issue with this model for now.
+    "m2m_100": ("facebook/m2m100_418M", TPSupport.NONE, Priority.MIDDLE),
+    # TODO: Llama 
+    # "wav2vec2": "facebook/wav2vec2-base",
+    # Remaning: XLNet, Deberta-v2, MPNet, CLIP
+}
 
 
 def _get_supported_models_for_script(
@@ -71,13 +118,16 @@ def _get_supported_models_for_script(
     if to_exclude is None:
         to_exclude = set()
     supported_models = []
-    for model_type, model_name in models_to_test.items():
+    for model_type, entry in models_to_test.items():
+        model_name, tp_support, priority = entry
         if model_type in to_exclude:
+            continue
+        if PRIORITY != "all" and PRIORITY != priority:
             continue
         if CONFIG_MAPPING[model_type] in task_mapping:
             if model_type == "bart" and task_mapping is not MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING:
                 continue
-            supported_models.append((model_type, model_name))
+            supported_models.append((model_type, model_name, tp_support))
     return supported_models
 
 
@@ -128,8 +178,8 @@ class ExampleTestMeta(type):
             models_to_test = _SCRIPT_TO_MODEL_MAPPING.get(example_name)
             if models_to_test is None:
                 raise AttributeError(f"could not create class because no model was found for example {example_name}")
-        for model_type, model_name in models_to_test:
-            attrs[f"test_{example_name}_{model_type}"] = cls._create_test(model_type, model_name)
+        for model_type, model_name_or_path, tp_support in models_to_test:
+            attrs[f"test_{example_name}_{model_type}"] = cls._create_test(model_type, model_name_or_path, tp_support)
         attrs["EXAMPLE_NAME"] = example_name
         return super().__new__(cls, name, bases, attrs)
 
@@ -140,7 +190,7 @@ class ExampleTestMeta(type):
         return attribute
 
     @classmethod
-    def _create_test(cls, model_type: str, model_name: str) -> Callable[["ExampleTesterBase"], None]:
+    def _create_test(cls, model_type: str, model_name_or_path: str, tp_support: TPSupport) -> Callable[["ExampleTesterBase"], None]:
         """
         Creates a test function that runs an example for a model_name.
 
@@ -154,391 +204,153 @@ class ExampleTestMeta(type):
         @slow
         @is_trainium_test
         def test(self):
-            if self.EXAMPLE_NAME is None:
-                raise ValueError("An example name must be provided")
-            example_script = Path(self.EXAMPLE_DIR).glob(f"*/{self.EXAMPLE_NAME}.py")
-            example_script = list(example_script)
-            if len(example_script) == 0:
-                raise RuntimeError(f"Could not find {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
-            elif len(example_script) > 1:
-                raise RuntimeError(f"Found more than {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
-            else:
-                example_script = example_script[0]
+            train_batch_size = ExampleTestMeta.process_class_attribute(self.TRAIN_BATCH_SIZE, model_type)
+            eval_batch_size = ExampleTestMeta.process_class_attribute(self.EVAL_BATCH_SIZE, model_type)
+            sequence_length = ExampleTestMeta.process_class_attribute(self.SEQUENCE_LENGTH, model_type)
+            gradient_accumulation_steps = ExampleTestMeta.process_class_attribute(self.GRADIENT_ACCUMULATION_STEPS, model_type)
 
-            self._install_requirements(example_script.parent / "requirements.txt")
+            tensor_parallel_size = 2 if tp_support is not TPSupport.NONE else 1
+            disable_embedding_parallelization = tp_support is TPSupport.PARTIAL
+            zero_1 = ExampleTestMeta.process_class_attribute(self.ZERO_1, model_type)
 
-            do_precompilation = ExampleTestMeta.process_class_attribute(self.DO_PRECOMPILATION, model_type)
-            only_precompilation = ExampleTestMeta.process_class_attribute(self.ONLY_PRECOMPILATION, model_type)
+            runner = ExampleRunner(model_name_or_path, self.TASK_NAME, example_dir=self.EXAMPLE_DIR, use_venv=USE_VENV)
 
-            eval_is_supported = ExampleTestMeta.process_class_attribute(self.EVAL_IS_SUPPORTED, model_type)
-            eval_score_threshold = ExampleTestMeta.process_class_attribute(self.EVAL_SCORE_THRESHOLD, model_type)
+            with TemporaryDirectory() as tmpdirname:
 
-            env = self.get_env(model_type)
-            if do_precompilation:
-                with TemporaryDirectory(dir=Path(self.EXAMPLE_DIR)) as tmp_dir:
-                    cmd_line = self._create_command_line(
-                        example_script,
-                        model_name,
-                        model_type,
-                        tmp_dir,
-                        is_precompilation=True,
-                    )
-                    joined_cmd_line = " ".join(cmd_line)
-                    print(f"#### Running precompilation... ####\n{joined_cmd_line}\n")
-                    p = subprocess.Popen(joined_cmd_line, shell=True, env=env)
-                    return_code = p.wait()
-                    self.assertEqual(return_code, 0)
+                returncode, stdout, stderr = runner.run(
+                    self.NUM_CORES,
+                    "bf16",
+                    train_batch_size,
+                    sequence_length=sequence_length,
+                    do_eval=self.DO_EVAL,
+                    eval_batch_size=eval_batch_size,
+                    gradient_accumulation_steps=gradient_accumulation_steps,
+                    num_epochs=self.NUM_EPOCHS,
+                    max_steps=self.MAX_STEPS,
+                    save_steps=self.SAVE_STEPS,
+                    learning_rate=self.LEARNING_RATE,
+                    tensor_parallel_size=tensor_parallel_size,
+                    disable_embedding_parallelization=disable_embedding_parallelization,
+                    zero_1=zero_1,
+                    output_dir=tmpdirname,
+                )
+                print(f"Return code: {returncode}")
+                print(f"Standard output:\n{stdout}\n")
+                print(f"Standard error:\n{stderr}\n")
 
-            if not only_precompilation:
-                with TemporaryDirectory(dir=Path(self.EXAMPLE_DIR)) as tmp_dir:
-                    cmd_line = self._create_command_line(
-                        example_script,
-                        model_name,
-                        model_type,
-                        tmp_dir,
-                    )
-                    joined_cmd_line = " ".join(cmd_line)
-                    print(f"#### Running command line... ####\n{joined_cmd_line}\n")
-                    os.environ["WANDB_NAME"] = f"{self.EXAMPLE_NAME}_{model_type}"
-                    p = subprocess.Popen(joined_cmd_line, shell=True, env=env)
-                    return_code = p.wait()
-                    self.assertEqual(return_code, 0)
+                assert returncode == 0
 
-                    if eval_is_supported:
-                        with open(Path(tmp_dir) / "all_results.json") as fp:
-                            results = json.load(fp)
-                        threshold_overrides = {}
-                        threshold = threshold_overrides.get(model_name, eval_score_threshold)
-                        if self.EVAL_SCORE_GREATER_IS_BETTER:
-                            self.assertGreaterEqual(float(results[self.SCORE_NAME]), threshold)
-                        else:
-                            self.assertLessEqual(float(results[self.SCORE_NAME]), threshold)
-
+                if self.ONLY_CHECK_THAT_LOSS_IS_DECREASING:
+                    # TODO
+                    pass
+                elif self.DO_EVAL:
+                    with open(Path(tmpdirname) / "all_results.json") as fp:
+                        results = json.load(fp)
+                    threshold = ExampleTestMeta.process_class_attribute(self.EVAL_SCORE_THRESHOLD, model_type)
+                    if self.EVAL_SCORE_GREATER_IS_BETTER:
+                        self.assertGreaterEqual(float(results[self.SCORE_NAME]), threshold)
+                    else:
+                        self.assertLessEqual(float(results[self.SCORE_NAME]), threshold)
         return test
 
 
 class ExampleTesterBase(TestCase):
     """
     Base example tester class.
-
-    Attributes:
-        EXAMPLE_DIR (`Union[str, Path]`) -- The directory containing the examples.
-        EXAMPLE_NAME (`Optional[str]`) -- The name of the example script without the file extension, e.g. run_qa, run_glue, etc.
-        TASK_NAME (`str`) -- The name of the dataset to use.
-        EVAL_IS_SUPPORTED (`bool`) -- Whether evaluation is currently supported on AWS Tranium.
-            If True, the example will run evaluation, otherwise it will be skipped.
-        EVAL_SCORE_THRESHOLD (`float`) -- The score threshold from which training is assumed to have worked.
-        SCORE_NAME (`str`) -- The name of the metric to use for checking that the example ran successfully.
-        DATASET_PARAMETER_NAME (`str`) -- The argument name to use for the dataset parameter.
-            Most of the time it will be "dataset_name", but for some tasks on a benchmark it might be something else.
-        TRAIN_BATCH_SIZE (`int`) -- The batch size to give to the example script for training.
-        EVAL_BATCH_SIZE (`int`) -- The batch size to give to the example script for evaluation.
-        GRADIENT_ACCUMULATION_STEPS (`int`) -- The number of gradient accumulation to use during training.
-        DATALOADER_DROP_LAST (`bool`) -- Whether to drop the last batch if it is a remainder batch.
-        NPROC_PER_NODE (`int`) -- The number of Neuron cores to use when doing multiple workers training.
-        EXTRA_COMMAND_LINE_ARGUMENTS (`Optional[List[str]]`) -- Extra arguments, if needed, to be passed to the command line traning
-            script.
     """
-
     EXAMPLE_DIR = Path(__file__).parent.parent / "examples"
-    EXAMPLE_NAME = ""
-    TASK_NAME = None
-    DATASET_CONFIG_NAME = ""
-    EVAL_IS_SUPPORTED = True
+    TASK_NAME: str 
+
+    NUM_EPOCHS: int = 1
+    MAX_STEPS: Optional[int] = None 
+
+    LEARNING_RATE: float = 1e-4
+    TRAIN_BATCH_SIZE: int = 16
+    EVAL_BATCH_SIZE: int = 16
+    GRADIENT_ACCUMULATION_STEPS: int = 16
+    SEQUENCE_LENGTH: Optional[Union[int, Tuple[int, int]]] = None
+
+    NUM_CORES: int = 32
+    LOGGING_STEPS: int = 1
+    SAVE_STEPS: int = 200
+
     # Camembert is pretrained on French.
-    EVAL_SCORE_THRESHOLD = {"default": 0.75, "camembert": 0.5}
-    EVAL_SCORE_GREATER_IS_BETTER = True
-    SCORE_NAME = "eval_accuracy"
-    DATASET_PARAMETER_NAME = "dataset_name"
-    NUM_EPOCHS = 1
-    MAX_STEPS = None
-    LEARNING_RATE = 1e-4
-    TRAIN_BATCH_SIZE = 16
-    EVAL_BATCH_SIZE = 16
-    GRADIENT_ACCUMULATION_STEPS = 16
-    NPROC_PER_NODE = 2
-    EXTRA_COMMAND_LINE_ARGUMENTS = None
-    LOGGING_STEPS = 1
-    SAVE_STEPS = 200
-    ONLY_PRECOMPILATION = False
-    DO_PRECOMPILATION = False
-    NEURON_CACHE = None
-    MULTI_PROC = os.environ.get("MULTI_PROC", "false")
-    BF16 = True
+    DO_EVAL: bool 
+    ONLY_CHECK_THAT_LOSS_IS_DECREASING: bool = False
+    EVAL_SCORE_THRESHOLD: float 
+    EVAL_SCORE_GREATER_IS_BETTER: bool
+    SCORE_NAME: str 
 
-    @classmethod
-    def setUpClass(cls):
-        cls._create_venv()
-        cls._orig_token = HfFolder.get_token()
-        cls._orig_cache_repo = load_custom_cache_repo_name_from_hf_home()
-        HfFolder.save_token(TOKEN)
-        set_custom_cache_repo_name_in_hf_home(CACHE_REPO_NAME)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._remove_venv()
-        if cls._orig_token is not None:
-            HfFolder.save_token(cls._orig_token)
-        if cls._orig_cache_repo is not None:
-            set_custom_cache_repo_name_in_hf_home(cls._orig_cache_repo)
-
-    def setUp(self):
-        set_neuron_cache_path("/var/tmp/neuron-compile-cache")
-
-    def tearDown(self):
-        set_neuron_cache_path("/var/tmp/neuron-compile-cache")
-
-        cmd_line = "sudo rmmod neuron".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        assert return_code == 0
-
-        cmd_line = "sudo modprobe neuron".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        assert return_code == 0
-
-    def get_env(self, model_type: str) -> Dict[str, str]:
-        env = dict(os.environ)
-        return env
-
-    def _create_command_line(
-        self,
-        script: str,
-        model_name: str,
-        model_type: str,
-        output_dir: str,
-        is_precompilation: bool = False,
-    ) -> List[str]:
-        # Task related.
-        task = ExampleTestMeta.process_class_attribute(self.TASK_NAME, model_type)
-        dataset_parameter_name = ExampleTestMeta.process_class_attribute(self.DATASET_PARAMETER_NAME, model_type)
-        dataset_config_name = ExampleTestMeta.process_class_attribute(self.DATASET_CONFIG_NAME, model_type)
-
-        # Batch size related.
-        train_batch_size = ExampleTestMeta.process_class_attribute(self.TRAIN_BATCH_SIZE, model_type)
-        eval_batch_size = ExampleTestMeta.process_class_attribute(self.EVAL_BATCH_SIZE, model_type)
-        gradient_accumulation_steps = ExampleTestMeta.process_class_attribute(
-            self.GRADIENT_ACCUMULATION_STEPS, model_type
-        )
-
-        # Training related.
-        learning_rate = ExampleTestMeta.process_class_attribute(self.LEARNING_RATE, model_type)
-        eval_is_supported = ExampleTestMeta.process_class_attribute(self.EVAL_IS_SUPPORTED, model_type)
-        n_proc_per_node = ExampleTestMeta.process_class_attribute(self.NPROC_PER_NODE, model_type)
-        num_train_epochs = ExampleTestMeta.process_class_attribute(self.NUM_EPOCHS, model_type)
-        max_steps = ExampleTestMeta.process_class_attribute(self.MAX_STEPS, model_type)
-        logging_steps = ExampleTestMeta.process_class_attribute(self.LOGGING_STEPS, model_type)
-        save_steps = ExampleTestMeta.process_class_attribute(self.SAVE_STEPS, model_type)
-
-        bf16 = ExampleTestMeta.process_class_attribute(self.BF16, model_type)
-        multi_proc = ExampleTestMeta.process_class_attribute(self.MULTI_PROC, model_type)
-
-        # Extra
-        extra_command_line_arguments = []
-        if self.EXTRA_COMMAND_LINE_ARGUMENTS is not None:
-            extra_command_line_arguments = [
-                ExampleTestMeta.process_class_attribute(arg, model_type) for arg in self.EXTRA_COMMAND_LINE_ARGUMENTS
-            ]
-
-        do_eval = eval_is_supported and not is_precompilation
-
-        do_eval_option = "--do_eval" if do_eval else " "
-        task_option = f"--{dataset_parameter_name} {task}" if task else " "
-
-        if multi_proc == "false":
-            program = ["venv/bin/python" if self.venv_was_created() else "python"]
-        else:
-            program = [
-                "venv/bin/torchrun" if self.venv_was_created() else "torchrun",
-                f"--nproc_per_node={n_proc_per_node}",
-            ]
-
-        if is_precompilation:
-            neuron_parallel_compile_path = (
-                "venv/bin/neuron_parallel_compile" if self.venv_was_created() else "neuron_parallel_compile"
-            )
-            program = [neuron_parallel_compile_path] + program
-
-        if max_steps is not None:
-            max_steps = f"--max_steps {max_steps}"
-        else:
-            max_steps = ""
-
-        cmd_line = program + [
-            f"{script}",
-            f"--model_name_or_path {model_name}",
-            f"{task_option}",
-            "--do_train",
-            f"{do_eval_option}",
-            f"--output_dir {output_dir}",
-            "--overwrite_output_dir true",
-            f"--learning_rate {learning_rate}",
-            f"--per_device_train_batch_size {train_batch_size}",
-            f"--per_device_eval_batch_size {eval_batch_size}",
-            f"--gradient_accumulation_steps {gradient_accumulation_steps}",
-            "--save_strategy steps",
-            f" --num_train_epochs {num_train_epochs}",
-            max_steps,
-            "--dataloader_num_workers 4",
-            f"--save_steps {save_steps}",
-            "--save_total_limit 1",
-            f"--logging_steps {logging_steps}",
-        ]
-        if bf16:
-            cmd_line.append("--bf16")
-        if is_precompilation:
-            cmd_line.append("--report_to none")
-
-        if dataset_config_name:
-            cmd_line.append(f"--dataset_config_name {dataset_config_name}")
-
-        if extra_command_line_arguments is not None:
-            cmd_line += extra_command_line_arguments
-
-        pattern = re.compile(r"([\"\'].+?[\"\'])|\s")
-        return [x for y in cmd_line for x in re.split(pattern, y) if x]
-
-    @classmethod
-    def venv_was_created(cls):
-        return os.environ.get("USE_VENV", "true") == "true" and os.path.isdir("venv")
-
-    @classmethod
-    def _create_venv(cls):
-        """
-        Creates the virtual environment for the example.
-        """
-        if os.environ.get("USE_VENV", "true") == "true":
-            cmd_line = "python -m venv venv".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            assert return_code == 0
-
-            # Install pip
-            cmd_line = "venv/bin/python -m ensurepip --upgrade".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            assert return_code == 0
-
-    @classmethod
-    def _remove_venv(cls):
-        """
-        Removes the virtual environment for the example.
-        """
-        if cls.venv_was_created():
-            cmd_line = "rm -rf venv".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            assert return_code == 0
-
-    def _install_requirements(self, requirements_filename: Union[str, os.PathLike]):
-        """
-        Installs the necessary requirements to run the example if the provided file exists, otherwise does nothing.
-        """
-
-        pip_name = "venv/bin/pip" if self.venv_was_created() else "pip"
-
-        # Update pip
-        cmd_line = f"{pip_name} install --upgrade pip".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        self.assertEqual(return_code, 0)
-
-        # Set pip repository pointing to the Neuron repository
-        cmd_line = f"{pip_name} config set global.extra-index-url https://pip.repos.neuron.amazonaws.com".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        self.assertEqual(return_code, 0)
-
-        # Install wget, awscli, Neuron Compiler and Neuron Framework
-        cmd_line = f"{pip_name} freeze | grep torch-neuronx".split()
-        p = subprocess.Popen(cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        outs, _ = p.communicate()
-        if outs is not None:
-            cmd_line = f"{pip_name} install wget awscli neuronx-cc==2.* torch-neuronx torchvision".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            self.assertEqual(return_code, 0)
-
-        cmd_line = f"{pip_name} install -e {Path(__file__).parent.parent}".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        self.assertEqual(return_code, 0)
-
-        # Install requirements
-        if Path(requirements_filename).exists():
-            cmd_line = f"{pip_name} install -r {requirements_filename}".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            self.assertEqual(return_code, 0)
-
-        # TODO: remove that as soon as possible.
-        cmd_line = f"{pip_name} install numpy==1.20.3".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        self.assertEqual(return_code, 0)
-
-        # Potentially install WANDB
-        wandb_token = os.environ.get("WANDB_TOKEN", None)
-        if wandb_token is not None:
-            cmd_line = f"{pip_name} install wandb".split()
-            p = subprocess.Popen(cmd_line)
-            return_code = p.wait()
-            self.assertEqual(return_code, 0)
-
-            env_with_updated_path = dict(os.environ, PATH=f"/home/ubuntu/.local/bin:{os.environ['PATH']}")
-
-            wandb_name = "venv/bin/wandb" if self.venv_was_created() else "wandb"
-            cmd_line = f"{wandb_name} login --relogin {wandb_token}".split()
-            p = subprocess.Popen(cmd_line, env=env_with_updated_path)
-            self.assertEqual(return_code, 0)
-
-            wandb_project_name = os.environ.get("WANDB_PROJECT", "aws-neuron-tests")
-            today = date.today().strftime("%d%m%Y")
-            wandb_project_name = f"{wandb_project_name}-{today}"
-            os.environ["WANDB_PROJECT"] = wandb_project_name
-            cmd_line = f"{wandb_name} init -p {wandb_project_name}".split()
-            p = subprocess.Popen(cmd_line, env=env_with_updated_path)
-            self.assertEqual(return_code, 0)
 
 
 class CausalLMExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_clm"):
-    TASK_NAME = "wikitext"
-    DATASET_CONFIG_NAME = "wikitext-2-raw-v1"
+    TASK_NAME = "causal-lm"
+
     NUM_EPOCHS = 1
-    TRAIN_BATCH_SIZE = {"default": 2, "gpt2": 1}
+    MAX_STEPS = 100
+    TRAIN_BATCH_SIZE = 2
     EVAL_BATCH_SIZE = 2
-    SCORE_NAME = "random_test"
-    EVAL_SCORE_THRESHOLD = 35
-    EVAL_SCORE_GREATER_IS_BETTER = False
+    SEQUENCE_LENGTH = 512
+
+    # TODO: enable ZERO_1 once it has been fixed by #222.
+    ZERO_1 = False
+
+    DO_EVAL = False
+    ONLY_CHECK_THAT_LOSS_IS_DECREASING: bool = True
 
 
 class TextClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_glue"):
-    TASK_NAME = "sst2"
-    DATASET_PARAMETER_NAME = "task_name"
+    TASK_NAME = "text-classification"
+
     NUM_EPOCHS = 1
+    SEQUENCE_LENGTH = 128
+
+    ZERO_1 = False
+
+    # Camembert is pretrained on French.
+    DO_EVAL = False # TODO: Evaluation is broken.
+    EVAL_SCORE_THRESHOLD = {"default": 0.75, "camembert": 0.5}
+    EVAL_SCORE_GREATER_IS_BETTER = True
+    SCORE_NAME = "eval_accuracy"
+
 
 
 class TokenClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_ner"):
-    TASK_NAME = "conll2003"
+    TASK_NAME = "token-classification"
+
+    NUM_EPOCHS = 1
     TRAIN_BATCH_SIZE = {"default": 4, "distilbert": 6}
     EVAL_BATCH_SIZE = {"default": 4, "distilbert": 6}
-    NUM_EPOCHS = 1
-    EXTRA_COMMAND_LINE_ARGUMENTS = [
-        "--max_seq_length 384",
-    ]
+    SEQUENCE_LENGTH = 384
+
+    ZERO_1 = False
+
+    # Camembert is pretrained on French.
+    DO_EVAL = False # TODO: Evaluation is broken.
+    EVAL_SCORE_THRESHOLD = {"default": 0.75, "camembert": 0.5}
+    EVAL_SCORE_GREATER_IS_BETTER = True
+    SCORE_NAME = "eval_accuracy"
 
 
 class MultipleChoiceExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_swag"):
-    EVAL_SCORE_THRESHOLD = {"default": 0.75, "camembert": 0.5, "distilbert": 0.645}
-    TRAIN_BATCH_SIZE = {"default": 2, "distilbert": 3}
-    EVAL_BATCH_SIZE = {"default": 2, "distilbert": 3}
+    TASK_NAME = "multiple-choice"
+
+    TRAIN_BATCH_SIZE = 2 
+    EVAL_BATCH_SIZE = 2 
     MAX_STEPS = 100
-    NUM_EPOCHS = 1
-    EXTRA_COMMAND_LINE_ARGUMENTS = [
-        "--max_eval_samples 840",
-        "--max_seq_length 512",
-    ]
+    SEQUENCE_LENGTH = 512
+
+    ZERO_1 = True
+
+    # Camembert is pretrained on French.
+    DO_EVAL = False # TODO: Evaluation is broken.
+    EVAL_SCORE_THRESHOLD = {"default": 0.75, "camembert": 0.5, "distilbert": 0.645}
+    EVAL_SCORE_GREATER_IS_BETTER = True
+    SCORE_NAME = "eval_accuracy"
+    # TODO: handle that.
+    # EXTRA_COMMAND_LINE_ARGUMENTS = [
+    #     "--max_eval_samples 840",
+    # ]
 
 
 class QuestionAnsweringExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_qa"):
@@ -547,99 +359,99 @@ class QuestionAnsweringExampleTester(ExampleTesterBase, metaclass=ExampleTestMet
     NUM_EPOCHS = 1
 
 
-class SummarizationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization"):
-    TASK_NAME = "cnn_dailymail"
-    DATASET_CONFIG_NAME = "3.0.0"
-    TRAIN_BATCH_SIZE = 1
-    EVAL_BATCH_SIZE = 1
-    MAX_STEPS = 200
-    EVAL_IS_SUPPORTED = False
-    EVAL_SCORE_THRESHOLD = 30
-    SCORE_NAME = "eval_rougeLsum"
-    EXTRA_COMMAND_LINE_ARGUMENTS = [
-        "--prediction_loss_only",
-        "--pad_to_max_length",
-        "--max_target_length 200",
-        {"default": "--max_source_length 1024", "t5": "--max_source_length 768"},
-        {"default": "", "t5": "--source_prefix 'summarize: '"},
-    ]
-
-    def _create_command_line(
-        self,
-        script: str,
-        model_name: str,
-        model_type: str,
-        output_dir: str,
-        is_precompilation: bool = False,
-    ) -> List[str]:
-        extra_command_line_arguments = [
-            ExampleTestMeta.process_class_attribute(arg, model_type) for arg in self.EXTRA_COMMAND_LINE_ARGUMENTS
-        ]
-        if extra_command_line_arguments is None:
-            extra_command_line_arguments = []
-        return super()._create_command_line(
-            script,
-            model_name,
-            model_type,
-            output_dir,
-            is_precompilation=is_precompilation,
-        )
-
-
-class TranslationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_translation"):
-    TASK_NAME = "wmt16"
-    DATASET_CONFIG_NAME = "ro-en"
-    TRAIN_BATCH_SIZE = 1
-    EVAL_BATCH_SIZE = 1
-    MAX_STEPS = 200
-    EVAL_IS_SUPPORTED = False
-    EVAL_SCORE_THRESHOLD = 22
-    SCORE_NAME = "eval_bleu"
-    EXTRA_COMMAND_LINE_ARGUMENTS = [
-        "--source_lang ro",
-        "--target_lang en",
-        "--pad_to_max_length",
-        {"default": "--max_source_length 512", "m2m_100": "--max_source_length 128"},
-        {"default": "--max_target_length 512", "m2m_100": "--max_target_length 128"},
-        # "--max_source_length 512",
-        # "--max_target_length 512",
-        "--prediction_loss_only",
-    ]
-
-    def _create_command_line(
-        self,
-        script: str,
-        model_name: str,
-        model_type: str,
-        output_dir: str,
-        is_precompilation: bool = False,
-    ) -> List[str]:
-        extra_command_line_arguments = [
-            ExampleTestMeta.process_class_attribute(arg, model_type) for arg in self.EXTRA_COMMAND_LINE_ARGUMENTS
-        ]
-        if extra_command_line_arguments is None:
-            extra_command_line_arguments = []
-        if "t5" in model_name:
-            extra_command_line_arguments.append("--source_prefix 'translate English to Romanian: '")
-        return super()._create_command_line(
-            script,
-            model_name,
-            model_type,
-            output_dir,
-            is_precompilation=is_precompilation,
-        )
-
-
-class ImageClassificationExampleTester(
-    ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_image_classification"
-):
-    TASK_NAME = "cifar10"
-    NUM_EPOCHS = 2
-    EXTRA_COMMAND_LINE_ARGUMENTS = [
-        "--remove_unused_columns false",
-        "--dataloader_drop_last true",
-        "--ignore_mismatched_sizes",
-    ]
+# class SummarizationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_summarization"):
+#     TASK_NAME = "cnn_dailymail"
+#     DATASET_CONFIG_NAME = "3.0.0"
+#     TRAIN_BATCH_SIZE = 1
+#     EVAL_BATCH_SIZE = 1
+#     MAX_STEPS = 200
+#     EVAL_IS_SUPPORTED = False
+#     EVAL_SCORE_THRESHOLD = 30
+#     SCORE_NAME = "eval_rougeLsum"
+#     EXTRA_COMMAND_LINE_ARGUMENTS = [
+#         "--prediction_loss_only",
+#         "--pad_to_max_length",
+#         "--max_target_length 200",
+#         {"default": "--max_source_length 1024", "t5": "--max_source_length 768"},
+#         {"default": "", "t5": "--source_prefix 'summarize: '"},
+#     ]
+# 
+#     def _create_command_line(
+#         self,
+#         script: str,
+#         model_name: str,
+#         model_type: str,
+#         output_dir: str,
+#         is_precompilation: bool = False,
+#     ) -> List[str]:
+#         extra_command_line_arguments = [
+#             ExampleTestMeta.process_class_attribute(arg, model_type) for arg in self.EXTRA_COMMAND_LINE_ARGUMENTS
+#         ]
+#         if extra_command_line_arguments is None:
+#             extra_command_line_arguments = []
+#         return super()._create_command_line(
+#             script,
+#             model_name,
+#             model_type,
+#             output_dir,
+#             is_precompilation=is_precompilation,
+#         )
+# 
+# 
+# class TranslationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_translation"):
+#     TASK_NAME = "wmt16"
+#     DATASET_CONFIG_NAME = "ro-en"
+#     TRAIN_BATCH_SIZE = 1
+#     EVAL_BATCH_SIZE = 1
+#     MAX_STEPS = 200
+#     EVAL_IS_SUPPORTED = False
+#     EVAL_SCORE_THRESHOLD = 22
+#     SCORE_NAME = "eval_bleu"
+#     EXTRA_COMMAND_LINE_ARGUMENTS = [
+#         "--source_lang ro",
+#         "--target_lang en",
+#         "--pad_to_max_length",
+#         {"default": "--max_source_length 512", "m2m_100": "--max_source_length 128"},
+#         {"default": "--max_target_length 512", "m2m_100": "--max_target_length 128"},
+#         # "--max_source_length 512",
+#         # "--max_target_length 512",
+#         "--prediction_loss_only",
+#     ]
+# 
+#     def _create_command_line(
+#         self,
+#         script: str,
+#         model_name: str,
+#         model_type: str,
+#         output_dir: str,
+#         is_precompilation: bool = False,
+#     ) -> List[str]:
+#         extra_command_line_arguments = [
+#             ExampleTestMeta.process_class_attribute(arg, model_type) for arg in self.EXTRA_COMMAND_LINE_ARGUMENTS
+#         ]
+#         if extra_command_line_arguments is None:
+#             extra_command_line_arguments = []
+#         if "t5" in model_name:
+#             extra_command_line_arguments.append("--source_prefix 'translate English to Romanian: '")
+#         return super()._create_command_line(
+#             script,
+#             model_name,
+#             model_type,
+#             output_dir,
+#             is_precompilation=is_precompilation,
+#         )
+# 
+# 
+# class ImageClassificationExampleTester(
+#     ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_image_classification"
+# ):
+#     TASK_NAME = "cifar10"
+#     NUM_EPOCHS = 2
+#     EXTRA_COMMAND_LINE_ARGUMENTS = [
+#         "--remove_unused_columns false",
+#         "--dataloader_drop_last true",
+#         "--ignore_mismatched_sizes",
+#     ]
 
 
 # class AudioClassificationExampleTester(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -60,7 +60,6 @@ if os.environ.get("HF_TOKEN_OPTIMUM_NEURON_CI", None) is not None:
 CACHE_REPO_NAME = "optimum-internal-testing/optimum-neuron-cache-for-testing"
 
 
-
 class TPSupport(str, Enum):
     """
     Describes the support for Tensor Parallelism for a given model:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -59,7 +59,6 @@ if os.environ.get("HF_TOKEN_OPTIMUM_NEURON_CI", None) is not None:
 
 CACHE_REPO_NAME = "optimum-internal-testing/optimum-neuron-cache-for-testing"
 
-USE_VENV = False  # os.environ.get("USE_VENV", "true") == "true"
 
 
 class TPSupport(str, Enum):
@@ -78,100 +77,101 @@ class TPSupport(str, Enum):
     NONE = "none"
 
 
-class Priority(str, Enum):
+class Coverage(str, Enum):
     LOW = "low"
     MIDDLE = "middle"
     HIGH = "high"
     ALL = "all"
 
 
-PRIORITY = Priority(os.environ.get("PRIORITY", "all"))
+COVERAGE = Coverage(os.environ.get("COVERAGE", "all"))
 RUN_TINY = string_to_bool(os.environ.get("RUN_TINY", "false"))
+USE_VENV = string_to_bool(os.environ.get("USE_VENV", "true"))
 
 MODELS_TO_TEST_MAPPING = {
     "albert": (
         "albert-base-v2",
         TPSupport.NONE,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     "bart": (
         "facebook/bart-base",
         TPSupport.NONE,
-        Priority.MIDDLE,
+        Coverage.MIDDLE,
         {"encoder_layers": 2, "decoder_layers": 2},
     ),
     "bert": (
         "bert-base-uncased",
         TPSupport.FULL,
-        Priority.HIGH,
+        Coverage.HIGH,
         {"num_hidden_layers": 4},
     ),
     "camembert": (
         "camembert-base",
         TPSupport.NONE,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     "distilbert": (
         "distilbert-base-uncased",
         TPSupport.NONE,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     "electra": (
         "google/electra-base-discriminator",
         TPSupport.NONE,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     "gpt2": (
         "gpt2",
         TPSupport.NONE,
-        Priority.MIDDLE,
+        Coverage.MIDDLE,
         {"num_hidden_layers": 4},
     ),
     "gpt_neo": (
         "EleutherAI/gpt-neo-125M",
         TPSupport.PARTIAL,
-        Priority.HIGH,
+        Coverage.HIGH,
         {"num_hidden_layers": 4, "attention_types": [[["global", "local"], 2]]},
     ),
     "marian": (
         "Helsinki-NLP/opus-mt-en-ro",
         TPSupport.NONE,
-        Priority.MIDDLE,
+        Coverage.MIDDLE,
         {"encoder_layers": 2, "decoder_layers": 2},
     ),
     "roberta": (
         "roberta-base",
         TPSupport.PARTIAL,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     "t5": (
         "t5-small",
         TPSupport.FULL,
-        Priority.HIGH,
+        Coverage.HIGH,
         {"num_hidden_layers": 2},
     ),
     "vit": (
         "google/vit-base-patch16-224-in21k",
         TPSupport.NONE,
-        Priority.HIGH,
+        Coverage.HIGH,
         {"num_hidden_layers": 4},
     ),
     "xlm-roberta": (
         "xlm-roberta-base",
         TPSupport.NONE,
-        Priority.LOW,
+        Coverage.LOW,
         {"num_hidden_layers": 4},
     ),
     # TODO: issue with this model for now.
     "m2m_100": (
         "facebook/m2m100_418M",
         TPSupport.NONE,
-        Priority.MIDDLE,
+        Coverage.MIDDLE,
         {"encoder_layers": 2, "decoder_layers": 2},
     ),
     # TODO: Llama
@@ -190,10 +190,10 @@ def _get_supported_models_for_script(
         to_exclude = set()
     supported_models = []
     for model_type, entry in models_to_test.items():
-        model_name, tp_support, priority, config_overrides = entry
+        model_name, tp_support, coverage, config_overrides = entry
         if model_type in to_exclude:
             continue
-        if PRIORITY != "all" and PRIORITY != priority:
+        if COVERAGE != "all" and COVERAGE != coverage:
             continue
         if CONFIG_MAPPING[model_type] in task_mapping:
             if model_type == "bart" and task_mapping is not MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING:
@@ -368,7 +368,7 @@ class ExampleTestMeta(type):
                     zero_1=zero_1,
                     output_dir=tmpdirname,
                     # TODO: enable precompilation once it's working with subprocess.
-                    do_precompilation=False,
+                    do_precompilation=True,
                     print_outputs=True,
                 )
                 assert returncode == 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -349,7 +349,7 @@ class ExampleTestMeta(type):
             )
 
             with TemporaryDirectory() as tmpdirname:
-                returncode, stdout, _ = runner.run(
+                returncode, stdout = runner.run(
                     self.NUM_CORES,
                     "bf16",
                     train_batch_size,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -71,9 +71,7 @@ class TestExampleRunner(TestCase):
     @parameterized.expand(TO_TEST)
     def test_run_example(self, task, model_name_or_path, sequence_length):
         runner = ExampleRunner(model_name_or_path, task)
-        returncode, stdout = runner.run(
-            1, "bf16", 1, sequence_length=sequence_length, max_steps=10, save_steps=5
-        )
+        returncode, stdout = runner.run(1, "bf16", 1, sequence_length=sequence_length, max_steps=10, save_steps=5)
         print(stdout)
         if returncode != 0:
             self.fail(f"ExampleRunner failed for task {task}.\nStandard output:\n{stdout}")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -24,7 +24,7 @@ from optimum.neuron.utils.cache_utils import (
     load_custom_cache_repo_name_from_hf_home,
     set_custom_cache_repo_name_in_hf_home,
 )
-from optimum.neuron.utils.compilation_utils import ExampleRunner
+from optimum.neuron.utils.runner import ExampleRunner
 from optimum.neuron.utils.testing_utils import is_trainium_test
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -71,11 +71,9 @@ class TestExampleRunner(TestCase):
     @parameterized.expand(TO_TEST)
     def test_run_example(self, task, model_name_or_path, sequence_length):
         runner = ExampleRunner(model_name_or_path, task)
-        returncode, stdout, stderr = runner.run(
+        returncode, stdout = runner.run(
             1, "bf16", 1, sequence_length=sequence_length, max_steps=10, save_steps=5
         )
-        print(f"Standard output:\n{stdout}")
-        print("=" * 50)
-        print(f"Standard error:\n{stderr}")
+        print(stdout)
         if returncode != 0:
-            self.fail(f"ExampleRunner failed for task {task}.\nStandard output:\n{stdout}\nStandard error:\b{stderr}")
+            self.fail(f"ExampleRunner failed for task {task}.\nStandard output:\n{stdout}")

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -233,7 +233,7 @@ class StagingNeuronTrainerTestCase(StagingTestMixin, TestCase):
             ]
 
             start = time.time()
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
             end = time.time()
             first_training_duration = end - start
 
@@ -277,7 +277,7 @@ class StagingNeuronTrainerTestCase(StagingTestMixin, TestCase):
             ]
 
             start = time.time()
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
             end = time.time()
             second_training_duration = end - start
 
@@ -337,8 +337,8 @@ class NeuronTrainerTestCase(TestCase):
                 f"--fsdp={fsdp_mode}",
             ]
 
-            proc = subprocess.Popen(fsdp_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
+            proc = subprocess.Popen(fsdp_cmd)
+            proc.wait()
 
             checkpoint = output_1 / "checkpoint-50"
             output_2 = Path(tmpdirname) / "out_2"
@@ -362,8 +362,8 @@ class NeuronTrainerTestCase(TestCase):
                 f"--fsdp={fsdp_mode}",
             ]
 
-            proc = subprocess.Popen(resume_fsdp_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
+            proc = subprocess.Popen(resume_fsdp_cmd)
+            proc.wait()
 
             training_fsdp_metrics = {}
             with open(output_1 / "all_results.json") as fp:
@@ -398,8 +398,8 @@ class NeuronTrainerTestCase(TestCase):
                 f"--fsdp={fsdp_mode}",
             ]
 
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
+            proc = subprocess.Popen(cmd)
+            proc.wait()
 
             regular_training_metrics = {}
             with open(output_3 / "all_results.json") as fp:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,6 @@ from optimum.neuron.utils.cache_utils import (
 from optimum.utils.testing_utils import TOKEN, USER
 
 
-
 def get_random_string(length) -> str:
     letters = string.ascii_lowercase
     return "".join(random.choice(letters) for _ in range(length))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,26 +44,6 @@ from optimum.neuron.utils.cache_utils import (
 from optimum.utils.testing_utils import TOKEN, USER
 
 
-MODELS_TO_TEST_MAPPING = {
-    "albert": "albert-base-v2",
-    "bart": "facebook/bart-base",
-    "bert": "bert-base-uncased",
-    "camembert": "camembert-base",
-    "distilbert": "distilbert-base-uncased",
-    "electra": "google/electra-base-discriminator",
-    "gpt2": "gpt2",
-    "gpt_neo": "EleutherAI/gpt-neo-125M",
-    "marian": "Helsinki-NLP/opus-mt-en-ro",
-    "roberta": "roberta-base",
-    "t5": "t5-small",
-    "vit": "google/vit-base-patch16-224-in21k",
-    "xlm-roberta": "xlm-roberta-base",
-    # TODO: issue with this model for now.
-    "m2m_100": "facebook/m2m100_418M",
-    # "wav2vec2": "facebook/wav2vec2-base",
-    # Remaning: XLNet, Deberta-v2, MPNet, CLIP
-}
-
 
 def get_random_string(length) -> str:
     letters = string.ascii_lowercase


### PR DESCRIPTION
- [x] Updates `ExampleRunner` to make it both usable for Neuron cache filling and testing examples
- [x] Updates the `tests/test_examples.py` file
    * It is possible to run "tiny" versions of the models by setting the following flag `RUN_TINY=1`. It will run the example with the same model except that it contains much less blocks.
    * Each model, for a given task, is tested on different sharding strategies: no sharding, ZeRO-1, TP, TP + ZeRO-1 (when it makes sense)
    * Each model has a defined "coverage" associated to it: low, middle, high. By setting the flag `COVERAGE` it is possible to run test a subset of the models. The coverage of a model is defined by its uniqueness. Ideally running `tests/test_examples.py` with `COVERAGE=high` should cover most of the use cases.
- [x] Checks that the training loss is decreasing
- [x] Test example workflow is now triggered manually 

In following PRs:

- Validation is fixed and performed, each evaluation score is compared to a reference value, either hardcoded manually or computed by running a similar training job with Transformers on GPU.
- Enable ZeRO-1 tests once #222 is merged.