### PR TITLE
[Stable Diffusion - LCM] Add dp option for loading the whole pipe to all cores

### DIFF
--- a/docs/source/tutorials/stable_diffusion.mdx
+++ b/docs/source/tutorials/stable_diffusion.mdx
@@ -74,7 +74,7 @@ Besides, don't hesitate to tweak the compilation configuration to find the best 
 >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
 >>> input_shapes = {"batch_size": 1, "height": 512, "width": 512}
 
->>> stable_diffusion = NeuronStableDiffusionPipeline.from_pretrained(model_id, export=True, **compiler_args, **input_shapes, device_ids=[0, 1])
+>>> stable_diffusion = NeuronStableDiffusionPipeline.from_pretrained(model_id, export=True, **compiler_args, **input_shapes)
 
 # Save locally or upload to the HuggingFace Hub
 >>> save_directory = "sd_neuron/"
@@ -118,7 +118,7 @@ from optimum.neuron import NeuronStableDiffusionImg2ImgPipeline
 # compile & save
 model_id = "nitrosocke/Ghibli-Diffusion"
 input_shapes = {"batch_size": 1, "height": 512, "width": 512}
-pipeline = NeuronStableDiffusionImg2ImgPipeline.from_pretrained(model_id, export=True, **input_shapes, device_ids=[0, 1])
+pipeline = NeuronStableDiffusionImg2ImgPipeline.from_pretrained(model_id, export=True, **input_shapes)
 pipeline.save_pretrained("sd_img2img/")
 
 url = "https://raw.githubusercontent.com/CompVis/stable-diffusion/main/assets/stable-samples/img2img/sketch-mountains-input.jpg"
@@ -149,7 +149,7 @@ from optimum.neuron import NeuronStableDiffusionInpaintPipeline
 
 model_id = "runwayml/stable-diffusion-inpainting"
 input_shapes = {"batch_size": 1, "height": 512, "width": 512}
-pipeline = NeuronStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True, **input_shapes, device_ids=[0, 1])
+pipeline = NeuronStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True, **input_shapes)
 pipeline.save_pretrained("sd_inpaint/")
 
 def download_image(url):
@@ -214,7 +214,7 @@ Here is an example of exporting stable diffusion components with `NeuronStableDi
 >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
 >>> input_shapes = {"batch_size": 1, "height": 1024, "width": 1024}
 
->>> stable_diffusion_xl = NeuronStableDiffusionXLPipeline.from_pretrained(model_id, export=True, **compiler_args, **input_shapes, device_ids=[0, 1])
+>>> stable_diffusion_xl = NeuronStableDiffusionXLPipeline.from_pretrained(model_id, export=True, **compiler_args, **input_shapes)
 
 # Save locally or upload to the HuggingFace Hub
 >>> save_directory = "sd_neuron_xl/"
@@ -255,7 +255,7 @@ prompt = "a dog running, lake, moat"
 url = "https://huggingface.co/datasets/optimum/documentation-images/resolve/main/intel/openvino/sd_xl/castle_friedrich.png"
 init_image = load_image(url).convert("RGB")
 
-pipe = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl/", device_ids=[0, 1])
+pipe = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl/")
 image = pipe(prompt=prompt, image=init_image).images[0]
 ```
 
@@ -280,7 +280,7 @@ init_image = load_image(img_url).convert("RGB")
 mask_image = load_image(mask_url).convert("RGB")
 prompt = "A deep sea diver floating"
 
