### PR TITLE
Push after running `neuron_parallel_compile`

### DIFF
--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -168,7 +168,7 @@ class NeuronCacheCallback(TrainerCallback):
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
             # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
             # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
-            # If find files under this directory are found, they were produced by `neuron_parallel_compile` and can be
+            # If files under this directory are found, they were produced by `neuron_parallel_compile` and can be
             # needed for current training.
             neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
             if neuron_compile_cache_dir.is_dir():
@@ -341,7 +341,7 @@ class NeuronCacheCallback(TrainerCallback):
                 if file_or_dir.name.startswith("checkpoint-") or file_or_dir.name == TENSOR_PARALLEL_SHARDS_DIR_NAME:
                     if xm.get_local_ordinal() == 0:
                         logger.info(
-                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, and "
+                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, "
                             "thus cannot be used."
                         )
                     shutil.rmtree(file_or_dir, ignore_errors=True)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -326,6 +326,8 @@ class NeuronCacheCallback(TrainerCallback):
         """
         if xm.get_local_ordinal() == 0 and is_precompilation() and self.tmp_neuron_cache_path is not None:
             create_or_append_to_neuron_parallel_compile_report(self.tmp_neuron_cache_path, self.neuron_hash_to_files)
+            for neuron_hash in self.neuron_hash_to_files:
+                self.neuron_hash_to_files[neuron_hash] = []
         if self.push:
             self.synchronize_temporary_neuron_cache()
         if self.wait_for_everyone_on_push:

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -164,6 +164,10 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
+            # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
+            # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
+            # If find files under this directory are found, they were produced by `neuron_parallel_compile` and can be
+            # needed for current training.
             neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
             if neuron_compile_cache_dir.is_dir():
                 neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -166,13 +166,6 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
-            # `neuron_parallel_compile` will still put files under the `neuron_cache_path / neuron-compile-cache`
-            # directory, even though `neuronx-cc` puts the compilation files under `neuron_cache_path` only.
-            # If files under this directory are found, they were produced by `neuron_parallel_compile` and can be
-            # needed for current training.
-            neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
-            if neuron_compile_cache_dir.is_dir():
-                neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)
         else:
             neuron_cache_files = []
 
@@ -196,6 +189,9 @@ class NeuronCacheCallback(TrainerCallback):
                     fail_when_folder_not_found=True,
                 )
             except Exception:
+                # Here only when the folder `get_neuron_compiler_version_dir_name()` was not in the path of
+                # `cache_file`. In this case, no symlink is created because it is interpreted as not being a
+                # compilation file.
                 continue
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -164,6 +164,9 @@ class NeuronCacheCallback(TrainerCallback):
         tmp_neuron_cache_path = Path(tmp_neuron_cache.name)
         if neuron_cache_path is not None:
             neuron_cache_files = list_files_in_neuron_cache(neuron_cache_path)
+            neuron_compile_cache_dir = neuron_cache_path / "neuron-compile-cache"
+            if neuron_compile_cache_dir.is_dir():
+                neuron_cache_files += list_files_in_neuron_cache(neuron_compile_cache_dir)
         else:
             neuron_cache_files = []
 

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -28,6 +28,7 @@ import torch
 from transformers import TrainerCallback, TrainerState
 
 from ..utils import logging
+from .distributed.utils import TENSOR_PARALLEL_SHARDS_DIR_NAME
 from .utils import is_torch_xla_available
 from .utils.cache_utils import (
     NeuronHash,
@@ -332,6 +333,18 @@ class NeuronCacheCallback(TrainerCallback):
         Event called at the end of training.
         """
         self.on_save(args, state, control, **kwargs)
