### PR TITLE
Using the real model name instead of hard code "model"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ trainer = Trainer(
 You can compile and export your 🤗 Transformers models to a serialized format before inference on Neuron devices:
 
 ```bash
-optimum-cli export neuron 
+optimum-cli export neuron \
   --model distilbert-base-uncased-finetuned-sst-2-english \
   --batch_size 1 \
   --sequence_length 32 \

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -205,8 +205,9 @@ def main_export(
         neuron_config = neuron_config_constructor(model.config, dynamic_batch_size=dynamic_batch_size, **input_shapes)
         if atol is None:
             atol = neuron_config.ATOL_FOR_VALIDATION
-        output_model_names = {"model": "model.neuron"}
-        models_and_neuron_configs = {"model": (model, neuron_config)}
+        model_name = model.name_or_path.split("/")[-1]
+        output_model_names = {model_name: "model.neuron"}
+        models_and_neuron_configs = {model_name: (model, neuron_config)}
         maybe_save_preprocessors(model, output.parent)
 
     if is_stable_diffusion:

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -346,7 +346,7 @@ class NeuronConfig(ExportConfig, ABC):
             return ModelWrapper(model, list(dummy_inputs.keys()))
 
 
-class NeuronDecoderConfig(ExportConfig):
+class NeuronDecoderConfig(NeuronConfig):
     """
     Base class for configuring the export of Neuron Decoder models
 

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -346,7 +346,7 @@ class NeuronConfig(ExportConfig, ABC):
             return ModelWrapper(model, list(dummy_inputs.keys()))
 
 
-class NeuronDecoderConfig(NeuronConfig):
+class NeuronDecoderConfig(ExportConfig):
     """
     Base class for configuring the export of Neuron Decoder models
 


### PR DESCRIPTION
The model config using the hard code "model" as model name, which is not flexible and cannot distinct the real model. The fix used model.name_or_path property for the model name. Thanks~