-pipe = NeuronStableDiffusionXLInpaintPipeline.from_pretrained("sd_neuron_xl/", device_ids=[0, 1])
+pipe = NeuronStableDiffusionXLInpaintPipeline.from_pretrained("sd_neuron_xl/")
 image = pipe(prompt=prompt, image=init_image, mask_image=mask_image, strength=0.85, guidance_scale=12.5).images[0]
 ```
 
@@ -301,7 +301,7 @@ SDXL includes a [refiner model](https://huggingface.co/stabilityai/stable-diffus
 from optimum.neuron import NeuronStableDiffusionXLPipeline, NeuronStableDiffusionXLImg2ImgPipeline
 
 prompt = "A majestic lion jumping from a big stone at night"
-base = NeuronStableDiffusionXLPipeline.from_pretrained("sd_neuron_xl/", device_ids=[0, 1])
+base = NeuronStableDiffusionXLPipeline.from_pretrained("sd_neuron_xl/")
 image = base(
     prompt=prompt,
     num_images_per_prompt=num_images_per_prompt,
@@ -311,7 +311,7 @@ image = base(
 ).images[0]
 del base  # To avoid neuron device OOM
 
-refiner = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl_refiner/", device_ids=[0, 1])
+refiner = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl_refiner/")
 image = image = refiner(
     prompt=prompt,
     num_inference_steps=40,
@@ -333,11 +333,11 @@ image = image = refiner(
 from optimum.neuron import NeuronStableDiffusionXLPipeline, NeuronStableDiffusionXLImg2ImgPipeline
 
 prompt = "A majestic lion jumping from a big stone at night"
-base = NeuronStableDiffusionXLPipeline.from_pretrained("sd_neuron_xl/", device_ids=[0, 1])
+base = NeuronStableDiffusionXLPipeline.from_pretrained("sd_neuron_xl/")
 image = base(prompt=prompt, output_type="latent").images[0]
 del base  # To avoid neuron device OOM
 
-refiner = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl_refiner/", device_ids=[0, 1])
+refiner = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained("sd_neuron_xl_refiner/")
 image = refiner(prompt=prompt, image=image[None, :]).images[0]
 ```
 

--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -469,7 +469,7 @@ def add_stable_diffusion_compiler_args(config, compiler_args):
     if "unet" in identifier:
         sdxl_ids = ["stable-diffusion-xl", "sdxl"]
         # SDXL unet doesn't support fast loading neuron binaries
-        if not any(sdxl_id in identifier for sdxl_id in sdxl_ids):
+        if not getattr(config, "is_sdxl", False) and not any(sdxl_id in identifier for sdxl_id in sdxl_ids):
             compiler_args.append("--enable-fast-loading-neuron-binaries")
         compiler_args.append("--model-type=unet-inference")
     return compiler_args

--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -467,9 +467,8 @@ def add_stable_diffusion_compiler_args(config, compiler_args):
         compiler_args.append("--enable-fast-loading-neuron-binaries")
     # unet
     if "unet" in identifier:
-        sdxl_ids = ["stable-diffusion-xl", "sdxl"]
         # SDXL unet doesn't support fast loading neuron binaries
-        if not getattr(config, "is_sdxl", False) and not any(sdxl_id in identifier for sdxl_id in sdxl_ids):
+        if not getattr(config, "is_sdxl", False):
             compiler_args.append("--enable-fast-loading-neuron-binaries")
         compiler_args.append("--model-type=unet-inference")
     return compiler_args

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -316,6 +316,14 @@ class UNetNeuronConfig(VisionNeuronConfig):
     def check_model_inputs_order(self, model, dummy_inputs):
         return self.ModelWrapper(model, list(dummy_inputs.keys()))
 
+    @property
+    def is_sdxl(self) -> bool:
+        return self._is_sdxl
+
+    @is_sdxl.setter
+    def is_sdxl(self, is_sdxl: bool):
+        self._is_sdxl = is_sdxl
+
 
 @register_in_tasks_manager("vae-encoder", *["semantic-segmentation"])
 class VaeEncoderNeuronConfig(VisionNeuronConfig):

--- a/optimum/exporters/neuron/utils.py
+++ b/optimum/exporters/neuron/utils.py
@@ -203,6 +203,8 @@ def get_stable_diffusion_models_for_export(
         dynamic_batch_size=dynamic_batch_size,
         **unet_input_shapes,
     )
+    if task == "stable-diffusion-xl":
+        unet_neuron_config.is_sdxl = True
     models_for_export[DIFFUSION_MODEL_UNET_NAME] = (unet, unet_neuron_config)
 
     # VAE Encoder

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -295,6 +295,8 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
             for submodel_name, submodel_path in submodels.items():
                 if submodel_path is not None and submodel_path.is_file():
                     submodels[submodel_name] = NeuronBaseModel.load_model(submodel_path)
