### PR TITLE
Sequence parallelism

### DIFF
--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -64,6 +64,7 @@ else:
 
 if is_neuronx_distributed_available():
     from neuronx_distributed import parallel_layers
+    from neuronx_distributed.utils.model_utils import move_model_to_device
 
 
 logger = logging.get_logger(__name__)
@@ -336,7 +337,7 @@ class NeuronAccelerator(Accelerator):
 
             with ModelPatcher(patching_specs=[(model, "_tie_or_clone_weights", _tie_or_clone_weights_for_tp)]):
                 model.tie_weights()
-                parallel_layers.move_model_to_device(model, self.device)
+                move_model_to_device(model, self.device)
                 model.tie_weights()
             self._model_cpu_parameters_to_xla[id(model)] = dict(zip(cpu_ids, model.parameters()))
             device_placement = False

--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -322,7 +322,7 @@ class NeuronAccelerator(Accelerator):
         if not evaluation_mode:
             cpu_ids = [id(v) for v in model.parameters()]
             # TODO: enable self.device (if needed).
-            model = self.state.tp_plugin.parallelize_model(model, return_orig_to_parallel=False, device=None)
+            model = self.state.tp_plugin.parallelize_model(model, device=None)
             if os.environ.get("XLA_USE_BF16", "0") == "1":
                 model.to(torch.bfloat16)
             else:

--- a/optimum/neuron/accelerate/utils/dataclasses.py
+++ b/optimum/neuron/accelerate/utils/dataclasses.py
@@ -142,6 +142,7 @@ class NeuronFullyShardedDataParallelPlugin(FullyShardedDataParallelPlugin):
 class TensorParallelismPlugin:
     tensor_parallel_size: int = 1
     parallelize_embeddings: bool = True
+    sequence_parallel_enabled: bool = False
 
     def __post_init__(self):
         if self.tensor_parallel_size < 1:
@@ -154,18 +155,13 @@ class TensorParallelismPlugin:
     def parallelize_model(
         self,
         model: "PreTrainedModel",
-        return_orig_to_parallel: bool = False,
         device: Optional["torch.device"] = None,
     ) -> Union["PreTrainedModel", Tuple["PreTrainedModel", Dict[int, "torch.nn.Parameter"]]]:
-        orig_to_parallel = {} if return_orig_to_parallel else None
         parallelizer = ParallelizersManager.parallelizer_for_model(model)
         parallelized_model = parallelizer.parallelize(
             model,
-            orig_to_parallel=orig_to_parallel,
             device=device,
             parallelize_embeddings=self.parallelize_embeddings,
+            sequence_parallel_enabled=self.sequence_parallel_enabled,
         )
-        if return_orig_to_parallel:
-            return parallelized_model, orig_to_parallel
-        else:
-            return parallelized_model
+        return parallelized_model

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -287,9 +287,6 @@ class Parallelizer(ABC):
                 # `reset_parameters()` method.
                 mod.reset_parameters()
 
-            for name, p in model.named_parameters():
-                if p.dtype != torch.float32:
-                    print(name, p.dtype)
         return model
 
     @classmethod

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -245,7 +245,6 @@ class Parallelizer(ABC):
 
                 if parameter in tied_weights:
                     new_parameter = tied_weights[parameter]
-
                 elif weight_info is not None:
                     if getattr(current_weight, "tensor_model_parallel", False):
                         if parameter.device == torch.device("meta"):
@@ -274,6 +273,7 @@ class Parallelizer(ABC):
                     device = torch.device("cpu") if device is None else device
                     new_parameter = torch.nn.Parameter(torch.empty_like(current_weight, device=device))
                     modules_to_initialize.append(module)
+
                 setattr(
                     module,
                     attribute_name,

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -92,9 +92,9 @@ class Parallelizer(ABC):
     def _parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]] = None,
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         """
         Parallelizes the model by transforming regular layer into their parallel counterparts.
@@ -103,15 +103,13 @@ class Parallelizer(ABC):
         Args:
             model (`PreTrainedModel`):
                 The model to parallelize.
-            orig_to_parallel (`Optional[Dict[int, torch.nn.Parameter]]`, defaults to `None`):
-                A dictionary to fill. It maps a former parameter id to its parallel version.
-                It might be deprecated soon.
             device (`Optional[torch.device]`, defaults to `None`):
                 The device where the new parallel layers should be put.
             parallelize_embeddings (`bool`, defaults to `True`):
                 Whether or not the embeddings should be parallelized.
                 This can be disabled in the case when the TP size does not divide the vocabulary size.
-
+            sequence_parallel_enabled (`bool`, defaults to `False`):
+                Whether or not sequence parallelism is enabled.
         Returns:
             `PreTrainedModel`: The parallelized model.
         """
@@ -120,9 +118,9 @@ class Parallelizer(ABC):
     def parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]] = None,
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         """
         Parallelizes the model by transforming regular layer into their parallel counterparts using
@@ -134,20 +132,19 @@ class Parallelizer(ABC):
         Args:
             model (`PreTrainedModel`):
                 The model to parallelize.
-            orig_to_parallel (`Optional[Dict[int, torch.nn.Parameter]]`, defaults to `None`):
-                A dictionary to fill. It maps a former parameter id to its parallel version.
-                It might be deprecated soon.
             device (`Optional[torch.device]`, defaults to `None`):
                 The device where the new parallel layers should be put.
             parallelize_embeddings (`bool`, defaults to `True`):
                 Whether or not the embeddings should be parallelized.
                 This can be disabled in the case when the TP size does not divide the vocabulary size.
+            sequence_parallel_enabled (`bool`, defaults to `False`):
+                Whether or not sequence parallelism is enabled.
 
         Returns:
             `PreTrainedModel`: The parallelized model.
         """
         model = cls._parallelize(
-            model, orig_to_parallel=orig_to_parallel, device=device, parallelize_embeddings=parallelize_embeddings
+            model, device=device, parallelize_embeddings=parallelize_embeddings, sequence_parallel_enabled=sequence_parallel_enabled,
         )
         weight_map = getattr(model, "_weight_map", {})
         with torch.no_grad():

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -71,10 +71,6 @@ class Parallelizer(ABC):
 
     SEQUENCE_PARALLEL_LAYERNORM_PATTERNS: Optional[List[str]] = None
     LAYERNORM_TYPE: LayerNormType = LayerNormType.REGULAR
-    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE: Optional[Type["torch.nn.Module"]] = None
-    SCATTER_BEFORE_FIRST_LAYER: bool = True
-    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE: Optional[Type["torch.nn.Module"]] = None
-    GATHER_AFTER_LAST_LAYER: bool = True
     SEQUENCE_COLLECTIVE_OPS_INFOS: Optional[List[SequenceCollectiveOpInfo]] = None
 
     def __init__(self):

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractclassmethod
 from dataclasses import asdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import torch
 from transformers.utils import WEIGHTS_NAME
