### PR TITLE
Transformers fix and doc update

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -10,12 +10,16 @@
       title: Overview
     - local: tutorials/fine_tune_bert
       title: Fine-tune BERT for Text Classification on AWS Trainium
+    - local: tutorials/llama2-13b-chatbot
+      title: Create your own chatbot with llama-2-13B on AWS Inferentia
+    - local: tutorials/deploy-neuron-tgi
+      title: Deploy a Text-generation-inference server for Neuron models
     title: Tutorials
   - sections:
     - local: guides/overview
       title: Overview
     - local: guides/setup_aws_instance
-      title: Set up AWS Trainium instance            
+      title: Set up AWS Trainium instance
     - local: guides/cache_system
       title: Neuron model cache
     - local: guides/fine_tune
@@ -23,7 +27,7 @@
     - local: guides/export_model
       title: Export a model to Inferentia
     - local: guides/models
-      title: Neuron models for inference 
+      title: Neuron models for inference
     - local: guides/pipelines
       title: Inference pipelines with AWS Neuron
     title: How-To Guides

--- a/docs/source/tutorials/deploy-neuron-tgi.mdx
+++ b/docs/source/tutorials/deploy-neuron-tgi.mdx
@@ -1,0 +1,133 @@
+<!---
+Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Deploy a Text-generation-inference server for Neuron models
+
+The Hugging Face [Text Generation Inference](https://github.com/huggingface/text-generation-inference) product provides the following features:
+
+- continuous batching,
+- token streaming,
+- greedy search and multinomial sampling using [transformers](https://huggingface.co/docs/transformers/generation_strategies#customize-text-generation).
+
+
+## Deploy the service
+
+The service is launched simply by running the `neuronx-tgi` container with two sets of parameters:
+
+```shell
+docker run <system_parameters> ghrc.io/huggingface/neuronx-tgi:latest <service_parameters>
+```
+
+- system parameters are used to map ports, volumes and devices between the host and the service,
+- service parameters are forwarded to the `text-generation-launcher`.
+
+The snippet below shows how you can deploy a service from a hub neuron model:
+
+```shell
+docker run -p 8080:80 \
+       -v $(pwd)/data:/data \
+       --device=/dev/neuron0 \
+       ghrc.io/huggingface/neuronx-tgi:latest \
+       --model-id aws-neuron/Llama-2-7b-hf-neuron-budget \
+       --max-concurrent-requests 1 \
+       --max-input-length 1024 \
+       --max-total-tokens 2048 \
+       --max-batch-prefill-tokens 1024 \
+       --max-batch-total-tokens 2048
+```
+
+Note that we export a shared volume mounted as `/data` in the container: this is where the hub model will be cached to
+speed up further instantiations of the service.
+
+Note also that all neuron devices have to be explicitly made visible to the container.
+
+For instance, if your instance has 12 neuron devices, the launch command becomes:
+
+```shell
+docker run -p 8080:80 \
+       -v $(pwd)/data:/data \
+       --device=/dev/neuron0 \
+       --device=/dev/neuron1 \
+       --device=/dev/neuron2 \
+       --device=/dev/neuron3 \
+       --device=/dev/neuron4 \
+       --device=/dev/neuron5 \
+       --device=/dev/neuron6 \
+       --device=/dev/neuron7 \
+       --device=/dev/neuron8 \
+       --device=/dev/neuron9 \
+       --device=/dev/neuron10 \
+       --device=/dev/neuron11 \
+       ...
+```
+
+### Choosing service parameters
+
+Use the following command to list the available service parameters:
+
+```
+docker run ghcr.io/huggingface/neuronx-tgi --help
+```
+
+The configuration of an inference endpoint is always a compromise between throughput and latency: serving more requests in parallel will allow a higher throughput, but it will increase the latency.
+
+The neuron models have static input dimensions `[batch_size, max_length]`.
+
+It leads to a maximum number of tokens of `max_tokens = batch_size * max_length`.
+
+This adds several restrictions to the following parameters:
+
+- `--max-concurrent-requests` must be set to `batch size`,
+- `--max-input-length` must be lower than `max_length`,
+- `--max-total-tokens` must be set to `max_length` (it is per-request),
+- `--max-batch-prefill-tokens` must be lower than `max_tokens`,
+- `--max-batch-total-tokens` must be set to `max_tokens`.
+
+### Choosing the correct batch size
+
+As seen in the previous paragraph, neuron model static batch size has a direct influence on the endpoint latency and throughput.
+
+Please refer to [text-generation-inference](https://github.com/huggingface/text-generation-inference) for optimization hints.
+
+Note that the main constraint is to be able to fit the model for the specified `batch_size` within the total device memory available
+on your instance (16GB per neuron core, with 2 cores per device).
+
+All neuron models on the 🤗 [HuggingFace Hub](https://huggingface.co/aws-neuron) include the number of cores required to run them.
+
+## Query the service
+
+You can query the model using either the `/generate` or `/generate_stream` routes:
+
+```
+curl 127.0.0.1:8080/generate \
+    -X POST \
+    -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":20}}' \
+    -H 'Content-Type: application/json'
+```
+
+```
+curl 127.0.0.1:8080/generate_stream \
+    -X POST \
+    -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":20}}' \
+    -H 'Content-Type: application/json'
+```
+
+## License
+
+The Text-generation-inference service is released under [HFOIL 1.0](https://github.com/huggingface/text-generation-inference/blob/bde25e62b33b05113519e5dbf75abda06a03328e/LICENSE).
+
+HFOIL stands for Hugging Face Optimized Inference License, and it has been specifically designed for our optimized inference solutions. While the source code remains accessible, HFOIL is not a true open source license because we added a restriction: to sell a hosted or managed service built on top of TGI, we require a separate agreement.
+
+Please refer to [this reference documentation](https://github.com/huggingface/text-generation-inference/issues/726) to see if the HFOIL 1.0 restrictions apply to your deployment.

--- a/docs/source/tutorials/deploy-neuron-tgi.mdx
+++ b/docs/source/tutorials/deploy-neuron-tgi.mdx
@@ -27,7 +27,7 @@ The Hugging Face [Text Generation Inference](https://github.com/huggingface/text
 The service is launched simply by running the `neuronx-tgi` container with two sets of parameters:
 
 ```shell
-docker run <system_parameters> ghrc.io/huggingface/neuronx-tgi:latest <service_parameters>
+docker run <system_parameters> ghcr.io/huggingface/neuronx-tgi:latest <service_parameters>
 ```
 
 - system parameters are used to map ports, volumes and devices between the host and the service,
@@ -39,7 +39,7 @@ The snippet below shows how you can deploy a service from a hub neuron model:
 docker run -p 8080:80 \
        -v $(pwd)/data:/data \
        --device=/dev/neuron0 \
-       ghrc.io/huggingface/neuronx-tgi:latest \
+       ghcr.io/huggingface/neuronx-tgi:latest \
        --model-id aws-neuron/Llama-2-7b-hf-neuron-budget \
        --max-concurrent-requests 1 \
        --max-input-length 1024 \

--- a/docs/source/tutorials/llama2-13b-chatbot.mdx
+++ b/docs/source/tutorials/llama2-13b-chatbot.mdx
@@ -1,0 +1,251 @@
+<!---
+Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Create your own chatbot with llama-2-13B on AWS Inferentia
+
+*There is a notebook version of that tutorial [here](https://github.com/huggingface/optimum-neuron/blob/main/notebooks/text-generation/llama2-13b-chatbot.ipynb)*.
+
+This guide will detail how to export, deploy and run a **LLama-2 13B** chat model on AWS inferentia.
+
+You will learn how to:
+- export the Llama-2 model to the Neuron format,
+- push the exported model to the Hugging Face Hub,
+- deploy the model and use it in a chat application.
+
+Note: This tutorial was created on a inf2.48xlarge AWS EC2 Instance.
+
+## 1. Export the Llama 2 model to Neuron
+
+For this guide, we will use the non-gated [NousResearch/Llama-2-13b-chat-hf](https://huggingface.co/NousResearch/Llama-2-13b-chat-hf) model, which is functionally equivalent to the original [meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf).
+
+This model is part of the **Llama 2** family of models, and has been tuned to recognize chat interactions
+between a *user* and an *assistant* (more on that later).
+
+As explained in the [optimum-neuron documentation](https://huggingface.co/docs/optimum-neuron/guides/export_model#why-compile-to-neuron-model)
+, models need to be compiled and exported to a serialized format before running them on Neuron devices.
+
+Fortunately, 🤗 **optimum-neuron** offers a [very simple API](https://huggingface.co/docs/optimum-neuron/guides/models#configuring-the-export-of-a-generative-model)
+to export standard 🤗 [transformers models](https://huggingface.co/docs/transformers/index) to the Neuron format.
+
+When exporting the model, we will specify two sets of parameters:
+
+- using *compiler_args*, we specify on how many cores we want the model to be deployed (each neuron device has two cores), and with which precision (here *float16*),
+- using *input_shapes*, we set the static input and output dimensions of the model. All model compilers require static shapes, and neuron makes no exception. Note that the
+*sequence_length* not only constrains the length of the input context, but also the length of the Key/Value cache, and thus, the output length.
+
+Depending on your choice of parameters and inferentia host, this may take from a few minutes to more than an hour.
+
+For your convenience, we host a pre-compiled version of that model on the Hugging Face hub, so you can skip the export and start using the model immediately in paragraph 2.
+
+
+```python
+from optimum.neuron import NeuronModelForCausalLM
+
+compiler_args = {"num_cores": 24, "auto_cast_type": 'fp16'}
+input_shapes = {"batch_size": 1, "sequence_length": 2048}
+model = NeuronModelForCausalLM.from_pretrained(
+        "NousResearch/Llama-2-13b-chat-hf",
+        export=True,
+        **compiler_args,
+        **input_shapes)
+```
+
+This will probably take a while.
+
+Fortunately, you will need to do this only once because you can save your model and reload it later.
+
+
+```python
+model.save_pretrained("llama-2-13b-chat-neuron")
+```
+
+Even better, you can push it to the [Hugging Face hub](https://huggingface.co/models).
+
+For that, you need to be logged in to a [HuggingFace account](https://huggingface.co/join).
+
+In the terminal, just type the following command and paste your Hugging Face token when requested:
+
+```shell
+huggingface-cli login
+```
+
+By default, the model will be uploaded to your account (organization equal to your user name).
+
+Feel free to edit the code below if you want to upload the model to a specific [Hugging Face organization](https://huggingface.co/docs/hub/organizations).
+
+
+```python
+from huggingface_hub import whoami
+
+org = whoami()['name']
+
+repo_id = f"{org}/llama-2-13b-chat-neuron"
+
+model.push_to_hub("llama-2-13b-chat-neuron", repository_id=repo_id)
+```
+
+### A few more words about export parameters.
+
+The minimum memory required to load a model can be computed with:
+
+```
+   memory = bytes per parameter * number of parameters
+```
+
+The **Llama 2 13B** model uses *float16* weights (stored on 2 bytes) and has 13 billion parameters, which means it requires at least 2 * 13B or ~26GB of memory to store its weights.
+
+Each NeuronCore has 16GB of memory which means that a 26GB model cannot fit on a single NeuronCore.
+
+In reality, the total space required is much greater than just the number of parameters due to caching attention layer projections (KV caching).
+This caching mechanism grows memory allocations linearly with sequence length and batch size.
+
+Here we set the *batch_size* to 1, meaning that we can only process one input prompt in parallel. We set the *sequence_length* to 2048, which corresponds to half the model maximum capacity (4096).
+
+The formula to evaluate the size of the KV cache is more involved as it also depends on parameters related to the model architecture, such as the width of the embeddings and the number of decoder blocks.
+
+Bottom-line is, to get very large language models to fit, tensor parallelism is used to split weights, data, and compute across multiple NeuronCores, keeping in mind that the memory on each core cannot exceed 16GB.
+
+Note that increasing the number of cores beyond the minimum requirement almost always results in a faster model.
+Increasing the tensor parallelism degree improves memory bandwidth which improves model performance.
+
+To optimize performance it's recommended to use all cores available on the instance.
+
+In this guide we use all the 24 cores of the *inf2.48xlarge*, but this should be changed to 12 if you are
+using a *inf2.24xlarge* instance.
+
+## 2. Generate text using Llama 2 on AWS Inferentia2
+
+Once your model has been exported, you can generate text using the transformers library, as it has been described in [detail in this post](https://huggingface.co/blog/how-to-generate).
+
+If as suggested you skipped the first paragraph, don't worry: we will use a precompiled model already present on the hub instead.
+
+
+```python
+from optimum.neuron import NeuronModelForCausalLM
+
+try:
+    model
+except NameError:
+    # Edit this to use another base model
+    model = NeuronModelForCausalLM.from_pretrained('aws-neuron/Llama-2-13b-chat-hf-neuron-latency')
+```
+
+We will need a *Llama 2* tokenizer to convert the prompt strings to text tokens.
+
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-13b-chat-hf")
+```
+
+The following generation strategies are supported:
+
+- greedy search,
+- multinomial sampling with top-k and top-p (with temperature).
+
+Most logits pre-processing/filters (such as repetition penalty) are supported.
+
+
+```python
+inputs = tokenizer("What is deep-learning ?", return_tensors="pt")
+outputs = model.generate(**inputs,
+                         max_new_tokens=128,
+                         do_sample=True,
+                         temperature=0.9,
+                         top_k=50,
+                         top_p=0.9)
+tokenizer.batch_decode(outputs, skip_special_tokens=True)
+```
+
+## 3. Create a chat application using llama on AWS Inferentia2
+
+We specifically selected a **Llama 2** chat variant to illustrate the excellent behaviour of the exported model when the length of the encoding context grows.
+
+The model expects the prompts to be formatted following a specific template corresponding to the interactions between a *user* role and an *assistant* role.
+
+Each chat model has its own convention for encoding such contents, and we will not go into too much details in this guide, because we will directly use the [Hugging Face chat templates](https://huggingface.co/blog/chat-templates) corresponding to our model.
+
+The utility function below converts a list of exchanges between the user and the model into a well-formatted chat prompt.
+
+
+```python
+def format_chat_prompt(message, history, max_tokens):
+    """ Convert a history of messages to a chat prompt
+
+
+    Args:
+        message(str): the new user message.
+        history (List[str]): the list of user messages and assistant responses.
+        max_tokens (int): the maximum number of input tokens accepted by the model.
+
+    Returns:
+        a `str` prompt.
+    """
+    chat = []
+    # Convert all messages in history to chat interactions
+    for interaction in history:
+        chat.append({"role": "user", "content" : interaction[0]})
+        chat.append({"role": "assistant", "content" : interaction[1]})
+    # Add the new message
+    chat.append({"role": "user", "content" : message})
+    # Generate the prompt, verifying that we don't go beyond the maximum number of tokens
+    for i in range(0, len(chat), 2):
+        # Generate candidate prompt with the last n-i entries
+        prompt = tokenizer.apply_chat_template(chat[i:], tokenize=False)
+        # Tokenize to check if we're over the limit
+        tokens = tokenizer(prompt)
+        if len(tokens.input_ids) <= max_tokens:
+            # We're good, stop here
+            return prompt
+    # We shall never reach this line
+    raise SystemError
+```
+
+We are now equipped to build a simplistic chat application.
+
+We simply store the interactions between the user and the assistant in a list that we use to generate
+the input prompt.
+
+
+```python
+history = []
+max_tokens = 1024
+
+def chat(message, history, max_tokens):
+    prompt = format_chat_prompt(message, history, max_tokens)
+    # Uncomment the line below to see what the formatted prompt looks like
+    #print(prompt)
+    inputs = tokenizer(prompt, return_tensors="pt")
+    outputs = model.generate(**inputs,
+                             max_length=2048,
+                             do_sample=True,
+                             temperature=0.9,
+                             top_k=50,
+                             repetition_penalty=1.2)
+    # Do not include the input tokens
+    outputs = outputs[0, inputs.input_ids.size(-1):]
+    response = tokenizer.decode(outputs, skip_special_tokens=True)
+    history.append([message, response])
+    return response
+```
+
+To test the chat application you can use for instance the following sequence of prompts:
+
+```python
+print(chat("My favorite color is blue. My favorite fruit is strawberry.", history, max_tokens))
+print(chat("Name a fruit that is on my favorite colour.", history, max_tokens))
+print(chat("What is the colour of my favorite fruit ?", history, max_tokens))
+```

--- a/docs/source/tutorials/overview.mdx
+++ b/docs/source/tutorials/overview.mdx
@@ -20,3 +20,4 @@ Welcome to the 🤗 Optimum Neuron how-to guides!
 These guides tackle more advanced topics and will show you how to easily get the best from HPUs:
 
 - [Getting started with AWS Trainium and Hugging Face Transformers](./fine_tune_bert)
+- [Create your own chatbot with llama-2-13B on AWS Inferentia](./llama2-13b-chatbot)

--- a/docs/source/tutorials/overview.mdx
+++ b/docs/source/tutorials/overview.mdx
@@ -21,3 +21,4 @@ These guides tackle more advanced topics and will show you how to easily get the
 
 - [Getting started with AWS Trainium and Hugging Face Transformers](./fine_tune_bert)
 - [Create your own chatbot with llama-2-13B on AWS Inferentia](./llama2-13b-chatbot)
+- [Deploy a Text-generation-inference server for Neuron models](./deploy-neuron-tgi)

--- a/docs/source/tutorials/overview.mdx
+++ b/docs/source/tutorials/overview.mdx
@@ -16,8 +16,8 @@ limitations under the License.
 
 # Overview
 
-Welcome to the 🤗 Optimum Neuron how-to guides!
-These guides tackle more advanced topics and will show you how to easily get the best from HPUs:
+Welcome to the 🤗 Optimum Neuron tutorials!
+These tutorials will help you quickly get started with AWS Trainium / Inferentia on the following topics:
 
 - [Getting started with AWS Trainium and Hugging Face Transformers](./fine_tune_bert)
 - [Create your own chatbot with llama-2-13B on AWS Inferentia](./llama2-13b-chatbot)

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -3,3 +3,4 @@
 | Notebook                                                                                                | Task                | Model Architectures                                                 |
 | ------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------ |
 | [Getting started with AWS Trainium and Hugging Face Transformers](./text-classification/notebook.ipynb) | text-classification | BERT, RoBERTa, DistilBERT, XLM-RoBERTa, ALBERT, Electra, CamemBERT |
+| [Create your own chatbot with llama-2-13B on AWS Inferentia](./text-generation/llama2-13b-chatbot.ipynb) | text-generation | Llama 2 |

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -35,7 +35,7 @@ from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_ver
 
 if is_transformers_neuronx_available():
     from transformers_neuronx.module import PretrainedModel as NeuronxPretrainedModel
-    from transformers_neuronx.module import save_pretrained_split
+    from transformers_neuronx.module import save_split
 
 
 if TYPE_CHECKING:
@@ -132,7 +132,9 @@ class NeuronDecoderModel(OptimizedModel):
 
         # Save the model checkpoint in a temporary directory
         checkpoint_dir = TemporaryDirectory()
-        save_pretrained_split(model, checkpoint_dir.name)
+        model.save_pretrained(
+            checkpoint_dir.name, save_function=save_split, safe_serialization=False, max_shard_size="10000GB"
+        )
 
         # If the sequence_length was not specified, deduce it from the model configuration
         if sequence_length is None:
@@ -282,4 +284,6 @@ class NeuronDecoderModel(OptimizedModel):
             exist_ok=True,
             private=private,
         )
-        api.upload_folder(repo_id=repository_id, folder_path=save_directory, token=huggingface_token, revision=revision)
+        api.upload_folder(
+            repo_id=repository_id, folder_path=save_directory, token=huggingface_token, revision=revision
+        )

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -107,6 +107,8 @@ class NeuronDecoderModel(OptimizedModel):
         sequence_length: Optional[int] = None,
         num_cores: Optional[int] = 2,
         auto_cast_type: Optional[str] = "fp32",
+        low_cpu_mem_usage: Optional[str] = True,
+        torch_dtype: Optional[Union[str, torch.dtype]] = "auto",
         **kwargs,
     ) -> "NeuronDecoderModel":
         if not is_transformers_neuronx_available():
@@ -127,6 +129,8 @@ class NeuronDecoderModel(OptimizedModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
+            low_cpu_mem_usage=low_cpu_mem_usage,
+            torch_dtype=torch_dtype,
             **kwargs,
         )
 

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -282,14 +282,4 @@ class NeuronDecoderModel(OptimizedModel):
             exist_ok=True,
             private=private,
         )
-        for path, subdirs, files in os.walk(save_directory):
-            for name in files:
-                local_file_path = os.path.join(path, name)
-                hub_file_path = os.path.relpath(local_file_path, save_directory)
-                api.upload_file(
-                    token=huggingface_token,
-                    repo_id=repository_id,
-                    path_or_fileobj=os.path.join(os.getcwd(), local_file_path),
-                    path_in_repo=hub_file_path,
-                    revision=revision,
-                )
+        api.upload_folder(repo_id=repository_id, folder_path=save_directory, token=huggingface_token, revision=revision)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers >= 4.33.1",
+    "transformers == 4.35.0",
     "accelerate == 0.23.0",
     "optimum >= 1.13.0",
     "huggingface_hub >= 0.14.0",

--- a/text-generation-inference/README.md
+++ b/text-generation-inference/README.md
@@ -33,7 +33,7 @@ Please refer to [this reference documentation](https://github.com/huggingface/te
 The service is launched simply by running the neuronx-tgi container with two sets of parameters:
 
 ```
-docker run <system_parameters> ghrc.io/huggingface/neuronx-tgi:latest <service_parameters>
+docker run <system_parameters> ghcr.io/huggingface/neuronx-tgi:latest <service_parameters>
 ```
 
 - system parameters are used to map ports, volumes and devices between the host and the service,
@@ -47,7 +47,7 @@ The snippet below shows how you can deploy a service from a hub neuron model:
 docker run -p 8080:80 \
        -v $(pwd)/data:/data \
        --device=/dev/neuron0 \
-       ghrc.io/huggingface/neuronx-tgi:latest \
+       ghcr.io/huggingface/neuronx-tgi:latest \
        --model-id aws-neuron/Llama-2-7b-hf-neuron-budget \
        --max-concurrent-requests 1 \
        --max-input-length 1024 \
@@ -89,7 +89,7 @@ Alternatively, you can first [export the model to neuron format](https://hugging
 docker run -p 8080:80 \
        -v $(pwd)/data:/data \
        --device=/dev/neuron0 \
-       ghrc.io/huggingface/neuronx-tgi:latest \
+       ghcr.io/huggingface/neuronx-tgi:latest \
        --model-id /data/<neuron_model_path> \
        ...
 ```


### PR DESCRIPTION
This modifies the serialization of `transformers-neuronx` checkpoints to avoid using `safetensors` (default option in `transformers >= 4.35.0`). To avoid further breaking changes, the `transformers` version is now pinned.

This also modifies the `NeuronModelForCausalLM.push_to_hub` method to avoid commiting each checkpoint file individually (each file is still uploaded individually though).

This also adds two new tutorials based on the `llama2 13B` notebook and the TGI README.

Finally, this sets two options in `NeuronModelForCausalLM.from_pretrained` to limit CPU memory usage.