### PR TITLE
Add mark step before computing model hash

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -48,7 +48,8 @@ jobs:
       shell: bash
       run: |
         pytest -m "not is_staging_test and not is_trainium_test and not is_inferentia_test" tests
-    - name: Staging Test with Pytest
-      shell: bash
-      run: |
-        HUGGINGFACE_CO_STAGING="1" pytest -m "is_staging_test and not is_trainium_test and not is_inferentia_test" tests
+    # Commenting because there is no such test for now, but couuld be useful one day.
+    # - name: Staging Test with Pytest
+    #   shell: bash
+    #   run: |
+    #     HUGGINGFACE_CO_STAGING="1" pytest -m "is_staging_test and not is_trainium_test and not is_inferentia_test" tests

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -44,6 +44,7 @@ from packaging import version
 
 from ...utils import logging
 from ...utils.logging import warn_once
+from ..utils.require_utils import requires_torch_xla
 from .constant import NEURON_BINARIES_PATH
 from .misc import string_to_bool
 from .version_utils import get_neuronxcc_version
@@ -622,7 +623,11 @@ class NeuronHash:
         else:
             hash_dict[attribute_name] = attribute
 
+    @requires_torch_xla
     def state_dict_to_bytes(self, state_dict: Dict[str, torch.Tensor]) -> bytes:
+        import torch_xla.core.xla_model as xm
+
+        xm.mark_step()
         cast_to_mapping = {
             torch.bfloat16: torch.float16,
         }

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -344,6 +344,7 @@ class StagingNeuronUtilsTestCase(StagingTestMixin, TestCase):
         _test_list_in_registry(True)
 
 
+@is_trainium_test
 class NeuronHashTestCase(TestCase):
     def test_neuron_hash_is_not_mutable(self):
         bert_model = BertModel(BertConfig())

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -244,6 +244,7 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
 
 
 @is_staging_test
+@is_trainium_test
 class StagingNeuronUtilsTestCase(StagingTestMixin, TestCase):
     def test_set_custom_cache_repo_name_in_hf_home(self):
         orig_token = HfFolder.get_token()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -83,7 +83,7 @@ class TestExampleRunner(TestCase):
     @parameterized.expand(TO_TEST)
     def test_run_example(self, task, model_name_or_path, sequence_length):
         runner = ExampleRunner(model_name_or_path, task, use_venv=False)
-        returncode, stdout = runner.run(1, "bf16", 1, sequence_length=sequence_length, max_steps=10, save_steps=5)
+        returncode, stdout = runner.run(2, "bf16", 1, sequence_length=sequence_length, max_steps=10, save_steps=5)
         print(stdout)
         if returncode != 0:
             self.fail(f"ExampleRunner failed for task {task}.\nStandard output:\n{stdout}")


### PR DESCRIPTION
This PR adds a `xm.mark_step()` right before moving the model weighs to the CPU following @aws-rhsoln suggestion in #301 .

@aws-rhsoln since we do not do any forward pass prior to that, is this `xm.mark_step()` going to do anything? At this point no graph was recorded.