@@ -126,6 +126,10 @@ class Parallelizer(ABC):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        """
+        This method needs to be overriden. It must patch anything model-specfic to make it compatible with sequence
+        parallelism.
+        """
         if sequence_parallel_enabled:
             raise NotImplementedError(
                 f"No patching for the attention mechansim for sequence parallelism was implemented for {model.__class__}"

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -185,7 +185,8 @@ class Parallelizer(ABC):
         io_sequence_parallelizer.sequence_parallelize(model)
 
         # 3. Applying model specific patching for sequence parallelism.
-        cls.patch_for_sequence_paralelism(model, sequence_parallel_enabled)
+        if sequence_parallel_enabled:
+            cls.patch_for_sequence_paralelism(model, sequence_parallel_enabled)
 
         model = cls._parallelize(
             model,

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -127,8 +127,8 @@ class Parallelizer(ABC):
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
         """
-        This method needs to be overriden. It must patch anything model-specfic to make it compatible with sequence
-        parallelism.
+        This method needs to be overriden. It must patch anything model-specfic to make the model compatible with
+        sequence parallelism.
         """
         if sequence_parallel_enabled:
             raise NotImplementedError(

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -239,7 +239,7 @@ class Parallelizer(ABC):
                 current_weight = getattr(module, attribute_name)
 
                 try:
-                    weight_info = WeightInformation(weight_map[name], name, device=device)
+                    weight_info = WeightInformation(weight_map[name], name, weight_map=weight_map, device=device)
                 except KeyError:
                     weight_info = None
 
@@ -284,11 +284,6 @@ class Parallelizer(ABC):
                 # This module has not pre-trained weights, it must be fine-tuned, we initialize it with the
                 # `reset_parameters()` method.
                 mod.reset_parameters()
-
-            for name, p in model.named_parameters():
-                if p.device == torch.device("meta"):
-                    continue
-                    print("Name", name)
         return model
 
     @classmethod

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -27,7 +27,12 @@ from transformers.utils import WEIGHTS_NAME
 
 from ...utils import logging
 from ..utils import is_neuronx_distributed_available, is_torch_xla_available
-from .parallel_layers import IOSequenceParallelizer, LayerNormSequenceParallelizer, LayerNormType, SequenceCollectiveOpInfo
+from .parallel_layers import (
+    IOSequenceParallelizer,
+    LayerNormSequenceParallelizer,
+    LayerNormType,
+    SequenceCollectiveOpInfo,
+)
 from .utils import TENSOR_PARALLEL_SHARDS_DIR_NAME, ParameterMetadata, WeightInformation, load_tensor_for_weight
 
 
@@ -176,10 +181,6 @@ class Parallelizer(ABC):
         io_sequence_parallelizer = IOSequenceParallelizer(
             sequence_parallel_enabled,
             sequence_collective_op_infos=cls.SEQUENCE_COLLECTIVE_OPS_INFOS,
-            # scatter_sequence_at_first_layer_of_type=cls.SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE,
-            # scatter_before_first_layer=cls.SCATTER_BEFORE_FIRST_LAYER,
-            # gather_sequence_at_last_layer_of_type=cls.GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE,
-            # gather_after_last_layer=cls.GATHER_AFTER_LAST_LAYER,
         )
         io_sequence_parallelizer.sequence_parallelize(model)
 

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -267,7 +267,9 @@ class Parallelizer(ABC):
                     else:
                         slices = None
 
-                    new_parameter = torch.nn.Parameter(load_tensor_for_weight(weight_info, tensor_slices=slices))
+                    new_parameter = torch.nn.Parameter(
+                        load_tensor_for_weight(weight_info, tensor_slices=slices).to(parameter.dtype)
+                    )
                 else:
                     # This means that there is no information about where to find the weights for this parameter.
                     device = torch.device("cpu") if device is None else device
@@ -284,6 +286,10 @@ class Parallelizer(ABC):
                 # This module has not pre-trained weights, it must be fine-tuned, we initialize it with the
                 # `reset_parameters()` method.
                 mod.reset_parameters()
+
+            for name, p in model.named_parameters():
+                if p.dtype != torch.float32:
+                    print(name, p.dtype)
         return model
 
     @classmethod

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -160,7 +160,7 @@ class Parallelizer(ABC):
         """
         if sequence_parallel_enabled:
             raise NotImplementedError(
-                f"No patching for the attention mechansim for sequence parallelism was implemented for {model.__class__}"
+                f"No patching for the attention mechanism for sequence parallelism was implemented for {model.__class__}"
             )
 
     @classmethod

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -33,6 +33,7 @@ from .parallel_layers import (
     ParallelEmbedding,
     ParallelMLP,
     ParallelSelfAttention,
+    SequenceCollectiveOpInfo,
 )
 from .utils import linear_to_parallel_linear
 
@@ -68,8 +69,10 @@ class GPTNeoParallelizer(Parallelizer):
         "transformer.h.[0-9]+.ln_[1-2]",
         "transformer.ln_f",
     ]
-    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = GPTNeoBlock
-    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = torch.nn.LayerNorm
+    SEQUENCE_COLLECTIVE_OPS_INFOS = [
+        SequenceCollectiveOpInfo("scatter", GPTNeoBlock, "before", "first"),
+        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "after", "last"),
+    ]
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
@@ -197,8 +200,10 @@ class LlamaParallelizer(Parallelizer):
         "model.norm",
     ]
     LAYERNORM_TYPE = LayerNormType.RMS_NORM
-    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = LlamaDecoderLayer
-    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = LlamaRMSNorm
+    SEQUENCE_COLLECTIVE_OPS_INFOS = [
+        SequenceCollectiveOpInfo("scatter", LlamaDecoderLayer, "before", "first"),
+        SequenceCollectiveOpInfo("gather", LlamaRMSNorm, "after", "last"),
+    ]
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -78,12 +78,12 @@ class GPTNeoParallelizer(Parallelizer):
             tensor = tensor.view(new_shape)
             if sequence_parallel_enabled:
                 # [S, B, num_heads, head_dim] -> [B, num_heads, S, head_dim]
-                return tensor.permute(1, 2, 0, 3).contiguous()
+                return tensor.permute(1, 2, 0, 3)
             return tensor.permute(0, 2, 1, 3)
 
         def _merge_heads(self, tensor, num_heads, attn_head_size):
             if sequence_parallel_enabled:
-                # [B, num_heads, S, head_dim] -> [S, B, num_heads, hidden_dim]
+                # [B, num_heads, S, head_dim] -> [S, B, num_heads, head_dim]
                 tensor = tensor.permute(2, 0, 1, 3).contiguous()
             else:
                 tensor = tensor.permute(0, 2, 1, 3).contiguous()

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -209,8 +209,8 @@ class LlamaParallelizer(Parallelizer):
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
         import math
 
-        import nn.functional as F
         import torch
+        import torch.nn.functional as F
         from torch import nn
 
         def attention_forward(

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -70,8 +70,8 @@ class GPTNeoParallelizer(Parallelizer):
         "transformer.ln_f",
     ]
     SEQUENCE_COLLECTIVE_OPS_INFOS = [
-        SequenceCollectiveOpInfo("scatter", GPTNeoBlock, "before", "first"),
-        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "after", "last"),
+        SequenceCollectiveOpInfo("scatter", GPTNeoBlock, "input", "first"),
+        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "output", "last"),
     ]
 
     @classmethod
@@ -201,8 +201,8 @@ class LlamaParallelizer(Parallelizer):
     ]
     LAYERNORM_TYPE = LayerNormType.RMS_NORM
     SEQUENCE_COLLECTIVE_OPS_INFOS = [
-        SequenceCollectiveOpInfo("scatter", LlamaDecoderLayer, "before", "first"),
-        SequenceCollectiveOpInfo("gather", LlamaRMSNorm, "after", "last"),
+        SequenceCollectiveOpInfo("scatter", LlamaDecoderLayer, "input", "first"),
+        SequenceCollectiveOpInfo("gather", LlamaRMSNorm, "output", "last"),
     ]
 
     @classmethod

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -76,6 +76,9 @@ class GPTNeoParallelizer(Parallelizer):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        if not sequence_parallel_enabled:
+            return
+
         def _split_heads(self, tensor, num_heads, attn_head_size):
             new_shape = tensor.size()[:-1] + (num_heads, attn_head_size)
             tensor = tensor.view(new_shape)
@@ -207,6 +210,9 @@ class LlamaParallelizer(Parallelizer):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        if not sequence_parallel_enabled:
+            return
+
         import math
 
         import torch

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 """Classes related to `neuronx-distributed` to perform parallelism."""
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 from .base import Parallelizer
 from .parallel_layers import ParallelCrossEntropy, ParallelEmbedding, ParallelMLP, ParallelSelfAttention
-from .utils import linear_to_parallel_linear
+from .utils import create_sequence_parallel_attention_forward, linear_to_parallel_linear
 
 
 if TYPE_CHECKING:
@@ -49,25 +49,59 @@ class GPTNeoParallelCrossEntropy(ParallelCrossEntropy):
 
 
 class GPTNeoParallelizer(Parallelizer):
+    SEQUENCE_PARALLEL_LAYERNORM_PATTERNS = [
+        "transformer.h.[0-9]+.ln_[1-2]",
+        "transformer.ln_f",
+    ]
+
+    @classmethod
+    def patch_attention_forward_for_sequence_parallelism(
+        cls, model: "PreTrainedModel", sequence_parallel_enabled: bool
+    ):
+        from transformers.models.gpt_neo.modeling_gpt_neo import GPTNeoSelfAttention
+
+        def _split_heads(self, tensor, num_heads, attn_head_size):
+            new_shape = tensor.size()[:-1] + (num_heads, attn_head_size)
+            tensor = tensor.view(new_shape)
+            if sequence_parallel_enabled:
+                # [S, B, num_heads, head_dim] -> [B, num_heads, S, head_dim] 
+                return tensor.permute(1, 2, 0, 3).contiguous()
+            return tensor.permute(0, 2, 1, 3)  
+
+        def _merge_heads(self, tensor, num_heads, attn_head_size):
+            if sequence_parallel_enabled:
+                # [B, num_heads, S, head_dim] -> [S, B, num_heads, hidden_dim]
+                tensor = tensor.permute(2, 0, 1, 3).contiguous()
+            else:
+                tensor = tensor.permute(0, 2, 1, 3).contiguous()
+            new_shape = tensor.size()[:-2] + (num_heads * attn_head_size,)
+            return tensor.view(new_shape)
+
+        for module in model.modules():
+            if isinstance(module, GPTNeoSelfAttention):
+                module._split_heads = _split_heads.__get__(module)
+                module._merge_heads = _merge_heads.__get__(module)
+
     @classmethod
     def _parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]],
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         if parallelize_embeddings:
-            model = GPTNeoParallelEmbedding.transform(model, model, device=device)
+            model = GPTNeoParallelEmbedding.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         for block in model.transformer.h:
             block.attn.attention = GPTNeoParallelSelfAttention.transform(
                 model,
                 block.attn.attention,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
-            block.mlp = GPTNeoParallelMLP.transform(model, block.mlp, device=device)
+            block.mlp = GPTNeoParallelMLP.transform(model, block.mlp, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         if parallelize_embeddings:
-            model = GPTNeoParallelCrossEntropy.transform(model, model, device=device)
+            model = GPTNeoParallelCrossEntropy.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         return model
 
 
@@ -96,12 +130,12 @@ class LLamaParallelMLP(ParallelMLP):
         cls,
         model: "PreTrainedModel",
         layer: "torch.nn.Module",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]] = None,
+        sequence_parallel_enabled: bool = False,
         device: Optional["torch.device"] = None,
     ) -> "torch.nn.Module":
         # TODO: Make it smart by merging the gate and the up_proj.
         # WARNING: be careful of the interleaved outputs when doing TP!
-        layer = super().transform(model, layer, orig_to_parallel=orig_to_parallel, device=device)
+        layer = super().transform(model, layer, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
 
         weight_map = getattr(model, "_weight_map", None)
 
@@ -126,7 +160,7 @@ class LLamaParallelMLP(ParallelMLP):
                 gather_output=False,
                 linear_layer_weight_info=linear_layer_weight_info,
                 linear_layer_bias_weight_info=linear_layer_bias_weight_info,
-                orig_to_parallel=orig_to_parallel,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             ),
         )
@@ -138,19 +172,147 @@ class LlamaParallelCrossEntropy(ParallelCrossEntropy):
 
 
 class LlamaParallelizer(Parallelizer):
+    SEQUENCE_PARALLEL_LAYERNORM_PATTERNS = [
+        "model.layers.[0-9]+.input_layernorm",
+        "model.layers.[0-9]+.post_attention_layernorm",
+        "model.norm",
+    ]
+
+    @classmethod
+    def patch_attention_forward_for_sequence_parallelism(
+        cls, model: "PreTrainedModel", sequence_parallel_enabled: bool
+    ):
+        from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb, repeat_kv
+        import torch.nn.functional as F
+        from torch import nn
+        import math
+
+        def forward(
+            self,
+            hidden_states: "torch.Tensor",
+            attention_mask: Optional["torch.Tensor"] = None,
+            position_ids: Optional["torch.LongTensor"] = None,
+            past_key_value: Optional[Tuple["torch.Tensor"]] = None,
+            output_attentions: bool = False,
+            use_cache: bool = False,
+        ) -> Tuple["torch.Tensor", Optional["torch.Tensor"], Optional[Tuple["torch.Tensor"]]]:
+            if sequence_parallel_enabled:
+                q_len, bsz, _ = hidden_states.size()
+            else:
+                bsz, q_len, _ = hidden_states.size()
+            print(hidden_states.size())
+
+            if self.config.pretraining_tp > 1:
+                key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.config.pretraining_tp
+                query_slices = self.q_proj.weight.split(
+                    (self.num_heads * self.head_dim) // self.config.pretraining_tp, dim=0
+                )
+                key_slices = self.k_proj.weight.split(key_value_slicing, dim=0)
+                value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
+
+                query_states = [F.linear(hidden_states, query_slices[i]) for i in range(self.config.pretraining_tp)]
+                query_states = torch.cat(query_states, dim=-1)
+
+                key_states = [F.linear(hidden_states, key_slices[i]) for i in range(self.config.pretraining_tp)]
+                key_states = torch.cat(key_states, dim=-1)
+
+                value_states = [F.linear(hidden_states, value_slices[i]) for i in range(self.config.pretraining_tp)]
+                value_states = torch.cat(value_states, dim=-1)
+
+            else:
+                query_states = self.q_proj(hidden_states)
+                key_states = self.k_proj(hidden_states)
+                value_states = self.v_proj(hidden_states)
+
+            if sequence_parallel_enabled:
+                # [S, B, hidden_dim] -> [S, B, num_heads, head_dim] -> [B, num_heads, S, head_dim]
+                query_states = query_states.view(q_len, bsz, self.num_heads, self.head_dim).permute(2, 0, 1, 3)
+                key_states = key_states.view(q_len, bsz, self.num_key_value_heads, self.head_dim).permute(2, 0, 1, 3)
+                value_states = value_states.view(q_len, bsz, self.num_key_value_heads, self.head_dim).permute(2, 0, 1, 3)
+            else:
+                query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+                key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+                value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+            kv_seq_len = key_states.shape[-2]
+            if past_key_value is not None:
+                kv_seq_len += past_key_value[0].shape[-2]
+            cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+
+            if past_key_value is not None:
+                # reuse k, v, self_attention
+                key_states = torch.cat([past_key_value[0], key_states], dim=2)
+                value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+            past_key_value = (key_states, value_states) if use_cache else None
+
+            # repeat k/v heads if n_kv_heads < n_heads
+            key_states = repeat_kv(key_states, self.num_key_value_groups)
+            value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+            attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+            if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
+                    f" {attn_weights.size()}"
+                )
+
+            if attention_mask is not None:
+                if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                    raise ValueError(
+                        f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                    )
+                attn_weights = attn_weights + attention_mask
+
+            # upcast attention to fp32
+            attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attn_output = torch.matmul(attn_weights, value_states)
+
+            if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+                raise ValueError(
+                    f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                    f" {attn_output.size()}"
+                )
+
+            attn_output = attn_output.transpose(1, 2).contiguous()
+            attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+            if self.config.pretraining_tp > 1:
+                attn_output = attn_output.split(self.hidden_size // self.config.pretraining_tp, dim=2)
+                o_proj_slices = self.o_proj.weight.split(self.hidden_size // self.config.pretraining_tp, dim=1)
+                attn_output = sum([F.linear(attn_output[i], o_proj_slices[i]) for i in range(self.config.pretraining_tp)])
+            else:
+                attn_output = self.o_proj(attn_output)
+
+            if not output_attentions:
+                attn_weights = None
+
+            if sequence_parallel_enabled:
+                # [B, S, hidden_dim] -> [S, B, hidden_dim]
+                attn_output = attn_output.transpose(0, 1)
+
+            return attn_output, attn_weights, past_key_value
+
+
+        for module in model.modules():
+            if isinstance(module, LlamaAttention):
+                module.forward = forward.__get__(module)
+
     @classmethod
     def _parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]],
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         if parallelize_embeddings:
-            model = LlamaParallelEmbedding.transform(model, model, device=device)
+            model = LlamaParallelEmbedding.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         for layer in model.model.layers:
-            layer.self_attn = LlamaParallelSelfAttention.transform(model, layer.self_attn, device=device)
-            layer.mlp = LLamaParallelMLP.transform(model, layer.mlp, device=device)
+            layer.self_attn = LlamaParallelSelfAttention.transform(model, layer.self_attn, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
+            layer.mlp = LLamaParallelMLP.transform(model, layer.mlp, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         if parallelize_embeddings:
-            model = LlamaParallelCrossEntropy.transform(model, model, device=device)
+            model = LlamaParallelCrossEntropy.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         return model

--- a/optimum/neuron/distributed/encoder_decoder_models.py
+++ b/optimum/neuron/distributed/encoder_decoder_models.py
@@ -14,14 +14,21 @@
 # limitations under the License.
 """Classes related to `neuronx-distributed` to perform parallelism."""
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
-from transformers.models.t5.modeling_t5 import T5ForSequenceClassification, T5Attention, T5LayerNorm
+from transformers.models.t5.modeling_t5 import T5Attention, T5ForSequenceClassification, T5LayerNorm
 
 from ...utils import NormalizedConfigManager
 from .base import Parallelizer
-from .parallel_layers import LayerNormType, ParallelCrossEntropy, ParallelEmbedding, ParallelMLP, ParallelSelfAttention, SequenceCollectiveOpInfo
+from .parallel_layers import (
+    LayerNormType,
+    ParallelCrossEntropy,
+    ParallelEmbedding,
+    ParallelMLP,
+    ParallelSelfAttention,
+    SequenceCollectiveOpInfo,
+)
 from .utils import linear_to_parallel_linear
 
 
@@ -306,7 +313,6 @@ class T5Parallelizer(Parallelizer):
             if isinstance(module, T5Attention):
                 module.forward = sequence_parallel_forward.__get__(module)
 
-
     @classmethod
     def _parallelize(
         cls,
@@ -351,8 +357,13 @@ class T5Parallelizer(Parallelizer):
                 device=device,
             )
             block.layer[2].DenseReluDense = T5ParallelMLP.transform(
-                model, block.layer[2].DenseReluDense, sequence_parallel_enabled=sequence_parallel_enabled, device=device
-                )
+                model,
+                block.layer[2].DenseReluDense,
+                sequence_parallel_enabled=sequence_parallel_enabled,
+                device=device,
+            )
         if parallelize_embeddings:
-            model = T5ParallelCrossEntropy.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
+            model = T5ParallelCrossEntropy.transform(
+                model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device
+            )
         return model

--- a/optimum/neuron/distributed/encoder_decoder_models.py
+++ b/optimum/neuron/distributed/encoder_decoder_models.py
@@ -170,6 +170,9 @@ class T5Parallelizer(Parallelizer):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        if not sequence_parallel_enabled:
+            return
+
         from torch import nn
 
         def sequence_parallel_forward(
@@ -350,7 +353,7 @@ class T5Parallelizer(Parallelizer):
                 sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
-            block.layer[0].SelfAttention = T5ParallelSelfAttention.transform(
+            block.layer[1].EncDecAttention = T5ParallelSelfAttention.transform(
                 model,
                 block.layer[1].EncDecAttention,
                 sequence_parallel_enabled=sequence_parallel_enabled,

--- a/optimum/neuron/distributed/encoder_decoder_models.py
+++ b/optimum/neuron/distributed/encoder_decoder_models.py
@@ -17,11 +17,11 @@
 from typing import TYPE_CHECKING, Dict, Optional
 
 import torch
-from transformers import T5ForSequenceClassification
+from transformers.models.t5.modeling_t5 import T5ForSequenceClassification, T5Attention, T5LayerNorm
 
 from ...utils import NormalizedConfigManager
 from .base import Parallelizer
-from .parallel_layers import ParallelCrossEntropy, ParallelEmbedding, ParallelMLP, ParallelSelfAttention
+from .parallel_layers import LayerNormType, ParallelCrossEntropy, ParallelEmbedding, ParallelMLP, ParallelSelfAttention, SequenceCollectiveOpInfo
 from .utils import linear_to_parallel_linear
 
 
@@ -47,8 +47,8 @@ class T5ParallelSelfAttention(ParallelSelfAttention):
         cls,
         model: "PreTrainedModel",
         layer: "torch.nn.Module",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]] = None,
         device: Optional["torch.device"] = None,
+        sequence_parallel_enabled: bool = False,
     ) -> "torch.nn.Module":
         from neuronx_distributed.parallel_layers.parallel_state import (
             get_tensor_model_parallel_rank,
@@ -77,7 +77,7 @@ class T5ParallelSelfAttention(ParallelSelfAttention):
                 layer.relative_attention_bias.num_embeddings = num_attention_heads_per_rank
                 set_tensor_model_parallel_attributes(layer.relative_attention_bias.weight, True, 1, stride=1)
 
-        layer = super().transform(model, layer, orig_to_parallel=orig_to_parallel, device=device)
+        layer = super().transform(model, layer, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
 
         return layer
 
@@ -91,7 +91,7 @@ class T5ParallelMLP(ParallelMLP):
         cls,
         model: "PreTrainedModel",
         layer: "torch.nn.Module",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]] = None,
+        sequence_parallel_enabled: bool = False,
         device: Optional["torch.device"] = None,
     ) -> "torch.nn.Module":
         from transformers.models.t5.modeling_t5 import T5DenseGatedActDense
@@ -106,7 +106,7 @@ class T5ParallelMLP(ParallelMLP):
             cls.FIRST_LINEAR_NAME = f"{orig_first_linear_name}_0"
 
         # This will parallelize both wi_0 and wo.
-        layer = super().transform(model, layer, orig_to_parallel=orig_to_parallel, device=device)
+        layer = super().transform(model, layer, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
 
         if isinstance(layer, T5DenseGatedActDense):
             # In this case, only wi_1 remains to be parallelized, we do it here.
@@ -133,7 +133,7 @@ class T5ParallelMLP(ParallelMLP):
                     gather_output=False,
                     linear_layer_weight_info=linear_layer_weight_info,
                     linear_layer_bias_weight_info=linear_layer_bias_weight_info,
-                    orig_to_parallel=orig_to_parallel,
+                    sequence_parallel_enabled=sequence_parallel_enabled,
                     device=device,
                 ),
             )
@@ -148,13 +148,181 @@ class T5ParallelCrossEntropy(ParallelCrossEntropy):
 
 
 class T5Parallelizer(Parallelizer):
+    SEQUENCE_PARALLEL_LAYERNORM_PATTERNS = [
+        "encoder.block.[0-9]+.layer.[0-9]+.layer_norm",
+        "encoder.final_layer_norm",
+        "decoder.block.[0-9]+.layer.[0-9]+.layer_norm",
+        "decoder.final_layer_norm",
+    ]
+
+    LAYERNORM_TYPE = LayerNormType.RMS_NORM
+    SEQUENCE_COLLECTIVE_OPS_INFOS = [
+        SequenceCollectiveOpInfo(torch.nn.Embedding, "first", "
+
+    ]
+    # SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = torch.nn.Embedding
+    # # Scattering needs to happen before the embeddings computations.
+    # SCATTER_BEFORE_FIRST_LAYER = False 
+    # GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = T5LayerNorm 
+
+    @classmethod
+    def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        from torch import nn
+
+        def sequence_parallel_forward(
+            self,
+            hidden_states,
+            mask=None,
+            key_value_states=None,
+            position_bias=None,
+            past_key_value=None,
+            layer_head_mask=None,
+            query_length=None,
+            use_cache=False,
+            output_attentions=False,
+        ):
+            # Input is (batch_size, seq_length, dim)
+            # Mask is (batch_size, key_length) (non-causal) or (batch_size, key_length, key_length)
+            # past_key_value[0] is (batch_size, n_heads, q_len - 1, dim_per_head)
+            if sequence_parallel_enabled:
+                batch_size = hidden_states.shape[1]
+            else:
+                batch_size = hidden_states.shape[0]
+
+
+            def shape(states):
+                """projection"""
+                if sequence_parallel_enabled:
+                    return states.view(-1, batch_size, self.n_heads, self.key_value_proj_dim).permute(1, 2, 0, 3)
+                return states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+
+            def unshape(states):
+                """reshape"""
+                if sequence_parallel_enabled:
+                    return states.permute(2, 0, 1, 3).view(-1, batch_size, self.inner_dim)
+                return states.transpose(1, 2).contiguous().view(batch_size, -1, self.inner_dim)
+
+            def project(hidden_states, proj_layer, key_value_states, past_key_value):
+                """projects hidden states correctly to key/query states"""
+                if key_value_states is None:
+                    # self-attn
+                    # (batch_size, n_heads, seq_length, dim_per_head)
+                    hidden_states = shape(proj_layer(hidden_states))
+                elif past_key_value is None:
+                    # cross-attn
+                    # (batch_size, n_heads, seq_length, dim_per_head)
+                    hidden_states = shape(proj_layer(key_value_states))
+
+                if past_key_value is not None:
+                    if key_value_states is None:
+                        # self-attn
+                        # (batch_size, n_heads, key_length, dim_per_head)
+                        if sequence_parallel_enabled:
+                            hidden_states = torch.cat([past_key_value, hidden_states.transpose(0, 1)], dim=2)
+                        else:
+                            hidden_states = torch.cat([past_key_value, hidden_states], dim=2)
+                    elif past_key_value.shape[2] != key_value_states.shape[1]:
+                        # checking that the `sequence_length` of the `past_key_value` is the same as
+                        # the provided `key_value_states` to support prefix tuning
+                        # cross-attn
+                        # (batch_size, n_heads, seq_length, dim_per_head)
+                        hidden_states = shape(proj_layer(key_value_states))
+                    else:
+                        # cross-attn
+                        hidden_states = past_key_value
+                return hidden_states
+
+            # get query states
+            query_states = shape(self.q(hidden_states))  # (batch_size, n_heads, seq_length, dim_per_head)
+
+            # get key/value states
+            key_states = project(
+                hidden_states, self.k, key_value_states, past_key_value[0] if past_key_value is not None else None
+            )
+            value_states = project(
+                hidden_states, self.v, key_value_states, past_key_value[1] if past_key_value is not None else None
+            )
+
+            real_seq_length = key_states.shape[2]
+
+            if past_key_value is not None:
+                if len(past_key_value) != 2:
+                    raise ValueError(
+                        f"past_key_value should have 2 past states: keys and values. Got { len(past_key_value)} past states"
+                    )
+                real_seq_length += past_key_value[0].shape[2] if query_length is None else query_length
+
+            # if sequence_parallel_enabled:
+            #     key_length = real_seq_length if key_value_states is None else key_value_states.shape[0]
+            # else:
+            print("Key value states shape", key_value_states.shape if key_value_states is not None  else None, key_states.shape)
+            key_length = real_seq_length if key_value_states is None else key_value_states.shape[1]
+
+            # compute scores
+            scores = torch.matmul(
+                query_states, key_states.transpose(3, 2)
+            )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
+
+            if position_bias is None:
+                if not self.has_relative_attention_bias:
+                    position_bias = torch.zeros(
+                        (1, self.n_heads, real_seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    )
+                    if self.gradient_checkpointing and self.training:
+                        position_bias.requires_grad = True
+                else:
+                    position_bias = self.compute_bias(real_seq_length, key_length, device=scores.device)
+
+                # if key and values are already calculated
+                # we want only the last query position bias
+                if past_key_value is not None:
+                    position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
+
+                if mask is not None:
+                    print(position_bias.shape, mask.shape)
+                    position_bias = position_bias + mask  # (batch_size, n_heads, seq_length, key_length)
+
+            if self.pruned_heads:
+                mask = torch.ones(position_bias.shape[1])
+                mask[list(self.pruned_heads)] = 0
+                position_bias_masked = position_bias[:, mask.bool()]
+            else:
+                position_bias_masked = position_bias
+
+            scores += position_bias_masked
+            attn_weights = nn.functional.softmax(scores.float(), dim=-1).type_as(
+                scores
+            )  # (batch_size, n_heads, seq_length, key_length)
+            attn_weights = nn.functional.dropout(
+                attn_weights, p=self.dropout, training=self.training
+            )  # (batch_size, n_heads, seq_length, key_length)
+
+            # Mask heads if we want to
+            if layer_head_mask is not None:
+                attn_weights = attn_weights * layer_head_mask
+
+            attn_output = unshape(torch.matmul(attn_weights, value_states))  # (batch_size, seq_length, dim)
+            attn_output = self.o(attn_output)
+
+            present_key_value_state = (key_states, value_states) if (self.is_decoder and use_cache) else None
+            outputs = (attn_output,) + (present_key_value_state,) + (position_bias,)
+
+            if output_attentions:
+                outputs = outputs + (attn_weights,)
+            return outputs
+
+        for module in model.modules():
+            if isinstance(module, T5Attention):
+                module.forward = sequence_parallel_forward.__get__(module)
+
+
     @classmethod
     def _parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]],
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         if isinstance(model, T5ForSequenceClassification):
             raise NotImplementedError(
@@ -172,6 +340,7 @@ class T5Parallelizer(Parallelizer):
             block.layer[0].SelfAttention = T5ParallelSelfAttention.transform(
                 model,
                 block.layer[0].SelfAttention,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
             block.layer[1].DenseReluDense = T5ParallelMLP.transform(
@@ -181,11 +350,12 @@ class T5Parallelizer(Parallelizer):
             block.layer[0].SelfAttention = T5ParallelSelfAttention.transform(
                 model,
                 block.layer[0].SelfAttention,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
             block.layer[2].DenseReluDense = T5ParallelMLP.transform(
-                model, block.layer[2].DenseReluDense, device=device
-            )
+                model, block.layer[2].DenseReluDense, sequence_parallel_enabled=sequence_parallel_enabled, device=device
+                )
         if parallelize_embeddings:
-            model = T5ParallelCrossEntropy.transform(model, model, device=device)
+            model = T5ParallelCrossEntropy.transform(model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device)
         return model

--- a/optimum/neuron/distributed/encoder_decoder_models.py
+++ b/optimum/neuron/distributed/encoder_decoder_models.py
@@ -164,8 +164,8 @@ class T5Parallelizer(Parallelizer):
 
     LAYERNORM_TYPE = LayerNormType.RMS_NORM
     SEQUENCE_COLLECTIVE_OPS_INFOS = [
-        SequenceCollectiveOpInfo("scatter", torch.nn.Embedding, "after", "first"),
-        SequenceCollectiveOpInfo("gather", T5LayerNorm, "after", "last"),
+        SequenceCollectiveOpInfo("scatter", torch.nn.Embedding, "output", "first"),
+        SequenceCollectiveOpInfo("gather", T5LayerNorm, "output", "last"),
     ]
 
     @classmethod

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -75,6 +75,8 @@ class BertParallelizer(Parallelizer):
         "bert.encoder.layer.[0-9]+.attention.output.LayerNorm",
         "bert.encoder.layer.[0-9]+.output.LayerNorm",
     ]
+    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = torch.nn.LayerNorm
+    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = torch.nn.LayerNorm
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
@@ -156,6 +158,8 @@ class RobertaParallelizer(Parallelizer):
         "roberta.encoder.layer.[0-9]+.attention.output.LayerNorm",
         "roberta.encoder.layer.[0-9]+.output.LayerNorm",
     ]
+    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = torch.nn.LayerNorm
+    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = torch.nn.LayerNorm
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -77,9 +77,7 @@ class BertParallelizer(Parallelizer):
     ]
 
     @classmethod
-    def patch_attention_forward_for_sequence_parallelism(
-        cls, model: "PreTrainedModel", sequence_parallel_enabled: bool
-    ):
+    def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
         from transformers.models.bert.modeling_bert import BertSelfAttention
 
         def transpose_for_scores(self, x: "torch.Tensor") -> "torch.Tensor":
@@ -160,9 +158,7 @@ class RobertaParallelizer(Parallelizer):
     ]
 
     @classmethod
-    def patch_attention_forward_for_sequence_parallelism(
-        cls, model: "PreTrainedModel", sequence_parallel_enabled: bool
-    ):
+    def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
         from transformers.models.roberta.modeling_roberta import RobertaSelfAttention
 
         def transpose_for_scores(self, x: "torch.Tensor") -> "torch.Tensor":

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Classes related to `neuronx-distributed` to perform parallelism."""
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ..utils.require_utils import requires_neuronx_distributed
 from .base import Parallelizer
@@ -166,31 +166,75 @@ class RobertaParallelCrossEntropy(ParallelCrossEntropy):
 
 
 class RobertaParallelizer(Parallelizer):
+    SEQUENCE_PARALLEL_LAYERNORM_PATTERNS = [
+        "roberta.embeddings.LayerNorm",
+        "roberta.encoder.layer.[0-9]+.attention.output.LayerNorm",
+        "roberta.encoder.layer.[0-9]+.output.LayerNorm",
+    ]
+
+    @classmethod
+    def patch_attention_forward_for_sequence_parallelism(
+        cls, model: "PreTrainedModel", sequence_parallel_enabled: bool
+    ):
+        from transformers.models.roberta.modeling_roberta import RobertaSelfAttention
+
+        def create_sequence_parallel_attention_forward(attention_forward):
+            import functools
+
+            @functools.wraps(attention_forward)
+            def sequence_parallel_attention_forward(self, *args, **kwargs):
+                outputs = attention_forward(*args, **kwargs)
+                context_layer = outputs[0]
+                if sequence_parallel_enabled:
+                    # [B, S, hidden_dim] -> [S, B, hidden_dim]
+                    context_layer = context_layer.transpose(0, 1)
+                return (context_layer,) + outputs[1:]
+
+            return sequence_parallel_attention_forward.__get__(attention_forward.__self__)
+
+        def transpose_for_scores(self, x: "torch.Tensor") -> "torch.Tensor":
+            new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
+            x = x.view(new_x_shape)
+            print("IS SEQUENCE", sequence_parallel_enabled)
+            if sequence_parallel_enabled:
+                # [S, B, num_heads, head_dim] -> [B, num_heads, S, head_dim]
+                return x.permute(1, 2, 0, 3)
+            return x.permute(0, 2, 1, 3)
+
+        for module in model.modules():
+            if isinstance(module, RobertaSelfAttention):
+                module.forward = create_sequence_parallel_attention_forward(module.forward)
+                module.transpose_for_scores = transpose_for_scores.__get__(module)
+
     @classmethod
     def _parallelize(
         cls,
         model: "PreTrainedModel",
-        orig_to_parallel: Optional[Dict[int, "torch.nn.Parameter"]],
         device: Optional["torch.device"] = None,
         parallelize_embeddings: bool = True,
+        sequence_parallel_enabled: bool = False,
     ) -> "PreTrainedModel":
         if parallelize_embeddings:
-            model = RobertaParallelEmbedding.transform(model, model, device=device)
+            model = RobertaParallelEmbedding.transform(
+                model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device
+            )
         for layer in model.roberta.encoder.layer:
             layer.attention.self = RobertaParallelSelfAttention.transform(
                 model,
                 layer.attention.self,
-                orig_to_parallel=orig_to_parallel,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
             layer.attention.output = RobertaParallelSelfOutput.transform(
                 model,
                 layer.attention.output,
-                orig_to_parallel=orig_to_parallel,
+                sequence_parallel_enabled=sequence_parallel_enabled,
                 device=device,
             )
         # Valid because we currently parallelize the cross-entropy loss only for language-modeling tasks where the
         # embeddings and the LM head are tied.
         if parallelize_embeddings:
-            model = RobertaParallelCrossEntropy.transform(model, model, device=device)
+            model = RobertaParallelCrossEntropy.transform(
+                model, model, sequence_parallel_enabled=sequence_parallel_enabled, device=device
+            )
         return model

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -16,6 +16,8 @@
 
 from typing import TYPE_CHECKING, Optional
 
+import torch
+
 from ..utils.require_utils import requires_neuronx_distributed
 from .base import Parallelizer
 from .parallel_layers import ParallelCrossEntropy, ParallelEmbedding, ParallelSelfAttention, ParallelSelfOutput
@@ -23,7 +25,6 @@ from .utils import create_sequence_parallel_attention_forward
 
 
 if TYPE_CHECKING:
-    import torch
     from transformers import PreTrainedModel
 
 

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -20,7 +20,13 @@ import torch
 
 from ..utils.require_utils import requires_neuronx_distributed
 from .base import Parallelizer
-from .parallel_layers import ParallelCrossEntropy, ParallelEmbedding, ParallelSelfAttention, ParallelSelfOutput
+from .parallel_layers import (
+    ParallelCrossEntropy,
+    ParallelEmbedding,
+    ParallelSelfAttention,
+    ParallelSelfOutput,
+    SequenceCollectiveOpInfo,
+)
 from .utils import create_sequence_parallel_attention_forward
 
 
@@ -76,8 +82,10 @@ class BertParallelizer(Parallelizer):
         "bert.encoder.layer.[0-9]+.attention.output.LayerNorm",
         "bert.encoder.layer.[0-9]+.output.LayerNorm",
     ]
-    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = torch.nn.LayerNorm
-    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = torch.nn.LayerNorm
+    SEQUENCE_COLLECTIVE_OPS_INFOS = [
+        SequenceCollectiveOpInfo("scatter", torch.nn.LayerNorm, "before", "first"),
+        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "after", "last"),
+    ]
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
@@ -159,8 +167,10 @@ class RobertaParallelizer(Parallelizer):
         "roberta.encoder.layer.[0-9]+.attention.output.LayerNorm",
         "roberta.encoder.layer.[0-9]+.output.LayerNorm",
     ]
-    SCATTER_SEQUENCE_AT_FIRST_LAYER_OF_TYPE = torch.nn.LayerNorm
-    GATHER_SEQUENCE_AT_LAST_LAYER_OF_TYPE = torch.nn.LayerNorm
+    SEQUENCE_COLLECTIVE_OPS_INFOS = [
+        SequenceCollectiveOpInfo("scatter", torch.nn.LayerNorm, "before", "first"),
+        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "after", "last"),
+    ]
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -98,7 +98,7 @@ class BertParallelizer(Parallelizer):
     ]
     SEQUENCE_COLLECTIVE_OPS_INFOS = [
         SequenceCollectiveOpInfo("scatter", torch.nn.LayerNorm, "input", "first"),
-        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "output", "last"),
+        SequenceCollectiveOpInfo("gather", "bert.encoder.layer.[0-9]+.output.LayerNorm", "output", "last"),
     ]
 
     @classmethod
