### PR TITLE
Fix neuron cache starting compilation before fetching

### DIFF
--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -182,7 +182,7 @@ class AugmentTrainerForNeuronMixin:
             original_neuron_cache_path=_ORIGINAL_NEURON_CACHE_PATH,
             fetch=fetch,
             push=push,
-            wait_for_everyone_on_fetch=False,
+            wait_for_everyone_on_fetch=True,
             wait_for_everyone_on_push=True,
         )
         self.add_callback(callback)


### PR DESCRIPTION
This PR applies the [suggested fix ](https://github.com/huggingface/optimum-neuron/issues/271#issuecomment-1787748978) by @5cp to prevent compilation to start before finishing fetching the model compilation files from the Neuron cache.