+                else:
+                    submodels[submodel_name] = None
             submodels["unet"] = torch_neuronx.DataParallel(
                 torch.jit.load(unet_path),
                 [0, 1],

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -270,19 +270,46 @@ class NeuronStableDiffusionPipelineBase(NeuronBaseModel):
         if device_ids is None:
             device_ids = [0, 1]
 
-        text_encoder = NeuronBaseModel.load_model(text_encoder_path)
-        if len(device_ids) > 1:
-            unet = torch_neuronx.DataParallel(
-                torch.jit.load(unet_path),
-                device_ids,
-                set_dynamic_batching=dynamic_batch_size,
-            )
-        else:
-            unet = NeuronBaseModel.load_model(unet_path)
+        # text_encoder = NeuronBaseModel.load_model(text_encoder_path)
+        # if len(device_ids) > 1:
+        #     unet = torch_neuronx.DataParallel(
+        #         torch.jit.load(unet_path),
+        #         device_ids,
+        #         set_dynamic_batching=dynamic_batch_size,
+        #     )
+        # else:
+        #     unet = NeuronBaseModel.load_model(unet_path)
 
-        vae_decoder = NeuronBaseModel.load_model(vae_decoder_path) if vae_decoder_path is not None else None
-        vae_encoder = NeuronBaseModel.load_model(vae_encoder_path) if vae_encoder_path is not None else None
-        text_encoder_2 = NeuronBaseModel.load_model(text_encoder_2_path) if text_encoder_2_path is not None else None
+        # vae_decoder = NeuronBaseModel.load_model(vae_decoder_path) if vae_decoder_path is not None else None
+        # vae_encoder = NeuronBaseModel.load_model(vae_encoder_path) if vae_encoder_path is not None else None
+        # text_encoder_2 = NeuronBaseModel.load_model(text_encoder_2_path) if text_encoder_2_path is not None else None
+        
+        device_ids = [0, 1]
+        text_encoder = torch_neuronx.DataParallel(
+            torch.jit.load(text_encoder_path),
+            device_ids,
+            set_dynamic_batching=dynamic_batch_size,
+        )
+        unet = torch_neuronx.DataParallel(
+            torch.jit.load(unet_path),
+            device_ids,
+            set_dynamic_batching=dynamic_batch_size,
+        )
+        vae_decoder = torch_neuronx.DataParallel(
+            torch.jit.load(vae_decoder_path),
+            device_ids,
+            set_dynamic_batching=dynamic_batch_size,
+        ) if vae_decoder_path is not None else None
+        vae_encoder = torch_neuronx.DataParallel(
+            torch.jit.load(vae_encoder_path),
+            device_ids,
+            set_dynamic_batching=dynamic_batch_size,
+        ) if vae_encoder_path is not None else None
+        text_encoder_2 = torch_neuronx.DataParallel(
+            torch.jit.load(text_encoder_2_path),
+            device_ids,
+            set_dynamic_batching=dynamic_batch_size,
+        ) if text_encoder_2_path is not None else None
 
         return {
             "text_encoder": text_encoder,

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
@@ -156,7 +156,9 @@ class NeuronStableDiffusionPipelineMixin(StableDiffusionPipelineMixin, StableDif
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0 and (self.dynamic_batch_size or len(self.device_ids) == 2)
+        do_classifier_free_guidance = guidance_scale > 1.0 and (
+            self.dynamic_batch_size or self.data_parallel_mode == "unet"
+        )
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_img2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_img2img.py
@@ -168,7 +168,7 @@ class NeuronStableDiffusionImg2ImgPipelineMixin(StableDiffusionPipelineMixin, St
         >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
         >>> input_shapes = {"batch_size": 1, "height": 512, "width": 512}
         >>> pipeline = NeuronStableDiffusionImg2ImgPipeline.from_pretrained(
-        ...     "nitrosocke/Ghibli-Diffusion", export=True, **compiler_args, **input_shapes, device_ids=[0, 1]
+        ...     "nitrosocke/Ghibli-Diffusion", export=True, **compiler_args, **input_shapes,
         ... )
         >>> pipeline.save_pretrained("sd_img2img/")
 
@@ -207,7 +207,9 @@ class NeuronStableDiffusionImg2ImgPipelineMixin(StableDiffusionPipelineMixin, St
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0 and (self.dynamic_batch_size or len(self.device_ids) == 2)
+        do_classifier_free_guidance = guidance_scale > 1.0 and (
+            self.dynamic_batch_size or self.data_parallel_mode == "unet"
+        )
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
@@ -155,7 +155,7 @@ class NeuronStableDiffusionInpaintPipelineMixin(StableDiffusionPipelineMixin, St
         >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
         >>> input_shapes = {"batch_size": 1, "height": 1024, "width": 1024}
         >>> pipeline = NeuronStableDiffusionInpaintPipeline.from_pretrained(
-        ...     "runwayml/stable-diffusion-inpainting", export=True, **compiler_args, **input_shapes, device_ids=[0, 1])
+        ...     "runwayml/stable-diffusion-inpainting", export=True, **compiler_args, **input_shapes,
         ... )
         >>> pipeline.save_pretrained("sd_inpaint/")
 
@@ -207,7 +207,9 @@ class NeuronStableDiffusionInpaintPipelineMixin(StableDiffusionPipelineMixin, St
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0 and (self.dynamic_batch_size or len(self.device_ids) == 2)
+        do_classifier_free_guidance = guidance_scale > 1.0 and (
+            self.dynamic_batch_size or self.data_parallel_mode == "unet"
+        )
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
@@ -240,14 +240,14 @@ class NeuronStableDiffusionXLPipelineMixin(StableDiffusionXLPipelineMixin, Stabl
         else:
             batch_size = prompt_embeds.shape[0]
         neuron_batch_size = self.unet.config.neuron["static_batch_size"]
-        # self.check_num_images_per_prompt(batch_size, neuron_batch_size, num_images_per_prompt)
+        self.check_num_images_per_prompt(batch_size, neuron_batch_size, num_images_per_prompt)
 
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
         do_classifier_free_guidance = (
             guidance_scale > 1.0
-            and (self.dynamic_batch_size or len(self.device_ids) == 2)
+            and (self.dynamic_batch_size or self.data_parallel_mode == "unet")
             and self.unet.config.time_cond_proj_dim is None
         )
 

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
@@ -240,7 +240,7 @@ class NeuronStableDiffusionXLPipelineMixin(StableDiffusionXLPipelineMixin, Stabl
         else:
             batch_size = prompt_embeds.shape[0]
         neuron_batch_size = self.unet.config.neuron["static_batch_size"]
-        self.check_num_images_per_prompt(batch_size, neuron_batch_size, num_images_per_prompt)
+        # self.check_num_images_per_prompt(batch_size, neuron_batch_size, num_images_per_prompt)
 
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
@@ -293,7 +293,7 @@ class NeuronStableDiffusionXLImg2ImgPipelineMixin(StableDiffusionXLPipelineMixin
         >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
         >>> input_shapes = {"batch_size": 1, "height": 512, "width": 512}
         >>> pipeline = NeuronStableDiffusionXLImg2ImgPipeline.from_pretrained(
-        ...     "stabilityai/stable-diffusion-xl-base-1.0", export=True, **compiler_args, **input_shapes, device_ids=[0, 1]
+        ...     "stabilityai/stable-diffusion-xl-base-1.0", export=True, **compiler_args, **input_shapes,
         ... )
         >>> pipeline.save_pretrained("sdxl_img2img/")
 
@@ -340,7 +340,9 @@ class NeuronStableDiffusionXLImg2ImgPipelineMixin(StableDiffusionXLPipelineMixin
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0 and (self.dynamic_batch_size or len(self.device_ids) == 2)
+        do_classifier_free_guidance = guidance_scale > 1.0 and (
+            self.dynamic_batch_size or self.data_parallel_mode == "unet"
+        )
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
@@ -318,7 +318,9 @@ class NeuronStableDiffusionXLInpaintPipelineMixin(StableDiffusionXLPipelineMixin
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
         # corresponds to doing no classifier free guidance.
-        do_classifier_free_guidance = guidance_scale > 1.0 and (self.dynamic_batch_size or len(self.device_ids) == 2)
+        do_classifier_free_guidance = guidance_scale > 1.0 and (
+            self.dynamic_batch_size or self.data_parallel_mode == "unet"
+        )
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_inpaint.py
@@ -266,7 +266,7 @@ class NeuronStableDiffusionXLInpaintPipelineMixin(StableDiffusionXLPipelineMixin
         >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
         >>> input_shapes = {"batch_size": 1, "height": 1024, "width": 1024}
         >>> pipeline = NeuronStableDiffusionXLInpaintPipeline.from_pretrained(
-        ...     "stabilityai/stable-diffusion-xl-base-1.0", export=True, **compiler_args, **input_shapes, device_ids=[0, 1])
+        ...     "stabilityai/stable-diffusion-xl-base-1.0", export=True, **compiler_args, **input_shapes,
         ... )
         >>> pipeline.save_pretrained("sdxl_inpaint/")
 

--- a/optimum/neuron/pipelines/diffusers/pipeline_utils.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_utils.py
@@ -24,7 +24,11 @@ logger = logging.getLogger(__name__)
 
 class DiffusionBasePipelineMixin:
     def check_num_images_per_prompt(self, prompt_batch_size: int, neuron_batch_size: int, num_images_per_prompt: int):
-        if not self.dynamic_batch_size and neuron_batch_size != prompt_batch_size * num_images_per_prompt:
+        if (
+            not self.data_parallel_mode == "all"
+            and not self.dynamic_batch_size
+            and neuron_batch_size != prompt_batch_size * num_images_per_prompt
+        ):
             raise ValueError(
                 f"Models in the pipeline were compiled with `batch_size` {neuron_batch_size} which does not equal the number of"
                 f" prompt({prompt_batch_size}) multiplied by `num_images_per_prompt`({num_images_per_prompt}). You need to enable"

--- a/tests/inference/test_stable_diffusion_pipeline.py
+++ b/tests/inference/test_stable_diffusion_pipeline.py
@@ -67,7 +67,6 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **input_shapes,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.unet, NeuronModelUnet)
@@ -86,7 +85,6 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=True,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         prompts = ["sailing ship in storm by Leonardo da Vinci"] * 2
@@ -101,7 +99,6 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         url = "https://raw.githubusercontent.com/CompVis/stable-diffusion/main/assets/stable-samples/img2img/sketch-mountains-input.jpg"
@@ -118,7 +115,6 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         img_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo.png"
@@ -137,7 +133,6 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         prompt = "Self-portrait oil painting, a beautiful cyborg with golden hair, 8k"
@@ -168,7 +163,6 @@ class NeuronStableDiffusionXLPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **input_shapes,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.text_encoder_2, NeuronModelTextEncoder)
@@ -198,7 +192,6 @@ class NeuronStableDiffusionXLPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=True,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         prompt = ["Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"] * 2
@@ -222,7 +215,6 @@ class NeuronStableDiffusionXLPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         url = "https://huggingface.co/datasets/optimum/documentation-images/resolve/main/intel/openvino/sd_xl/castle_friedrich.png"
@@ -239,7 +231,6 @@ class NeuronStableDiffusionXLPipelineIntegrationTest(unittest.TestCase):
             dynamic_batch_size=False,
             **self.STATIC_INPUTS_SHAPES,
             **self.COMPILER_ARGS,
-            device_ids=[0, 1],
         )
 
         img_url = (


### PR DESCRIPTION
* Add `data_parallel_mode` option and set it as default for LCM (without classifier-free guidance, one neuron core will be left idle otherwise).
* Leverage passed `task` for defining compilation flags. @neo
* Accordingly change the doc and tests