@@ -188,7 +188,7 @@ class RobertaParallelizer(Parallelizer):
     ]
     SEQUENCE_COLLECTIVE_OPS_INFOS = [
         SequenceCollectiveOpInfo("scatter", torch.nn.LayerNorm, "input", "first"),
-        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "output", "last"),
+        SequenceCollectiveOpInfo("gather", "roberta.encoder.layer.[0-9]+.output.LayerNorm", "output", "last"),
     ]
 
     @classmethod

--- a/optimum/neuron/distributed/encoder_models.py
+++ b/optimum/neuron/distributed/encoder_models.py
@@ -103,6 +103,9 @@ class BertParallelizer(Parallelizer):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        if not sequence_parallel_enabled:
+            return
+
         from transformers.models.bert.modeling_bert import BertSelfAttention
 
         def transpose_for_scores(self, x: "torch.Tensor") -> "torch.Tensor":
@@ -190,6 +193,9 @@ class RobertaParallelizer(Parallelizer):
 
     @classmethod
     def patch_for_sequence_paralelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
+        if not sequence_parallel_enabled:
+            return
+
         from transformers.models.roberta.modeling_roberta import RobertaSelfAttention
 
         def transpose_for_scores(self, x: "torch.Tensor") -> "torch.Tensor":

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -902,7 +902,7 @@ class LayerNormSequenceParallelizer:
         _set_sequence_parallel_enabled(module.weight, self.sequence_parallel_enabled)
 
     def sequence_parallelize(self, model: "PreTrainedModel", layernorm_type: Union[str, LayerNormType]):
