### PR TITLE
Add missing decoder model architectures

### DIFF
--- a/docs/source/package_reference/export.mdx
+++ b/docs/source/package_reference/export.mdx
@@ -17,13 +17,13 @@ limitations under the License.
 # Inferentia Exporter
 
 You can export a PyTorch model to Neuron with 🤗 Optimum to run inference on AWS [Inferntia 1](https://aws.amazon.com/ec2/instance-types/inf1/)
-and [Inferentia 2](https://aws.amazon.com/ec2/instance-types/inf2/). 
+and [Inferentia 2](https://aws.amazon.com/ec2/instance-types/inf2/).
 
 ## Export functions
 
 There is an export function for each generation of the Inferentia accelerator, [`~optimum.exporters.neuron.convert.export_neuron`]
 for INF1 and [`~optimum.exporters.onnx.convert.export_neuronx`] on INF2, but you will be able to use directly the export function [`~optimum.exporters.neuron.convert.export`], which will select the proper
-exporting function according to the environment. 
+exporting function according to the environment.
 
 Besides, you can check if the exported model is valid via [`~optimum.exporters.neuron.convert.validate_model_outputs`], which compares
 the compiled model's output on Neuron devices to the PyTorch model's output on CPU.
@@ -56,6 +56,7 @@ Since many architectures share similar properties for their Neuron configuration
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | ALBERT                 | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | BERT                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| BLOOM                  | text-generation                                                                                                                               |
 | CamemBERT              | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | ConvBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | DeBERTa (INF2 only)    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
@@ -64,8 +65,10 @@ Since many architectures share similar properties for their Neuron configuration
 | ELECTRA                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | FlauBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | GPT2                   | text-generation                                                                                                                               |
+| Llama, Llama 2         | text-generation                                                                                                                               |
 | MobileBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | MPNet                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| OPT                    | text-generation                                                                                                                               |
 | RoBERTa                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | RoFormer               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | XLM                    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |


### PR DESCRIPTION
The supported model table had not been updated since the addition of `llama`, `opt` and `bloom`.