### PR TITLE
update ckpt conversion flow to use the new sharded ckpt path structure

### DIFF
--- a/optimum/neuron/distributed/checkpointing.py
+++ b/optimum/neuron/distributed/checkpointing.py
@@ -38,12 +38,10 @@ def consolidate_tensor_parallel_checkpoints(checkpoint_dir: Union[str, Path]) ->
 
     state_dicts = []
 
-    for sharded_checkpoint in checkpoint_dir.glob("tp_rank_*"):
+    for sharded_checkpoint in sorted(checkpoint_dir.glob("tp_rank_*/checkpoint.pt")):
         if not sharded_checkpoint.is_file():
             continue
         state_dicts.append(torch.load(sharded_checkpoint))
-
-    state_dicts = sorted(state_dicts, key=lambda d: d["tp_rank"])
 
     parameter_names = state_dicts[0]["model"].keys()
     sharded_metadatas = {


### PR DESCRIPTION
This [recent change](https://github.com/aws-neuron/neuronx-distributed/commit/a8bce14394c80909f1f68ce9792cfd47da85d285#diff-03393251b3e1f7eba603073ff0b1c3b434e0c755a8b6276bacdd30147f76844cR81) in neuronx-distributed affected the checkpoint paths/filenames when saving sharded checkpoints.

This PR adjusts Optimum Neuron's checkpoint consolidation code to use the new path/filename structure.