### PR TITLE
test(generation): specify revision for hub test model

### DIFF
--- a/tests/generation/test_fused_logits_warper.py
+++ b/tests/generation/test_fused_logits_warper.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from optimum.neuron.generation import FusedLogitsWarper
+from optimum.neuron.generation.logits_process import FusedLogitsWarper
 
 
 def test_temperature():
@@ -54,7 +54,7 @@ def test_top_p(batch_size, vocab_size):
     norm_logits = torch.zeros(batch_size, vocab_size, dtype=torch.float)
     # We have 4 buckets, each corresponding to 0.25 of the total weights
     # With populations corresponding to 0.4, 0.3, 0.2 and 0.1 percent of the vocab_size
-    buckets = [0.4, 0.3, 0.2, 0.1]
+    buckets = [0.5, 0.2, 0.2, 0.1]
     bucket_weight = 1.0 / len(buckets)
     index = 0
     for bucket in buckets:

--- a/tests/inference/test_modeling_decoder.py
+++ b/tests/inference/test_modeling_decoder.py
@@ -103,7 +103,9 @@ def test_model_from_path(neuron_model_path):
 @is_inferentia_test
 @requires_neuronx
 def test_model_from_hub():
-    model = NeuronModelForCausalLM.from_pretrained("dacorvo/tiny-random-gpt2-neuronx")
+    model = NeuronModelForCausalLM.from_pretrained(
+        "dacorvo/tiny-random-gpt2-neuronx", revision="320d42fb0968d4f7857a00eb65a301e977098aa0"
+    )
     _check_neuron_model(model)
 
 


### PR DESCRIPTION
This is to prepare a breaking change in generative model serialization.