### PR TITLE
Add sagemaker compatible image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ $(PACKAGE_DIST) $(PACKAGE_WHEEL): $(PACKAGE_FILES)
 neuronx-tgi: $(PACKAGE_DIST)
 	docker build --rm -f text-generation-inference/Dockerfile --build-arg VERSION=$(VERSION) -t neuronx-tgi:$(VERSION) .
 
+neuronx-tgi-sagemaker: $(PACKAGE_DIST)
+	docker build --rm -f text-generation-inference/Dockerfile --target sagemaker --build-arg VERSION=$(VERSION) -t neuronx-tgi:$(VERSION) .
+
 # Creates example scripts from Transformers
 transformers_examples:
 	rm -f examples/**/*.py

--- a/text-generation-inference/Dockerfile
+++ b/text-generation-inference/Dockerfile
@@ -125,6 +125,14 @@ COPY --from=builder /usr/src/target/release/text-generation-launcher /usr/local/
 COPY --from=pyserver /pyserver/build/dist dist
 RUN pip install dist/text-generation-server*.tar.gz
 
+# AWS Sagemaker compatible image
+FROM neuron as sagemaker
+
+COPY text-generation-inference/sagemaker-entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]
+
 # Final image
 FROM neuron
 

--- a/text-generation-inference/sagemaker-entrypoint.sh
+++ b/text-generation-inference/sagemaker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+  echo "HF_MODEL_ID must be set"
+  exit 1
+fi
+export MODEL_ID="${HF_MODEL_ID}"
+
+if [[ -n "${HF_MODEL_REVISION}" ]]; then
+  export REVISION="${HF_MODEL_REVISION}"
+fi
+
+if [[ -n "${HF_MODEL_TRUST_REMOTE_CODE}" ]]; then
+  export TRUST_REMOTE_CODE="${HF_MODEL_TRUST_REMOTE_CODE}"
+fi
+
+text-generation-launcher --port 8080


### PR DESCRIPTION
The base neuronx-tgi image does not contain the entrypoint script that is required for sagemaker.

This adds a specific target and the associated build command in the Makefile.