+        if is_precompilation():
+            output_dir = Path(args.output_dir)
+            for file_or_dir in output_dir.glob("**/*"):
+                if file_or_dir.is_file():
+                    continue
+                if file_or_dir.name.startswith("checkpoint-") or file_or_dir.name == TENSOR_PARALLEL_SHARDS_DIR_NAME:
+                    if xm.get_local_ordinal() == 0:
+                        logger.info(
+                            f"Removing {file_or_dir} since the weights were produced by `neuron_parallel_compile`, and "
+                            "thus cannot be used."
+                        )
+                    shutil.rmtree(file_or_dir, ignore_errors=True)
 
     def on_evaluate(self, args: "TrainingArguments", state: TrainerState, control: "TrainerControl", **kwargs):
         """

--- a/optimum/neuron/trainer_callback.py
+++ b/optimum/neuron/trainer_callback.py
@@ -33,6 +33,7 @@ from .utils.cache_utils import (
     NeuronHash,
     download_cached_model_from_hub,
     get_neuron_cache_path,
+    get_neuron_compiler_version_dir_name,
     list_files_in_neuron_cache,
     path_after_folder,
     push_to_cache_on_hub,
@@ -186,7 +187,15 @@ class NeuronCacheCallback(TrainerCallback):
         for cache_file in neuron_cache_files:
             if cache_file.name == "cache_stats.json":
                 continue
-            path_in_neuron_cache = path_after_folder(cache_file, neuron_cache_path.name)
+            try:
+                path_in_neuron_cache = path_after_folder(
+                    cache_file,
+                    get_neuron_compiler_version_dir_name(),
+                    include_folder=True,
+                    fail_when_folder_not_found=True,
+                )
+            except Exception:
+                continue
             tmp_cache_file = tmp_neuron_cache_path / path_in_neuron_cache
             tmp_cache_file.parent.mkdir(parents=True, exist_ok=True)
             # TODO: investigate why it is needed. Minor issue.

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -107,16 +107,23 @@ if os.environ.get("TORCHELASTIC_RUN_ID"):
     if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):
         _ORIGINAL_NEURON_CACHE_PATH = get_neuron_cache_path()
 
-        if not is_precompilation():
-            if os.environ["RANK"] == "0":
-                _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
-                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=True)
-                store.set("tmp_neuron_cache_path", _TMP_NEURON_CACHE_DIR.name)
-                _TMP_NEURON_CACHE_PATH = Path(_TMP_NEURON_CACHE_DIR.name)
+        # _ORIGINAL_NEURON_CACHE_PATH is None when the `--no-cache` flag is set.
+        if _ORIGINAL_NEURON_CACHE_PATH is not None:
+            if is_precompilation():
+                # During precompilation, we make sure to set the cache path to the defined compile cache path by the
+                # user. If nothing is specified, it is set to the default compile cache used by the Neuron compiler:
+                # /var/tmp/neuron-compile-cache
+                set_neuron_cache_path(_ORIGINAL_NEURON_CACHE_PATH)
             else:
-                store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=False)
-                _TMP_NEURON_CACHE_PATH = Path(store.get("tmp_neuron_cache_path").decode("utf-8"))
-            set_neuron_cache_path(_TMP_NEURON_CACHE_PATH)
+                if os.environ["RANK"] == "0":
+                    _TMP_NEURON_CACHE_DIR = NeuronCacheCallback.create_temporary_neuron_cache(get_neuron_cache_path())
+                    store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=True)
+                    store.set("tmp_neuron_cache_path", _TMP_NEURON_CACHE_DIR.name)
+                    _TMP_NEURON_CACHE_PATH = Path(_TMP_NEURON_CACHE_DIR.name)
+                else:
+                    store = torch.distributed.TCPStore(_TCP_STORE_ADDRESS, _TCP_STORE_PORT, is_master=False)
+                    _TMP_NEURON_CACHE_PATH = Path(store.get("tmp_neuron_cache_path").decode("utf-8"))
+                set_neuron_cache_path(_TMP_NEURON_CACHE_PATH)
 
         torch.distributed.init_process_group(backend="xla")
         if not isinstance(torch.distributed.group.WORLD, xbn.ProcessGroupXla):

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -73,7 +73,6 @@ else:
 
 HASH_FILENAME = "pytorch_model.bin"
 REGISTRY_FILENAME = "registry.json"
-NEURON_COMPILE_CACHE_NAME = "neuron-compile-cache"
 
 _IP_PATTERN = re.compile(r"ip-([0-9]{1,3}-){4}")
 _HF_HUB_HTTP_ERROR_REQUEST_ID_PATTERN = re.compile(r"\(Request ID: Root=[\w-]+\)")

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -276,6 +276,12 @@ def get_num_neuron_cores_used() -> int:
     return int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
 
 
+def get_neuron_compiler_version_dir_name(neuron_compiler_version: Optional[str] = None) -> str:
+    if neuron_compiler_version is None:
+        neuron_compiler_version = get_neuronxcc_version()
+    return f"neuronxcc-{neuron_compiler_version}"
+
+
 def list_files_in_neuron_cache(neuron_cache_path: Union[str, Path], only_relevant_files: bool = False) -> List[Path]:
     if isinstance(neuron_cache_path, str):
         neuron_cache_path = Path(neuron_cache_path)
@@ -285,12 +291,16 @@ def list_files_in_neuron_cache(neuron_cache_path: Union[str, Path], only_relevan
     return files
 
 
-def path_after_folder(path: Path, folder: Union[str, Path], include_folder: bool = False) -> Path:
+def path_after_folder(
+    path: Path, folder: Union[str, Path], include_folder: bool = False, fail_when_folder_not_found: bool = False
+) -> Path:
     if isinstance(folder, Path):
         folder = folder.name
     try:
         index = path.parts.index(folder)
-    except ValueError:
+    except ValueError as e:
+        if fail_when_folder_not_found:
+            raise e
         index = len(path.parts)
     index = index + 1 if not include_folder else index
     return Path("").joinpath(*path.parts[index:])
@@ -686,7 +696,7 @@ class NeuronHash:
 
     @property
     def neuron_compiler_version_dir_name(self):
-        return f"neuronxcc-{self.neuron_compiler_version}"
+        return get_neuron_compiler_version_dir_name(self.neuron_compiler_version)
 
     @property
     def is_private(self):

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -348,7 +348,7 @@ def create_or_append_to_neuron_parallel_compile_report(
     neuron_cache_path: Union[str, Path], neuron_hash_to_files: Dict["NeuronHash", List[Path]]
 ):
     report_content = get_neuron_parallel_compile_report(neuron_cache_path)
-    inserted = {}
+    inserted =  set()
     for neuron_hash, filenames in neuron_hash_to_files.items():
         for filename in filenames:
             directory = filename.parent
@@ -357,6 +357,7 @@ def create_or_append_to_neuron_parallel_compile_report(
             report_content.append(
                 {"neuron_hash": neuron_hash.to_dict_for_neuron_compile_report(), "directory": directory.as_posix()}
             )
+            inserted.add(directory)
 
     report_file = Path(neuron_cache_path) / NEURON_PARALLEL_COMPILE_REPORT_FILENAME
     with open(report_file, "w") as fp:

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -231,7 +231,7 @@ def get_neuron_cache_path() -> Optional[Path]:
         if match_:
             path = Path(match_.group(1))
         else:
-            path = Path("/var/tmp")
+            path = Path("/var/tmp/neuron-compile-cache")
 
         return path
 

--- a/optimum/neuron/utils/cache_utils.py
+++ b/optimum/neuron/utils/cache_utils.py
@@ -46,13 +46,11 @@ from transformers import PretrainedConfig, PreTrainedModel
 from ...utils import logging
 from ...utils.logging import warn_once
 from .constant import NEURON_BINARIES_PATH
-from .misc import should_log, string_to_bool
+from .misc import should_current_worker_log, string_to_bool
 from .version_utils import get_neuronxcc_version
 
 
 logger = logging.get_logger()
-
-# SHOULD_LOG = should_log()
 
 HOME = Path.home()
 DEFAULT_HF_HOME = f"{HOME}/.cache/huggingface"
@@ -113,7 +111,7 @@ def set_custom_cache_repo_name_in_hf_home(repo_id: str, hf_home: str = HF_HOME, 
             )
 
     existing_custom_cache_repo = load_custom_cache_repo_name_from_hf_home(hf_home_cache_repo_file)
-    if should_log() and existing_custom_cache_repo is not None:
+    if should_current_worker_log() and existing_custom_cache_repo is not None:
         logger.warning(
             f"A custom cache repo was already registered: {existing_custom_cache_repo}. It will be overwritten to "
             f"{repo_id}."
@@ -168,7 +166,7 @@ def has_write_access_to_repo(repo_id: str) -> bool:
         if org["name"] == username_or_organization:
             # Role in an organization can be either:
             # "admin", "write", "contributor", "read".
-            if should_log() and org["roleInOrg"] == "contributor":
+            if should_current_worker_log() and org["roleInOrg"] == "contributor":
                 logger.warning(
                     f"You are logged in as a contributor to the cache repo {repo_id}. It is not possible to infer "
                     "whether you have write access on this repo or not, so it will be assumed you do not."
@@ -188,7 +186,7 @@ def get_hf_hub_cache_repos():
     if custom_cache_repo is not None and custom_cache_repo not in hf_hub_repos:
         hf_hub_repos = [custom_cache_repo] + hf_hub_repos
 
-    if should_log() and saved_custom_cache_repo is None and custom_cache_repo is None:
+    if should_current_worker_log() and saved_custom_cache_repo is None and custom_cache_repo is None:
         warn_once(
             logger,
             "No Neuron cache name is saved locally. This means that only the official Neuron cache will be used. You "
@@ -204,7 +202,7 @@ def get_hf_hub_cache_repos():
     # making it easier for higher-level abstractions using the cache utils to reason on which
     # parts should only run on the master process and which parts should run on everyone.
 
-    if should_log() and hf_hub_repos and not has_write_access_to_repo(hf_hub_repos[0]):
+    if should_current_worker_log() and hf_hub_repos and not has_write_access_to_repo(hf_hub_repos[0]):
         warn_once(
             logger,
             f"You do not have write access to {hf_hub_repos[0]} so you will not be able to push any cached compilation "
@@ -472,7 +470,7 @@ def add_in_registry(repo_id: str, neuron_hash: "NeuronHash"):
                 )
             except Exception as e:
                 if "A commit has happened since" in str(e):
-                    if should_log():
+                    if should_current_worker_log():
                         logger.info(
                             "A commit has happened in cache repository since we tried to update the registry, starting "
                             "again..."
@@ -720,7 +718,9 @@ class NeuronHash:
         bytes_to_join = []
         for name, tensor in state_dict.items():
             memfile = io.BytesIO()
-            np.save(memfile, tensor.to(cast_to_mapping.get(tensor.dtype, tensor.dtype)).cpu().numpy())
+            # It is actually important to first move the tensor to CPU then cast, because all XLA tensor operations,
+            # and in particular `to()` behave differently when doing `neuron_parallel_compile`.
+            np.save(memfile, tensor.cpu().to(cast_to_mapping.get(tensor.dtype, tensor.dtype)).numpy())
             bytes_to_join.append(name.encode("utf-8"))
             bytes_to_join.append(memfile.getvalue())
         return b"".join(bytes_to_join)
@@ -957,7 +957,7 @@ def push_to_cache_on_hub(
         exists = any(filename.startswith(path_in_repo_str) for filename in repo_filenames)
     else:
         exists = any(filename == path_in_repo_str for filename in repo_filenames)
-    if should_log() and exists:
+    if should_current_worker_log() and exists:
         if not overwrite_existing:
             logger.info(
                 f"Did not push the cached model located at {local_cache_dir_or_file} to the repo named {cache_repo_id} "
@@ -988,7 +988,7 @@ def push_to_cache_on_hub(
                 raise e
             msg = could_not_push_message.format(cache_repo_id=cache_repo_id, error=e)
             msg = re.sub(_HF_HUB_HTTP_ERROR_REQUEST_ID_PATTERN, "", msg)
-            if should_log():
+            if should_current_worker_log():
                 warn_once(logger, msg)
             success = False
     else:
@@ -1004,7 +1004,7 @@ def push_to_cache_on_hub(
                 raise e
             msg = could_not_push_message.format(cache_repo_id=cache_repo_id, error=e)
             msg = re.sub(_HF_HUB_HTTP_ERROR_REQUEST_ID_PATTERN, "", msg)
-            if should_log():
+            if should_current_worker_log():
                 warn_once(logger, msg)
             success = False
 

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -45,7 +45,7 @@ from .require_utils import requires_safetensors
 logger = logging.get_logger()
 
 
-def should_current_worker_log() -> bool:
+def is_main_worker() -> bool:
     if torch.distributed.is_initialized() and is_torch_xla_available():
         import torch_xla.core.xla_model as xm
 

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -38,10 +38,19 @@ from transformers.utils import (
 from transformers.utils.hub import get_checkpoint_shard_files
 
 from ...utils import logging
+from .import_utils import is_torch_xla_available
 from .require_utils import requires_safetensors
 
 
 logger = logging.get_logger()
+
+
+def should_log() -> bool:
+    if is_torch_xla_available():
+        import torch_xla.core.xla_model as xm
+
+        return xm.get_local_ordinal() == 0
+    return True
 
 
 # From https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -46,7 +46,7 @@ logger = logging.get_logger()
 
 
 def should_log() -> bool:
-    if is_torch_xla_available():
+    if torch.distributed.is_initialized() and is_torch_xla_available():
         import torch_xla.core.xla_model as xm
 
         return xm.get_local_ordinal() == 0

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -45,7 +45,7 @@ from .require_utils import requires_safetensors
 logger = logging.get_logger()
 
 
-def should_log() -> bool:
+def should_current_worker_log() -> bool:
     if torch.distributed.is_initialized() and is_torch_xla_available():
         import torch_xla.core.xla_model as xm
 


### PR DESCRIPTION
This PR adds support for pushing to the cache repository on the Hugging Face Hub after using `neuron_paralell_compile`. 

Basically, when running a training after doing `neuron_parallel_compile`, all the compilation files will be pushed to the Hub before starting actual training.

cc @5cp 