### PR TITLE
Fix `neuron_parallel_compile` compatibility with the cache system

### DIFF
--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -168,7 +168,7 @@ class NeuronCacheCallback(TrainerCallback):
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
             # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
             # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
-            # If find files under this directory are found, they were produced by `neuron_parallel_compile` and can be
+            # If files under this directory are found, they were produced by `neuron_parallel_compile` and can be
             # needed for current training.
             neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
             if neuron_compile_cache_dir.is_dir():
@@ -341,7 +341,7 @@ class NeuronCacheCallback(TrainerCallback):
                 if file_or_dir.name.startswith("checkpoint-") or file_or_dir.name == TENSOR_PARALLEL_SHARDS_DIR_NAME:
                     if xm.get_local_ordinal() == 0:
                         logger.info(
-                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, and "
+                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, "
                             "thus cannot be used."
                         )
                     shutil.rmtree(file_or_dir, ignore_errors=True)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -164,6 +164,10 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
+            # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
+            # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
+            # If find files under this directory are found, they were produced by `neuron_parallel_compile` and can be
+            # needed for current training.
             neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
             if neuron_compile_cache_dir.is_dir():
                 neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -166,13 +166,6 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
-            # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
-            # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
-            # If files under this directory are found, they were produced by `neuron_parallel_compile` and can be
-            # needed for current training.
-            neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
-            if neuron_compile_cache_dir.is_dir():
-                neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)
         else:
             neuron_cache_files = []
 
@@ -196,6 +189,9 @@ class NeuronCacheCallback(TrainerCallback):
                     fail_when_folder_not_found=True,
                 )
             except Exception:
+                # Here only when the folder `get_neuron_compiler_version_dir_name()` was not in the path of
+                # `cache_file`. In this case, no symlink is created because it is interpreted as not being a
+                # compilation file.
                 continue
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -164,6 +164,9 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
+            neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
+            if neuron_compile_cache_dir.is_dir():
+                neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)
         else:
             neuron_cache_files = []
 

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -28,6 +28,7 @@ import torch
 from transformers import TrainerCallback, TrainerState
 
 from ..utils import logging
+from .distributed.utils import TENSOR_PARALLEL_SHARDS_DIR_NAME
 from .utils import is_torch_xla_available
 from .utils.cache_utils import (
     NeuronHash,
@@ -332,6 +333,18 @@ class NeuronCacheCallback(TrainerCallback):
         Event called at the end of training.
         """
         self.on_save(args, state, control, **kwargs)
+        if is_precompilation():
+            output_dir = Path(args.output_dir)
+            for file_or_dir in output_dir.glob("**/*"):
+                if file_or_dir.is_file():
+                    continue
+                if file_or_dir.name.startswith("checkpoint-") or file_or_dir.name == TENSOR_PARALLEL_SHARDS_DIR_NAME:
+                    if xm.get_local_ordinal() == 0:
+                        logger.info(
+                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, and "
+                            "thus cannot be used."
+                        )
+                    shutil.rmtree(file_or_dir, ignore_errors=True)
 
     def on_evaluate(self, args: "TrainingArguments", state: TrainerState, control: "TrainerControl", **kwargs):
         """

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -33,6 +33,7 @@ from .utils.cache_utils import (
     NeuronHash,
     download_cached_model_from_hub,
     get_neuron_cache_path,
+    get_neuron_compiler_version_dir_name,
     list_files_in_neuron_cache,
     path_after_folder,
     push_to_cache_on_hub,
@@ -186,7 +187,15 @@ class NeuronCacheCallback(TrainerCallback):
         for cache_file in neuron_cache_files:
             if cache_file.name == "cache_stats.json":
                 continue
-            path_in_neuron_cache = path_after_folder(cache_file, neuron_cache_path.name)
+            try:
+                path_in_neuron_cache = path_after_folder(
+                    cache_file,
+                    get_neuron_compiler_version_dir_name(),
+                    include_folder=True,
+                    fail_when_folder_not_found=True,
+                )
+            except Exception:
+                continue
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)
             # TODO: investigate why it is needed. Minor issue.

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -107,16 +107,23 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
     if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):
         _ORIGINAL_NEURON_CACHE_PATH = get_neuron_cache_path()
 
-        if not is_precompilation():
-            if os.environ["RANK"] == "0":
-                _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
-                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=True)
-                store.set("tmp_neuron_cache_path", _TMP_NEURON_CACHE_DIR.name)
-                _TMP_NEURON_CACHE_PATH = Path(_TMP_NEURON_CACHE_DIR.name)
+        # _ORIGINAL_NEURON_CACHE_PATH is None when the `--no-cache` flag is set.
+        if _ORIGINAL_NEURON_CACHE_PATH is not None:
+            if is_precompilation():
+                # During precompilation, we make sure to set the cache path to the defined compile cache path by the
+                # user. If nothing is specified, it is set to the default compile cache used by the Neuron compiler:
+                # /var/tmp/neuron-compile-cache
+                set_neuron_cache_path(_ORIGINAL_NEURON_CACHE_PATH)
             else:
-                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=False)
-                _TMP_NEURON_CACHE_PATH = Path(store.get("tmp_neuron_cache_path").decode("utf-8"))
-            set_neuron_cache_path(_TMP_NEURON_CACHE_PATH)
+                if os.environ["RANK"] == "0":
+                    _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
+                    store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=True)
+                    store.set("tmp_neuron_cache_path", _TMP_NEURON_CACHE_DIR.name)
+                    _TMP_NEURON_CACHE_PATH = Path(_TMP_NEURON_CACHE_DIR.name)
+                else:
+                    store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=False)
+                    _TMP_NEURON_CACHE_PATH = Path(store.get("tmp_neuron_cache_path").decode("utf-8"))
+                set_neuron_cache_path(_TMP_NEURON_CACHE_PATH)
 
         torch.distributed.init_process_group(backend="xla")
         if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -107,7 +107,7 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
     if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):
         _ORIGINAL_NEURON_CACHE_PATH = get_neuron_cache_path()
 
-        # _ORIGINAL_NEURON_CACHE_PATH is None when the `--no-cache` flag is set.
+        # _ORIGINAL_NEURON_CACHE_PATH is `None` when the `--no-cache` flag is set.
         if _ORIGINAL_NEURON_CACHE_PATH is not None:
             if is_precompilation():
                 # During precompilation, we make sure to set the cache path to the defined compile cache path by the

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -73,7 +73,6 @@ else:
 
 HASH_FILENAME = "pytorch_model.bin"
 REGISTRY_FILENAME = "registry.json"
-NEURON_COMPILE_CACHE_NAME = "neuron-compile-cache"
 
 _IP_PATTERN = re.compile(r"ip-([0-9]{1,3}-){4}")
 _HF_HUB_HTTP_ERROR_REQUEST_ID_PATTERN = re.compile(r"\(Request ID: Root=[\w-]+\)")

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -276,6 +276,12 @@ def get_num_neuron_cores_used() -> int:
     return int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
 
 
+def get_neuron_compiler_version_dir_name(neuron_compiler_version: Optional[str] = None) -> str:
+    if neuron_compiler_version is None:
+        neuron_compiler_version = get_neuronxcc_version()
+    return f"neuronxcc-{neuron_compiler_version}"
+
+
 def list_files_in_neuron_cache(neuron_cache_path: Union[str, Path], only_relevant_files: bool = False) -> List[Path]:
     if isinstance(neuron_cache_path, str):
         neuron_cache_path = Path(neuron_cache_path)
@@ -285,12 +291,16 @@ def list_files_in_neuron_cache(neuron_cache_path: Union[str, Path], only_relevan
     return files
 
 
-def path_after_folder(path: Path, folder: Union[str, Path], include_folder: bool = False) -> Path:
+def path_after_folder(
+    path: Path, folder: Union[str, Path], include_folder: bool = False, fail_when_folder_not_found: bool = False
+) -> Path:
     if isinstance(folder, Path):
         folder = folder.name
     try:
         index = path.parts.index(folder)
-    except ValueError:
+    except ValueError as e:
+        if fail_when_folder_not_found:
+            raise e
         index = len(path.parts)
     index = index + 1 if not include_folder else index
     return Path("").joinpath(*path.parts[index:])
@@ -686,7 +696,7 @@ class NeuronHash:
 
     @property
     def neuron_compiler_version_dir_name(self):
-        return f"neuronxcc-{self.neuron_compiler_version}"
+        return get_neuron_compiler_version_dir_name(self.neuron_compiler_version)
 
     @property
     def is_private(self):

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -231,7 +231,7 @@ def get_neuron_cache_path() -> Optional[Path]:
         if match_:
             path = Path(match_.group(1))
         else:
-            path = Path("/var/tmp")
+            path = Path("/var/tmp/neuron-compile-cache")
 
         return path
 

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -89,7 +89,7 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
         self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name)
 
         os.environ["NEURON_CC_FLAGS"] = "--some --parameters --here --other --paremeters --here"
-        self.assertEqual(get_neuron_cache_path(), Path("/var/tmp"))
+        self.assertEqual(get_neuron_cache_path(), Path("/var/tmp/neuron-compile-cache"))
 
     def _test_set_neuron_cache_path(self, new_cache_path):
         os.environ["NEURON_CC_FLAGS"] = "--some --parameters --here --no-cache --other --paremeters --here"


### PR DESCRIPTION
The cache system cannot use files produced by the `neuron_parallel_compile`.

The issue was fixed first in #200, but the issue re-appeared because:

- We stopped supporting the old naming convention (the cache path is the specified cache name to which we append `neuron-parallel-compile`) for the neuron cache.
- While the Neuron Compiler (`neuronx-cc`) does not use the old naming convention, the `neuron_parallel_compile` still does

This PR fixes the issue by still looking for this directory if needed.

Fixes #345 