### PR TITLE
Fix neuron pipelines

### DIFF
--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -158,7 +158,7 @@ def pipeline(
     feature_extractor: Optional[Union[str, PreTrainedFeatureExtractor]] = None,
     use_fast: bool = True,
     export: bool = False,
-    input_shapes: Optional[Dict[str, int]] = None,
+    input_shapes: Optional[Dict[str, int]] = {},
     token: Optional[Union[str, bool]] = None,
     revision: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
@@ -191,8 +191,7 @@ def pipeline(
         input_shapes["batch_size"] = config.neuron_batch_size
         input_shapes["sequence_length"] = config.neuron_sequence_length
 
-    # check if input shapes are provided and if not use default ones
-    if input_shapes is None and export:
+    if export and not input_shapes:
         input_shapes = {"batch_size": 1, "sequence_length": 128}
         logger.warning(f"No input shapes provided, using default shapes, {input_shapes}")
 

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -104,22 +104,24 @@ def load_pipeline(
     subfolder: str = "",
     token: Optional[Union[bool, str]] = None,
     revision: str = "main",
-    model_kwargs: Optional[Dict[str, Any]] = None,
+    compiler_args: Optional[Dict[str, Any]] = {},
     config: AutoConfig = None,
+    hub_kwargs: Optional[Dict[str, Any]] = {},
     **kwargs,
 ):
-    if model_kwargs is None:
-        model_kwargs = {}
-
     # loads default model
     if model is None:
         model_id = supported_tasks[targeted_task]["default"]
-        model = supported_tasks[targeted_task]["class"][0].from_pretrained(model_id, export=True, **input_shapes)
+        model = supported_tasks[targeted_task]["class"][0].from_pretrained(
+            model_id, export=True, **compiler_args, **input_shapes, **hub_kwargs, **kwargs
+        )
     # loads model from model id and converts it to neuronx optionally
     elif isinstance(model, str):
         model_id = model
         neuronx_model_class = supported_tasks[targeted_task]["class"][0]
-        model = neuronx_model_class.from_pretrained(model, export=export, **model_kwargs, **input_shapes)
+        model = neuronx_model_class.from_pretrained(
+            model, export=export, **compiler_args, **input_shapes, **hub_kwargs, **kwargs
+        )
     # uses neuron model
     elif isinstance(model, NeuronBaseModel):
         if tokenizer is None and load_tokenizer:
@@ -158,10 +160,10 @@ def pipeline(
     use_fast: bool = True,
     export: bool = False,
     input_shapes: Optional[Dict[str, int]] = {},
+    compiler_args: Optional[Dict[str, int]] = {},
     token: Optional[Union[str, bool]] = None,
     revision: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
-    *model_kwargs,
     **kwargs,
 ) -> Pipeline:
     if task not in NEURONX_SUPPORTED_TASKS:
@@ -233,12 +235,11 @@ def pipeline(
         load_feature_extractor,
         export=export,
         input_shapes=input_shapes,
+        compiler_args=compiler_args,
         supported_tasks=NEURONX_SUPPORTED_TASKS,
         config=config,
         hub_kwargs=hub_kwargs,
         token=token,
-        *model_kwargs,
-        **kwargs,
     )
 
     if tokenizer is None and load_tokenizer:

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -39,7 +39,7 @@ def test_load_tensor_for_weight():
         tmpdir = Path(tmpdirname)
         filename = tmpdir / "tensors.safetensors"
 
-        t1 = torch.empty((24, 24), dtype=torch.bfloat16)
+        t1 = torch.randn((24, 24), dtype=torch.bfloat16)
         # Creating a slice from t1, meaning that it shares the same storage as t1.
         # It is important to make sure that the resulting loaded file does not have a bigger storage than needed.
         t2 = t1[:2, :2].contiguous()

--- a/tests/pipelines/test_decoder_pipelines.py
+++ b/tests/pipelines/test_decoder_pipelines.py
@@ -22,3 +22,10 @@ def _test_generation(p):
 def test_export_no_parameters(inf_decoder_model):
     p = pipeline("text-generation", inf_decoder_model, export=True)
     _test_generation(p)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_load_no_parameters(inf_decoder_path):
+    p = pipeline("text-generation", inf_decoder_path)
+    _test_generation(p)

--- a/tests/pipelines/test_decoder_pipelines.py
+++ b/tests/pipelines/test_decoder_pipelines.py
@@ -45,3 +45,12 @@ def test_error_already_exported(inf_decoder_path):
 def test_error_needs_export(inf_decoder_model):
     with pytest.raises(ValueError, match="must be exported"):
         pipeline("text-generation", inf_decoder_model, export=False)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_from_hub():
+    model_id = "dacorvo/tiny-random-gpt2-neuronx"
+    revision = "b8f1aec89f9b278721068bfe616fa9227c1d0238"
+    p = pipeline("text-generation", model_id, revision=revision)
+    _test_generation(p)

--- a/tests/pipelines/test_decoder_pipelines.py
+++ b/tests/pipelines/test_decoder_pipelines.py
@@ -1,3 +1,5 @@
+import pytest
+
 from optimum.neuron import NeuronModelForCausalLM
 from optimum.neuron.pipelines import pipeline
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
@@ -29,3 +31,17 @@ def test_export_no_parameters(inf_decoder_model):
 def test_load_no_parameters(inf_decoder_path):
     p = pipeline("text-generation", inf_decoder_path)
     _test_generation(p)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_error_already_exported(inf_decoder_path):
+    with pytest.raises(ValueError, match="already been exported"):
+        pipeline("text-generation", inf_decoder_path, export=True)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_error_needs_export(inf_decoder_model):
+    with pytest.raises(ValueError, match="must be exported"):
+        pipeline("text-generation", inf_decoder_model, export=False)


### PR DESCRIPTION
This fixes a few issues with the neuron pipelines:

- not passing `input_shapes` to the `pipeline()` method with `export=False` led to errors if the model was not a model instance,
- the model static `batch_size` was never passed to the pipeline, leading to all inputs being processed individually,
- inconsistent parameters to `pipeline()` were not correctly checked,
- `hub_kwargs` was never passed to `from_pretrained()`.

Several tests are added for decoder models to check all features are correctly implemented. 

I also renamed `model_kwargs` to `compiler_args` to match the names used in other places.

Finally, I fixed the long-standing `load_tensor_for_weight` failure, that could have allowed me to get my first green CI, but alas there is an issue with the trainium test cache on the hub.