-        if type(layernorm_type) is str:
+        if type(layernorm_type) is str: # noqa: E721
             layernorm_type = LayerNormType(layernorm_type)
 
         layernorm_type_to_parallelize_method = {

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -517,7 +517,6 @@ class ParallelMLP(ParallelLayer):
                 device=device,
             )
 
-            print(f"{layer_qualified_name}.{attribute_name}")
         setattr(
             module,
             attribute_name,

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 """Classes related to parallel versions of common blocks in Transformers models."""
 
+from dataclasses import dataclass
 import functools
 import re
 from abc import ABC, abstractclassmethod
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union, Literal
 
 import torch
 from torch.nn.modules.loss import _WeightedLoss
@@ -712,6 +713,18 @@ class ParallelCrossEntropy(ParallelLayer):
         return layer
 
 
+@dataclass(frozen=True)
+class SequenceCollectiveOpInfo:
+    collective_op: Union[Literal["scatter"], Literal["gather"]]
+    layer: Union[Type["torch.nn.Module"], str]
+    position: Union[Literal["before"], Literal["after"]]
+    first_or_last: Union[Literal["first"], Literal["last"]]
+
+    def __post_init__(self):
+        if self.collective_op not in ["scatter", "gather"]:
+            raise ValueError(f'Authorized values are "scatter" and "gather", but {self.collective_op} was given here') 
+
+
 if is_neuronx_distributed_available():
     from neuronx_distributed.parallel_layers.mappings import (
         gather_from_sequence_parallel_region,
@@ -721,12 +734,36 @@ if is_neuronx_distributed_available():
     class IOSequenceParallelizer:
         def __init__(
             self,
-            sequence_scatter_at_first_layer_of_type: Optional[Type["torch.nn.Module"]] = None,
-            sequence_gather_at_last_layer_of_type: Optional[Type["torch.nn.Module"]] = None,
+            sequence_parallel_enabled: bool,
+            sequence_collective_op_infos: Optional[List[SequenceCollectiveOpInfo]] = None 
+            # scatter_sequence: Optional[List[SequenceCollectiveOpInfo]] = None,
+            # gather_sequence: Optional[List[SequenceCollectiveOpInfo]] = None,
+            # scatter_sequence_at_first_layer_of_type: Optional[Type["torch.nn.Module"]] = None,
+            # scatter_before_first_layer: bool = True,
+            # gather_sequence_at_last_layer_of_type: Optional[Type["torch.nn.Module"]] = None,
+            # gather_after_last_layer: bool = True,
         ):
-            self.scatter_layer_type = sequence_scatter_at_first_layer_of_type
-            self.gather_layer_type = sequence_gather_at_last_layer_of_type
-            self.count = 0
+            self.sequence_parallel_enabled = sequence_parallel_enabled
+            self.sequence_collective_op_infos = sequence_collective_op_infos
+            # self.scatter_sequence = scatter_sequence
+            # self.gather_sequence = gather_sequence
+            # self.scatter_layer_type = scatter_sequence_at_first_layer_of_type
+            # self.scatter_before_first_layer = scatter_before_first_layer
+            # self.gather_layer_type = gather_sequence_at_last_layer_of_type
+            # self.gather_after_last_layer = gather_after_last_layer
+
+        def get_first_and_last_layers_matching_pattern(self, model: "torch.nn.Module", pattern: str) -> Tuple["torch.nn.Module", "torch.nn.Module"]:
+            first_layer = None
+            last_layer = None
+            for name, module in model.named_modules():
+                if re.match(pattern, name):
+                    if first_layer is None:
+                        first_layer = module
+                    last_layer = module
+            if first_layer is None:
+                raise ValueError(f"Could not find layer of with pattern {pattern} in {model}.")
+            return [first_layer, last_layer]
+
 
         def get_first_and_last_layers_of_type(
             self, model: "torch.nn.Module", type_: Type["torch.nn.Module"]
@@ -742,34 +779,113 @@ if is_neuronx_distributed_available():
                 raise ValueError(f"Could not find layer of type {type_} in {model}.")
             return [first_layer, last_layer]
 
-        def sequence_parallelize(self, model: "torch.nn.Module"):
-            print(self.count)
-            self.count += 1
-            if self.scatter_layer_type is not None:
-                scatter_layer, _ = self.get_first_and_last_layers_of_type(model, self.scatter_layer_type)
+
+        def _sequence_parallelize(self, model: "torch.nn.Module", sequence_collective_op_info: SequenceCollectiveOpInfo):
+
+            if sequence_collective_op_info.collective_op == "scatter":
+                if isinstance(sequence_collective_op_info.layer, str):
+                    first_layer, last_layer = self.get_first_and_last_layers_matching_pattern(model, sequence_collective_op_info.layer)
+                else:
+                    first_layer, last_layer = self.get_first_and_last_layers_of_type(model, sequence_collective_op_info.layer)
+                scatter_layer = first_layer if sequence_collective_op_info.first_or_last == "first" else last_layer
                 orig_scatter_layer_forward = scatter_layer.forward
 
-                @functools.wraps(orig_scatter_layer_forward)
-                def sequence_parallel_forward(*args, **kwargs):
-                    hidden_states = args[1]
-                    hidden_states = hidden_states.transpose(0, 1).contiguous()
-                    hidden_states = scatter_to_sequence_parallel_region(hidden_states)
-                    return orig_scatter_layer_forward(hidden_states, *args[2:], **kwargs)
+                if sequence_collective_op_info.position == "before":
+                    @functools.wraps(orig_scatter_layer_forward)
+                    def sequence_parallel_forward(*args, **kwargs):
+                        hidden_states = args[1]
+                        hidden_states = hidden_states.transpose(0, 1).contiguous()
+                        hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+                        return orig_scatter_layer_forward(hidden_states, *args[2:], **kwargs)
+                else:
+                    @functools.wraps(orig_scatter_layer_forward)
+                    def sequence_parallel_forward(*args, **kwargs):
+                        output = orig_scatter_layer_forward(*args[1:], **kwargs)
+                        hidden_states = output if isinstance(output, torch.Tensor) else output[0]
+                        hidden_states = hidden_states.transpose(0, 1).contiguous()
+                        hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+                        return hidden_states if isinstance(output, torch.Tensor) else (hidden_states,) + output[1:]
 
                 scatter_layer.forward = sequence_parallel_forward.__get__(scatter_layer)
 
-            if self.gather_layer_type is not None:
-                _, gather_layer = self.get_first_and_last_layers_of_type(model, self.gather_layer_type)
+            else:
+                if isinstance(sequence_collective_op_info.layer, str):
+                    first_layer, last_layer = self.get_first_and_last_layers_matching_pattern(model, sequence_collective_op_info.layer)
+                else:
+                    first_layer, last_layer = self.get_first_and_last_layers_of_type(model, sequence_collective_op_info.layer)
+                gather_layer = first_layer if sequence_collective_op_info.first_or_last == "first" else last_layer
                 orig_gather_layer_forward = gather_layer.forward
 
-                @functools.wraps(orig_gather_layer_forward)
-                def sequence_parallel_forward(*args, **kwargs):
-                    output = orig_gather_layer_forward(*args[1:], **kwargs)
-                    output = gather_from_sequence_parallel_region(output, to_model_parallel=False)
-                    output = output.transpose(0, 1).contiguous()
-                    return output
+                if sequence_collective_op_info.position == "after":
+                    @functools.wraps(orig_gather_layer_forward)
+                    def sequence_parallel_forward(*args, **kwargs):
+                        output = orig_gather_layer_forward(*args[1:], **kwargs)
+                        output = gather_from_sequence_parallel_region(output, to_model_parallel=False)
+                        output = output.transpose(0, 1).contiguous()
+                        return output
+                else:
+                    @functools.wraps(orig_gather_layer_forward)
+                    def sequence_parallel_forward(*args, **kwargs):
+                        hidden_states = args[1]
+                        hidden_states = gather_from_sequence_parallel_region(hidden_states, to_model_parallel=False)
+                        hidden_states = hidden_states.transpose(0, 1).contiguous()
+                        output = orig_gather_layer_forward(hidden_states, *args[2:], **kwargs)
+                        return output
+
 
                 gather_layer.forward = sequence_parallel_forward.__get__(gather_layer)
+
+            # if self.scatter_layer_type is not None:
+            #     scatter_layer, _ = self.get_first_and_last_layers_of_type(model, self.scatter_layer_type)
+            #     orig_scatter_layer_forward = scatter_layer.forward
+
+            #     if self.scatter_before_first_layer:
+            #         @functools.wraps(orig_scatter_layer_forward)
+            #         def sequence_parallel_forward(*args, **kwargs):
+            #             hidden_states = args[1]
+            #             hidden_states = hidden_states.transpose(0, 1).contiguous()
+            #             hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+            #             return orig_scatter_layer_forward(hidden_states, *args[2:], **kwargs)
+            #     else:
+            #         @functools.wraps(orig_scatter_layer_forward)
+            #         def sequence_parallel_forward(*args, **kwargs):
+            #             output = orig_scatter_layer_forward(*args[1:], **kwargs)
+            #             hidden_states = output if isinstance(output, torch.Tensor) else output[0]
+            #             hidden_states = hidden_states.transpose(0, 1).contiguous()
+            #             hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+            #             return hidden_states if isinstance(output, torch.Tensor) else (hidden_states,) + output[1:]
+
+            #     scatter_layer.forward = sequence_parallel_forward.__get__(scatter_layer)
+
+            # if self.gather_layer_type is not None:
+            #     _, gather_layer = self.get_first_and_last_layers_of_type(model, self.gather_layer_type)
+            #     orig_gather_layer_forward = gather_layer.forward
+
+            #     if self.gather_after_last_layer:
+
+            #         @functools.wraps(orig_gather_layer_forward)
+            #         def sequence_parallel_forward(*args, **kwargs):
+            #             output = orig_gather_layer_forward(*args[1:], **kwargs)
+            #             output = gather_from_sequence_parallel_region(output, to_model_parallel=False)
+            #             output = output.transpose(0, 1).contiguous()
+            #             return output
+            #     else:
+            #         @functools.wraps(orig_gather_layer_forward)
+            #         def sequence_parallel_forward(*args, **kwargs):
+            #             hidden_states = args[1]
+            #             hidden_states = gather_from_sequence_parallel_region(hidden_states, to_model_parallel=False)
+            #             hidden_states = hidden_states.transpose(0, 1).contiguous()
+            #             output = orig_gather_layer_forward(hidden_states, *args[2:], **kwargs)
+            #             return output
+
+
+            #     gather_layer.forward = sequence_parallel_forward.__get__(gather_layer)
+
+        def sequence_parallelize(self, model: "torch.nn.Module"):
+            if not self.sequence_parallel_enabled or not self.sequence_collective_op_infos:
+                return
+            for sequence_collective_op_info in self.sequence_collective_op_infos:
+                self._sequence_parallelize(model, sequence_collective_op_info)
 
 else:
 

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -48,8 +48,6 @@ logger = logging.get_logger()
 # changes inputs inplace. This way the original input is not transformed and can be used in tests for comparison.
 _PARALLEL_CROSS_ENTROPY_SHOULD_PRESERVE_INPUT: bool = False
 
-_shape_t = Union[int, List[int], torch.Size]
-
 
 class ParallelLayer(ABC):
     @classmethod

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -714,8 +714,17 @@ class SequenceCollectiveOpInfo:
     """
     Represents a collective op to perform.
 
-    Example:
+    Attributes:
+        - collective_op (`Union[Literal["scatter"], Literal["gather"]]`) -- The collective operation that should be
+        performed.
+        - layer (`Union[Type[torch.nn.Module], str]`) -- The layer to consider. It can either be a type or a qualified
+        name pattern to match.
+        - io (`Union[Literal["input"], Literal["output"]]`) -- Whether the collective op should be applied to the input
+        or to the output of the matched layer.
+        - first_or_last (`Union[Literal["first"], Literal["last"]]`) -- Whether to consider the first matching layer or
+        the last matching layer.
 
+    Example:
         ```python
         info = SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "output", "last")
         ```

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -210,7 +210,7 @@ def embedding_to_parallel_embedding(
                 linear_layer_bias_weight_info=lm_head_bias_weight_info,
                 embedding_weight_to_tie=embedding_weight_to_tie,
                 gather_output=False,
-                sequence_parallel_enabled=sequence_parallel_enabled,
+                sequence_parallel_enabled=False,
                 device=device,
             )
 
@@ -449,6 +449,20 @@ def gqa_key_value_slicing_when_tp_size_greater_than_num_key_value_heads(
                 )
     return sliced_linear_layer
 
+
+def create_sequence_parallel_attention_forward(attention_forward, sequence_parallel_enabled: bool):
+    import functools
+
+    @functools.wraps(attention_forward)
+    def sequence_parallel_attention_forward(self, *args, **kwargs):
+        outputs = attention_forward(*args, **kwargs)
+        context_layer = outputs[0]
+        if sequence_parallel_enabled:
+            # [B, S, hidden_dim] -> [S, B, hidden_dim]
+            context_layer = context_layer.transpose(0, 1)
+        return (context_layer,) + outputs[1:]
+
+    return sequence_parallel_attention_forward.__get__(attention_forward.__self__)
 
 @classmethod
 @requires_torch_xla

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -450,21 +450,6 @@ def gqa_key_value_slicing_when_tp_size_greater_than_num_key_value_heads(
     return sliced_linear_layer
 
 
-def create_sequence_parallel_attention_forward(attention_forward, sequence_parallel_enabled: bool):
-    import functools
-
-    @functools.wraps(attention_forward)
-    def sequence_parallel_attention_forward(self, *args, **kwargs):
-        outputs = attention_forward(*args, **kwargs)
-        context_layer = outputs[0]
-        if sequence_parallel_enabled:
-            # [B, S, hidden_dim] -> [S, B, hidden_dim]
-            context_layer = context_layer.transpose(0, 1)
-        return (context_layer,) + outputs[1:]
-
-    return sequence_parallel_attention_forward.__get__(attention_forward.__self__)
-
-
 @classmethod
 @requires_torch_xla
 def from_pretrained_for_tp(

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -346,7 +346,6 @@ def linear_to_parallel_linear(
                         None,
                     ),
                 )
-                print(linear_layer.weight.shape, parallel_linear_layer.weight.shape, weight_data.shape)
                 parallel_linear_layer.weight.copy_(weight_data)
 
             elif linear_layer.weight.device != torch.device("meta"):
@@ -562,9 +561,9 @@ def from_pretrained_for_tp(
         # from `GPTNeoModel` when using `GPTNeoForCausalLM`, then our model weight names might not match the names in
         # `weight_map`.
         weight_map_for_model = {}
-        model_parameter_and_buffer_names = ({
+        model_parameter_and_buffer_names = {
             n for n, _ in itertools.chain(model.named_parameters(), model.named_buffers())
-        })
+        }
         names_of_weights_not_in_model = set()
         prefixes = set()
         for name, filename in weight_map.items():

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -464,6 +464,7 @@ def create_sequence_parallel_attention_forward(attention_forward, sequence_paral
 
     return sequence_parallel_attention_forward.__get__(attention_forward.__self__)
 
+
 @classmethod
 @requires_torch_xla
 def from_pretrained_for_tp(

--- a/optimum/neuron/training_args.py
+++ b/optimum/neuron/training_args.py
@@ -59,6 +59,10 @@ class NeuronTrainingArgumentsMixin:
         default=True,
         metadata={"help": "Whether or not the embedding parallelization when doing TP should be disabled."},
     )
+    sequence_parallel_enabled: bool = field(
+        default=False,
+        metadata={"help": "Whether or not to enable sequence parallelism."},
+    )
 
     def __post_init__(self):
         # Patches accelerate.utils.imports.is_tpu_available to match `is_torch_xla_available`

--- a/optimum/neuron/utils/deprecate_utils.py
+++ b/optimum/neuron/utils/deprecate_utils.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions to handle deprecation."""
+
+import functools
+import inspect
+import warnings
+from typing import Callable, Dict
+
+from packaging import version
+
+from ..version import __version__
+from .version_utils import (
+    get_neuroncc_version,
+    get_neuronx_distributed_version,
+    get_neuronxcc_version,
+    get_torch_version,
+    get_torch_xla_version,
+)
+
+
+PACKAGE_NAME_TO_GET_VERSION_FUNCTION: Dict[str, Callable[[], str]] = {
+    "optimum-neuron": lambda: __version__,
+    "neuroncc": get_neuroncc_version,
+    "neuronxcc": get_neuronxcc_version,
+    "torch": get_torch_version,
+    "torch_xla": get_torch_xla_version,
+    "neuronx_distributed": get_neuronx_distributed_version,
+}
+
+
+def deprecate(deprecate_version: str, package_name: str = "optimum-neuron", reason: str = ""):
+    if package_name not in PACKAGE_NAME_TO_GET_VERSION_FUNCTION:
+        raise ValueError(f"Do not know how to retrieve the version of the package called {package_name}.")
+    deprecate_version = version.parse(deprecate_version)
+    try:
+        package_version = PACKAGE_NAME_TO_GET_VERSION_FUNCTION[package_name]()
+    except ModuleNotFoundError:
+        # We do not want to fail if the package is not available, otherwise it will make developping locally impossible.
+        package_version = "0.0.0"
+
+    package_version = version.parse(package_version)
+
+    def deprecator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if package_version >= deprecate_version:
+                msg = [f"{func.__name__} is deprecated."]
+                if reason:
+                    msg.append(f"Reason: {reason}")
+                msg = " ".join(msg)
+                warnings.warn(msg, category=DeprecationWarning)
+
+            if inspect.isgeneratorfunction(func):
+                yield from func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return deprecator

--- a/optimum/neuron/utils/require_utils.py
+++ b/optimum/neuron/utils/require_utils.py
@@ -52,14 +52,3 @@ requires_safetensors = _create_requires_function("safetensors")
 requires_torch_xla = _create_requires_function("torch_xla")
 requires_neuronx_distributed = _create_requires_function("neuronx_distributed")
 requires_torch_neuronx = _create_requires_function("torch_neuronx")
-
-
-class RequirementClass:
-    PACKAGE_NAME: str
-
-    def __init__(self, *args, **kwargs):
-        if not _AVAILIBILITIES[self.PACKAGE_NAME]():
-            raise ModuleNotFoundError(
-                f"{self.__class__} requires the `{self.PACKAGE_NAME} package. You can install it by running: pip "
-                f"install {self.PACKAGE_NAME}"
-            )

--- a/optimum/neuron/utils/require_utils.py
+++ b/optimum/neuron/utils/require_utils.py
@@ -22,7 +22,7 @@ from transformers.utils import is_safetensors_available
 from . import is_neuronx_distributed_available, is_torch_neuronx_available, is_torch_xla_available
 
 
-_AVAILIBILITIES: Dict[str, Callable[[], bool]] = {
+_AVAILABILITIES: Dict[str, Callable[[], bool]] = {
     "safetensors": is_safetensors_available,
     "torch_xla": is_torch_xla_available,
     "neuronx_distributed": is_neuronx_distributed_available,
@@ -31,7 +31,7 @@ _AVAILIBILITIES: Dict[str, Callable[[], bool]] = {
 
 
 def _create_requires_function(package_name: str) -> Callable[..., Any]:
-    availability_function = _AVAILIBILITIES[package_name]
+    availability_function = _AVAILABILITIES[package_name]
 
     def require_func(func):
         @functools.wraps(func)

--- a/optimum/neuron/utils/version_utils.py
+++ b/optimum/neuron/utils/version_utils.py
@@ -23,6 +23,8 @@ from .import_utils import is_neuron_available, is_neuronx_available
 _neuronxcc_version: Optional[str] = None
 _neuroncc_version: Optional[str] = None
 _torch_xla_version: Optional[str] = None
+_neuronx_distributed_version: Optional[str] = None
+_torch_version: Optional[str] = None
 
 
 def get_neuronxcc_version() -> str:
@@ -32,7 +34,7 @@ def get_neuronxcc_version() -> str:
     try:
         import neuronxcc
     except ImportError:
-        raise ValueError("NeuronX Compiler python package is not installed.")
+        raise ModuleNotFoundError("NeuronX Compiler python package is not installed.")
     _neuronxcc_version = neuronxcc.__version__
     return _neuronxcc_version
 
@@ -44,7 +46,7 @@ def get_neuroncc_version() -> str:
     try:
         import neuroncc
     except ImportError:
-        raise ValueError("Neuron Compiler python package is not installed.")
+        raise ModuleNotFoundError("Neuron Compiler python package is not installed.")
     _neuroncc_version = neuroncc.__version__
     return _neuroncc_version
 
@@ -56,9 +58,33 @@ def get_torch_xla_version() -> str:
     try:
         import torch_xla
     except ImportError:
-        raise ValueError("`torch_xla` python package is not installed.")
+        raise ModuleNotFoundError("`torch_xla` python package is not installed.")
     _torch_xla_version = torch_xla.__version__
     return _torch_xla_version
+
+
+def get_neuronx_distributed_version() -> str:
+    global _neuronx_distributed_version
+    if _neuronx_distributed_version is not None:
+        return _neuronx_distributed_version
+    try:
+        import neuronx_distributed
+    except ImportError:
+        raise ModuleNotFoundError("`neuronx_distributed` python package is not installed.")
+    _neuronx_distributed_version = neuronx_distributed.__version__
+    return _neuronx_distributed_version
+
+
+def get_torch_version() -> str:
+    global _torch_version
+    if _torch_version is not None:
+        return _torch_version
+    try:
+        import torch
+    except ImportError:
+        raise ModuleNotFoundError("`torch` python package is not installed.")
+    _torch_version = torch.__version__
+    return _torch_version
 
 
 def check_compiler_compatibility(compiler_type: str, compiler_version: str):

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -131,6 +131,9 @@ def gather_output(output, gather_dim):
     return result
       
 if is_parallel:
+    # Because of parallelism (embeddings and sequence parallelism), some outputs need to be gathered.
+    # Since it is not possible to generically know which one, we save both the "regular" output and the gathered 
+    # version of it. We then compare both of them to the original output and fail both of them do not match.
     gathered_model_outputs =  dict()
     for name, output in model_outputs.items():
         gathered_model_outputs[name] = output

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -138,7 +138,7 @@ def gather_output(output, gather_dim):
 if is_parallel:
     # Because of parallelism (embeddings and sequence parallelism), some outputs need to be gathered.
     # Since it is not possible to generically know which one, we save both the "regular" output and the gathered 
-    # version of it. We then compare both of them to the original output and fail both do not match.
+    # version of it. We then compare both of them to the original output and fail if both do not match.
     gathered_model_outputs =  dict()
     for name, output in model_outputs.items():
         gathered_model_outputs[name] = output

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -115,7 +115,7 @@ for k, v in inputs.items():
 shape = list(xla_inputs.values())[0].shape
 
 if computing_loss_is_supported:
-  xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
+    xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
 
 model_outputs = model(**xla_inputs, return_dict=True)
 xm.mark_step()

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -108,7 +108,7 @@ for k, v in inputs.items():
 # Might not work for every tasks.
 shape = list(xla_inputs.values())[0].shape
 
-xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
+# xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
 
 model_outputs = model(**xla_inputs, return_dict=True)
 xm.mark_step()

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -32,6 +32,7 @@ is_parallel = os.environ["is_parallel"] == "true"
 config_overwrite = os.environ.get("config_overwrite", "")
 parallelize_embeddings = is_parallel and os.environ["parallelize_embeddings"] == "true"
 sequence_parallel_enabled = os.environ["sequence_parallel_enabled"] == "true"
+computing_loss_is_supported = os.environ["computing_loss_is_supported"] == "true"
 
 # This is required to prevent `parallel_cross_entropy` to mutate the logits (which would make them not comparable).
 if is_parallel and parallelize_embeddings:
@@ -108,7 +109,8 @@ for k, v in inputs.items():
 # Might not work for every tasks.
 shape = list(xla_inputs.values())[0].shape
 
-# xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
+if computing_loss_is_supported:
+  xla_inputs.update(generate_dummy_labels(model, shape, vocab_size=vocab_size, device="xla", seed=SEED))
 
 model_outputs = model(**xla_inputs, return_dict=True)
 xm.mark_step()

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -15,7 +15,7 @@ from transformers.trainer_utils import set_seed
 import optimum
 from optimum.neuron.distributed import ParallelizersManager, lazy_load_for_parallelism
 
-from utils import gather_along_last_dim, generate_dummy_labels
+from utils import gather_along_dim, generate_dummy_labels
 
 
 if os.environ.get("TORCHELASTIC_RUN_ID"):
@@ -115,13 +115,38 @@ if computing_loss_is_supported:
 model_outputs = model(**xla_inputs, return_dict=True)
 xm.mark_step()
 
+axis_to_gather = dict()
+axis_to_gather["default"] = -1
+axis_to_gather["past_key_values"] = 1
+
+def gather_output(output, gather_dim):
+    if isinstance(output, (tuple, list, set)):
+        output_type = type(output)
+        gathered_output = []
+        for t in output:
+            gathered_output.append(gather_output(t, gather_dim))
+        result = output_type(gathered_output)
+    else:
+        result = gather_along_dim(output, gather_dim)
+    return result
+      
 if is_parallel and parallelize_embeddings:
-    gathered_model_outputs =  dict()
+    # gathered_model_outputs =  dict()
     for name, output in model_outputs.items():
-        if name == "loss" or output is None or not isinstance(output, torch.Tensor) or output.shape[-1] != (vocab_size // {tp_size}):
-            gathered_model_outputs[name] = output
+        gathered_model_outputs[name] = output
+        if name == "loss" or output is None: # or not isinstance(output, torch.Tensor) or output.shape[-1] != (vocab_size // {tp_size}):
+            gathered_output = output
         else:
-            gathered_model_outputs[name] = gather_along_last_dim(output)
+            gathered_output = gather_output(output, axis_to_gather.get(name, axis_to_gather["default"]))
+        gathered_output_name = "gathered_" + name
+        gathered_model_outputs[gathered_output_name] = gathered_output
+        # elif isinstance(output, (tuple, list, set)):
+        #     output_type = type(output)
+        #     gathered_output = []
+        #     for t in output:
+        #         
+        # else:
+        #     gathered_model_outputs[name] = gather_along_last_dim(output)
     model_outputs = gathered_model_outputs
 
 xm.save(model_outputs, "{output_path}" + "/" + filename)

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -53,6 +53,9 @@ for overwrite_info in config_overwrite:
     attr_type = type(getattr(config, attr_name))
     setattr(config, attr_name, attr_type(attr_value))
 
+if getattr(config, "problem_type", None) is None:
+    config.problem_type = "single_label_classification"
+
 if xm.get_ordinal() == 0:
   print(config)
 

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -7,6 +7,7 @@ from inspect import signature
 import torch
 import neuronx_distributed
 from neuronx_distributed import parallel_layers
+from neuronx_distributed.utils.model_utils import move_model_to_device
 import torch_xla.core.xla_model as xm
 
 from transformers import AutoConfig, AutoTokenizer, {model_class}
@@ -89,7 +90,7 @@ if is_parallel:
         parallelize_embeddings=parallelize_embeddings, 
         sequence_parallel_enabled=sequence_parallel_enabled,
     )
-    parallel_layers.move_model_to_device(model, "xla")
+    move_model_to_device(model, "xla")
     filename = "parallel.bin"
 else:
     model = model.to("xla")

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -76,7 +76,8 @@ def load_model_with_seed(seed: int, from_config: bool):
     if from_config:
         model = {model_class}(config)
     else:
-      ctx = lazy_load_for_parallelism(tensor_parallel_size={tp_size}) if lazy_load else nullcontext()
+      tp_size = {tp_size} if is_parallel else 1
+      ctx = lazy_load_for_parallelism(tensor_parallel_size=tp_size) if lazy_load else nullcontext()
       with ctx:
           model = {model_class}.from_pretrained("{model_name_or_path}", config=config, ignore_mismatched_sizes=True)
     return model

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -149,6 +149,4 @@ if is_parallel:
         gathered_model_outputs[gathered_output_name] = gathered_output
     model_outputs = gathered_model_outputs
 
-print(model_outputs.keys())
-
 xm.save(model_outputs, "{output_path}" + "/" + filename)

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -31,6 +31,7 @@ lazy_load = os.environ["lazy_load"] == "true"
 is_parallel = os.environ["is_parallel"] == "true"
 config_overwrite = os.environ.get("config_overwrite", "")
 parallelize_embeddings = is_parallel and os.environ["parallelize_embeddings"] == "true"
+sequence_parallel_enabled = os.environ["sequence_parallel_enabled"] == "true"
 
 # This is required to prevent `parallel_cross_entropy` to mutate the logits (which would make them not comparable).
 if is_parallel and parallelize_embeddings:
@@ -57,6 +58,14 @@ preprocessor = AutoTokenizer.from_pretrained("{model_name_or_path}")
 
 inputs = preprocessor("This is a test to check that TP is working.", return_tensors="pt")
 
+if sequence_parallel_enabled and hasattr(preprocessor, "pad_token_id"):
+    for name, tensor in inputs.items():
+        if tensor.shape[1] % {tp_size} != 0:
+            tensor = torch.nn.functional.pad(
+              tensor, pad=(0, tensor.shape[1] % {tp_size}), value=preprocessor.pad_token_id
+            )
+            inputs[name] = tensor
+
 def load_model_with_seed(seed: int, from_config: bool):
     set_seed(seed)
     if from_config:
@@ -74,7 +83,11 @@ model = model.eval()
 vocab_size = getattr(model.config, "vocab_size", None)
 
 if is_parallel:
-    model = ParallelizersManager.parallelizer_for_model(model).parallelize(model, parallelize_embeddings=parallelize_embeddings)
+    model = ParallelizersManager.parallelizer_for_model(model).parallelize(
+        model, 
+        parallelize_embeddings=parallelize_embeddings, 
+        sequence_parallel_enabled=sequence_parallel_enabled,
+    )
     parallel_layers.move_model_to_device(model, "xla")
     filename = "parallel.bin"
 else:

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -130,8 +130,8 @@ def gather_output(output, gather_dim):
         result = gather_along_dim(output, gather_dim)
     return result
       
-if is_parallel and parallelize_embeddings:
-    # gathered_model_outputs =  dict()
+if is_parallel:
+    gathered_model_outputs =  dict()
     for name, output in model_outputs.items():
         gathered_model_outputs[name] = output
         if name == "loss" or output is None: # or not isinstance(output, torch.Tensor) or output.shape[-1] != (vocab_size // {tp_size}):
@@ -140,13 +140,8 @@ if is_parallel and parallelize_embeddings:
             gathered_output = gather_output(output, axis_to_gather.get(name, axis_to_gather["default"]))
         gathered_output_name = "gathered_" + name
         gathered_model_outputs[gathered_output_name] = gathered_output
-        # elif isinstance(output, (tuple, list, set)):
-        #     output_type = type(output)
-        #     gathered_output = []
-        #     for t in output:
-        #         
-        # else:
-        #     gathered_model_outputs[name] = gather_along_last_dim(output)
     model_outputs = gathered_model_outputs
+
+print(model_outputs.keys())
 
 xm.save(model_outputs, "{output_path}" + "/" + filename)

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -138,11 +138,11 @@ def gather_output(output, gather_dim):
 if is_parallel:
     # Because of parallelism (embeddings and sequence parallelism), some outputs need to be gathered.
     # Since it is not possible to generically know which one, we save both the "regular" output and the gathered 
-    # version of it. We then compare both of them to the original output and fail both of them do not match.
+    # version of it. We then compare both of them to the original output and fail both do not match.
     gathered_model_outputs =  dict()
     for name, output in model_outputs.items():
         gathered_model_outputs[name] = output
-        if name == "loss" or output is None: # or not isinstance(output, torch.Tensor) or output.shape[-1] != (vocab_size // {tp_size}):
+        if name == "loss" or output is None: 
             gathered_output = output
         else:
             gathered_output = gather_output(output, axis_to_gather.get(name, axis_to_gather["default"]))

--- a/tests/distributed/model_parallel_test_template.txt
+++ b/tests/distributed/model_parallel_test_template.txt
@@ -63,11 +63,11 @@ preprocessor = AutoTokenizer.from_pretrained("{model_name_or_path}")
 
 inputs = preprocessor("This is a test to check that TP is working.", return_tensors="pt")
 
-if sequence_parallel_enabled and hasattr(preprocessor, "pad_token_id"):
+if sequence_parallel_enabled:
     for name, tensor in inputs.items():
         if tensor.shape[1] % {tp_size} != 0:
             tensor = torch.nn.functional.pad(
-              tensor, pad=(0, tensor.shape[1] % {tp_size}), value=preprocessor.pad_token_id
+              tensor, pad=(0, tensor.shape[1] % {tp_size}), value=1,
             )
             inputs[name] = tensor
 

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -267,7 +267,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             # TODO: enable once ParallelCrossEntropy works.
             # parallelize_embeddings=True,
             parallelize_embeddings=False,
-            sequence_parallel_enabled=False,
+            sequence_parallel_enabled=True,
             overwrite_model_config=config_overwrite,
         )
 

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -296,7 +296,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
         self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     ):
         self._test_model_parallel(
-            num_neuron_cores=2,
+            num_neuron_cores=8,
             tp_size=2,
             run_test_in_parallel=True,
             model_class_name=model_class_name,

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -137,6 +137,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
         from_config: bool,
         with_lazy_load: bool,
         parallelize_embeddings: bool,
+        sequence_parallel_enabled: bool,
         num_neuron_cores: int = NUM_NEURON_CORES_AVAILABLE,
         run_test_in_parallel: bool = False,
         overwrite_model_config: Optional[Dict[str, str]] = None,
@@ -164,6 +165,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             "from_config": "true" if from_config else "false",
             "lazy_load": "true" if with_lazy_load else "false",
             "parallelize_embeddings": "true" if parallelize_embeddings else "false",
+            "sequence_parallel_enabled": "true" if sequence_parallel_enabled else "false",
             **os.environ,
         }
 
@@ -262,7 +264,10 @@ class ModelParallelizationTestCase(unittest.TestCase):
             model_name_or_path=model_name_or_path,
             from_config=True,
             with_lazy_load=False,
+            # TODO: enable once ParallelCrossEntropy works.
+            # parallelize_embeddings=True,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config=config_overwrite,
         )
 
@@ -278,7 +283,10 @@ class ModelParallelizationTestCase(unittest.TestCase):
             model_name_or_path=model_name_or_path,
             from_config=False,
             with_lazy_load=False,
+            # TODO: enable once ParallelCrossEntropy works.
+            # parallelize_embeddings=True,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=True,
             overwrite_model_config=config_overwrite,
         )
 
@@ -295,8 +303,44 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=False,
             with_lazy_load=True,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=True,
             overwrite_model_config=config_overwrite,
         )
+
+    # TODO: enable that once ParallelCrossEntropy works.
+    # @parameterized.expand(MODELS_TO_TEST)
+    # def test_model_parallel_without_sequence_parallel(
+    #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
+    # ):
+    #     self._test_model_parallel(
+    #         num_neuron_cores=8,
+    #         tp_size=2,
+    #         run_test_in_parallel=True,
+    #         model_class_name=model_class_name,
+    #         model_name_or_path=model_name_or_path,
+    #         from_config=False,
+    #         with_lazy_load=True,
+    #         parallelize_embeddings=True,
+    #         sequence_parallel_enabled=False,
+    #         overwrite_model_config=config_overwrite,
+    #     )
+
+    # @parameterized.expand(MODELS_TO_TEST)
+    # def test_model_parallel_without_anything(
+    #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
+    # ):
+    #     self._test_model_parallel(
+    #         num_neuron_cores=8,
+    #         tp_size=2,
+    #         run_test_in_parallel=True,
+    #         model_class_name=model_class_name,
+    #         model_name_or_path=model_name_or_path,
+    #         from_config=False,
+    #         with_lazy_load=True,
+    #         parallelize_embeddings=False,
+    #         sequence_parallel_enabled=False,
+    #         overwrite_model_config=config_overwrite,
+    #     )
 
     @unittest.skipIf(
         NUM_NEURON_CORES_AVAILABLE < 32,
@@ -315,6 +359,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=True,
             with_lazy_load=False,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config={
                 "num_hidden_layers": "2",
                 "num_attention_heads": "8",
@@ -333,6 +378,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=True,
             with_lazy_load=False,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config={
                 "num_hidden_layers": "2",
                 "num_attention_heads": "8",
@@ -351,6 +397,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=True,
             with_lazy_load=False,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config={
                 "num_hidden_layers": "2",
                 "hidden_size": "32",
@@ -370,6 +417,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=True,
             with_lazy_load=False,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config={
                 "num_hidden_layers": "2",
                 "hidden_size": "32",
@@ -389,6 +437,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
             from_config=True,
             with_lazy_load=False,
             parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
             overwrite_model_config={
                 "num_hidden_layers": "2",
                 "hidden_size": "32",

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -244,6 +244,8 @@ class ModelParallelizationTestCase(unittest.TestCase):
             original_model_outputs = torch.load(temporary_dir / "original.bin")
             parallel_model_outputs = torch.load(temporary_dir / "parallel.bin")
             for name, t in parallel_model_outputs.items():
+                # if name == "loss":
+                #     continue
                 if not isinstance(t, torch.Tensor):
                     continue
                 original_t = original_model_outputs[name]

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -259,7 +259,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
         self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     ):
         self._test_model_parallel(
-            num_neuron_cores=8,
+            num_neuron_cores=2,
             tp_size=2,
             run_test_in_parallel=True,
             model_class_name=model_class_name,

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -112,7 +112,7 @@ MODEL_TYPES_TO_TEST = [
     ("bert", "hf-internal-testing/tiny-random-bert"),
     ("roberta", "hf-internal-testing/tiny-random-roberta"),
     ("gpt_neo", "hf-internal-testing/tiny-random-GPTNeoModel"),
-    ("llama", "anushehchaudry/llama-2-tiny-random"),
+    ("llama", "anushehchaudry/llama-2-tiny-random", {"num_hidden_layers": "2"}),
     ("t5", "hf-tiny-model-private/tiny-random-T5ForConditionalGeneration", {"d_ff": "64"}),
 ]
 

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -346,40 +346,41 @@ class ModelParallelizationTestCase(unittest.TestCase):
             overwrite_model_config=config_overwrite,
         )
 
-    # TODO: enable that once ParallelCrossEntropy works.
-    # @parameterized.expand(MODELS_TO_TEST)
-    # def test_model_parallel_lazy_load_without_sequence_parallel(
-    #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
-    # ):
-    #     self._test_model_parallel(
-    #         num_neuron_cores=8,
-    #         tp_size=2,
-    #         run_test_in_parallel=True,
-    #         model_class_name=model_class_name,
-    #         model_name_or_path=model_name_or_path,
-    #         from_config=False,
-    #         with_lazy_load=True,
-    #         parallelize_embeddings=True,
-    #         sequence_parallel_enabled=False,
-    #         overwrite_model_config=config_overwrite,
-    #     )
+    @unittest.skip("Parallel cross entropy does not work yet.")
+    @parameterized.expand(MODELS_TO_TEST)
+    def test_model_parallel_lazy_load_without_sequence_parallel(
+        self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
+    ):
+        self._test_model_parallel(
+            num_neuron_cores=8,
+            tp_size=2,
+            run_test_in_parallel=True,
+            model_class_name=model_class_name,
+            model_name_or_path=model_name_or_path,
+            from_config=False,
+            with_lazy_load=True,
+            parallelize_embeddings=True,
+            sequence_parallel_enabled=False,
+            overwrite_model_config=config_overwrite,
+        )
 
-    # @parameterized.expand(MODELS_TO_TEST)
-    # def test_model_parallel_lazy_load_without_anything()
-    #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
-    # ):
-    #     self._test_model_parallel(
-    #         num_neuron_cores=8,
-    #         tp_size=2,
-    #         run_test_in_parallel=True,
-    #         model_class_name=model_class_name,
-    #         model_name_or_path=model_name_or_path,
-    #         from_config=False,
-    #         with_lazy_load=True,
-    #         parallelize_embeddings=False,
-    #         sequence_parallel_enabled=False,
-    #         overwrite_model_config=config_overwrite,
-    #     )
+    @unittest.skip("Parallel cross entropy does not work yet.")
+    @parameterized.expand(MODELS_TO_TEST)
+    def test_model_parallel_lazy_load_without_anything(
+        self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
+    ):
+        self._test_model_parallel(
+            num_neuron_cores=8,
+            tp_size=2,
+            run_test_in_parallel=True,
+            model_class_name=model_class_name,
+            model_name_or_path=model_name_or_path,
+            from_config=False,
+            with_lazy_load=True,
+            parallelize_embeddings=False,
+            sequence_parallel_enabled=False,
+            overwrite_model_config=config_overwrite,
+        )
 
     @unittest.skipIf(
         NUM_NEURON_CORES_AVAILABLE < 32,

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -166,6 +166,8 @@ class ModelParallelizationTestCase(unittest.TestCase):
             "lazy_load": "true" if with_lazy_load else "false",
             "parallelize_embeddings": "true" if parallelize_embeddings else "false",
             "sequence_parallel_enabled": "true" if sequence_parallel_enabled else "false",
+            # TODO: disable that once that loss computation compilation for LLama does not take forever.
+            "computing_loss_is_supported": "true" if not model_class_name.startswith("Llama") else "false",
             **os.environ,
         }
 

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -277,6 +277,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
                 except AssertionError as e:
                     regular_parallel_outputs_error_msg = str(e)
                 if regular_parallel_outputs_error_msg is not None:
+                    print("Regular output did not match, testing with the gathered output...")
                     try:
                         self._check_output(name, t, parallel_model_outputs[f"gathered_{name}"])
                     except AssertionError as e:

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -403,7 +403,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
 
     @pytest.mark.skipif(
         NUM_NEURON_CORES_AVAILABLE < 32,
-        f"This test requires 32 Neuron cores, but only {NUM_NEURON_CORES_AVAILABLE} are available",
+        reason=f"This test requires 32 Neuron cores, but only {NUM_NEURON_CORES_AVAILABLE} are available",
     )
     def test_llama_v2_gqa_variants(self):
         llama_v2_model_name = "anushehchaudry/llama-2-tiny-random"

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -311,7 +311,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(MODELS_TO_TEST)
-    def test_model_parallel_from_pretrained_without_lazy_load(
+    def test_model_parallel_from_pretrained_no_lazy_load(
         self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     ):
         self._test_model_parallel(
@@ -330,7 +330,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(MODELS_TO_TEST)
-    def test_model_parallel_without_parallelizing_embeddings(
+    def test_model_parallel_lazy_load_without_parallelizing_embeddings(
         self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     ):
         self._test_model_parallel(
@@ -348,7 +348,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
 
     # TODO: enable that once ParallelCrossEntropy works.
     # @parameterized.expand(MODELS_TO_TEST)
-    # def test_model_parallel_without_sequence_parallel(
+    # def test_model_parallel_lazy_load_without_sequence_parallel(
     #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     # ):
     #     self._test_model_parallel(
@@ -365,7 +365,7 @@ class ModelParallelizationTestCase(unittest.TestCase):
     #     )
 
     # @parameterized.expand(MODELS_TO_TEST)
-    # def test_model_parallel_without_anything(
+    # def test_model_parallel_lazy_load_without_anything()
     #     self, model_class_name: str, model_name_or_path: str, config_overwrite: Dict[str, str]
     # ):
     #     self._test_model_parallel(

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -146,7 +146,9 @@ class ParallelUtilsTestCase(unittest.TestCase):
                 torch.testing.assert_close(
                     parallel_lm_head.weight, lm_head_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size, :]
                 )
-                torch.testing.assert_close(parallel_lm_head.bias, lm_head_bias_weight)
+                torch.testing.assert_close(
+                    parallel_lm_head.bias, lm_head_bias_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size]
+                )
                 assert id(parallel_embedding.weight) != id(parallel_lm_head.weight)
                 assert id(parallel_lm_head.bias) != id(lm_head.bias)
 
@@ -172,7 +174,9 @@ class ParallelUtilsTestCase(unittest.TestCase):
                 torch.testing.assert_close(
                     parallel_lm_head.weight, embedding_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size, :]
                 )
-                torch.testing.assert_close(parallel_lm_head.bias, lm_head_bias_weight)
+                torch.testing.assert_close(
+                    parallel_lm_head.bias, lm_head_bias_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size]
+                )
                 assert id(parallel_embedding.weight) == id(parallel_lm_head.weight)
                 assert id(parallel_lm_head.bias) != id(lm_head.bias)
 

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -182,6 +182,7 @@ def gather_along_first_dim(input_: torch.Tensor) -> torch.Tensor:
 @requires_torch_xla
 @requires_neuronx_distributed
 def gather_along_dim(input_: torch.Tensor, dim: int) -> torch.Tensor:
+    input_ = input_.clone().contiguous()
     if dim == 0:
         return gather_along_first_dim(input_)
     elif dim in [-1, input_.dim() - 1]:

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -189,4 +189,4 @@ def gather_along_dim(input_: torch.Tensor, dim: int) -> torch.Tensor:
     else:
         t = input_.transpose(0, dim)
         gathered_t = gather_along_first_dim(t)
-        return gathered_t.transpose(0, dim)
+        return gathered_t.transpose(0, dim).contiguous()

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -187,6 +187,6 @@ def gather_along_dim(input_: torch.Tensor, dim: int) -> torch.Tensor:
     elif dim in [-1, input_.dim() - 1]:
         return gather_along_last_dim(input_)
     else:
-        t = input_.transpose(0, dim)
+        t = input_.transpose(0, dim).contiguous()
         gathered_t = gather_along_first_dim(t)
         return gathered_t.transpose(0, dim).contiguous()


### PR DESCRIPTION
- [x] Removes depecrated `orig_to_parallel` parameter in all the tensor parallel related functions and classes.
- [x] Adds support for sequence parallelism for BERT, RoBERTa, GPT-Neo, LLama and T5
- [x] T5: the cross attention is also parallelized under a TP setting.
- [x] Fixes lazy loading with tied weights.