### PR TITLE
Remove numpy pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ INSTALL_REQUIRES = [
     "accelerate == 0.23.0",
     "optimum >= 1.13.0",
     "huggingface_hub >= 0.14.0",
-    "numpy>=1.22.2, <=1.25.2",
     "protobuf<4",
 ]
 


### PR DESCRIPTION
numpy versioning is determined by neuronx-cc. Having pinning also here can cause issues post-installation when `neuronx-cc` changes its pinnings.

For the future release, `neuronx-cc` will have `numpy>=1.24.3, <=1.25.2`.