### PR TITLE
Revert "Remove numpy pinning"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ INSTALL_REQUIRES = [
     "accelerate == 0.23.0",
     "optimum >= 1.13.0",
     "huggingface_hub >= 0.14.0",
+    "numpy>=1.22.2, <=1.25.2",
     "protobuf<4",
 ]
 


### PR DESCRIPTION
Reverts huggingface/optimum-neuron#344.

The trainium on CI fails with the following errors:

```
RuntimeError: Failed compilation with ['neuronx-cc', '--target=trn1', 'compile', '--framework', 'XLA', 
'/tmp/ubuntu/neuroncc_compile_workdir/ba410759-09ac-4a06-b2f6-f991003d4cf0/model.MODULE_17340000842283803951+abb26765.hlo.pb',
'--output',  '/tmp/ubuntu/neuroncc_compile_workdir/ba410759-09ac-4a06-b2f6-f991003d4cf0/model.MODULE_17340000842283803951+abb26765.neff',
 '--model-type=transformer', '--verbose=35']: 
RuntimeError: module compiled against API version 0xf but this version of numpy is 0xe
```