### PR TITLE
Deleted the 'maybe_free_model_hooks()' from Diffusers Pipelines

### DIFF
--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
@@ -388,9 +388,6 @@ class NeuronStableDiffusionInpaintPipelineMixin(StableDiffusionPipelineMixin, St
 
         image = self.image_processor.postprocess(image, output_type=output_type, do_denormalize=do_denormalize)
 
-        # Offload all models
-        self.maybe_free_model_hooks()
-
         if not return_dict:
             return (image, has_nsfw_concept)
 

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
@@ -506,9 +506,6 @@ class NeuronStableDiffusionXLImg2ImgPipelineMixin(StableDiffusionXLPipelineMixin
 
         image = self.image_processor.postprocess(image, output_type=output_type)
 
-        # Offload all models
-        self.maybe_free_model_hooks()
-
         if not return_dict:
             return (image,)
 

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
@@ -564,9 +564,6 @@ class NeuronStableDiffusionXLInpaintPipelineMixin(StableDiffusionXLPipelineMixin
 
         image = self.image_processor.postprocess(image, output_type=output_type)
 
-        # Offload all models
-        self.maybe_free_model_hooks()
-
         if not return_dict:
             return (image,)
 


### PR DESCRIPTION
As described in: #327 issue the maybe_free_model_hooks() present in the following 3 pipelines:
- optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py:392
- [optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_x|_img2img.py:510](https://github.com/huggingface/optimum-neuron/blame/fb283d74310b573116312de993106964437a1595/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py#L510)
- optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_x|_inpaint.py:568

is removed.
This will allow the pipelines to work as expected.