### PR TITLE
Remove experimental compilation flag for text-generation models

### DIFF
--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -206,9 +206,7 @@ class NeuronDecoderModel(OptimizedModel):
 
         # Compile the Neuron model (if present compiled artifacts will be reloaded instead of compiled)
         neuron_cc_flags = os.environ.get("NEURON_CC_FLAGS", "")
-        os.environ["NEURON_CC_FLAGS"] = (
-            neuron_cc_flags + " --model-type=transformer-inference --enable-experimental-O1"
-        )
+        os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags + " --model-type=transformer-inference"
         neuronx_model.to_neuron()
         os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags
 


### PR DESCRIPTION
Using the `--enable-experimental-01` flag speeds up the compilation, but also increases inference latency by 25 to 35 %.