### PR TITLE
Add support for Mistral models

### DIFF
--- a/docs/source/package_reference/export.mdx
+++ b/docs/source/package_reference/export.mdx
@@ -66,6 +66,7 @@ Since many architectures share similar properties for their Neuron configuration
 | FlauBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | GPT2                   | text-generation                                                                                                                               |
 | Llama, Llama 2         | text-generation                                                                                                                               |
+| Mistral                | text-generation                                                                                                                               |
 | MobileBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | MPNet                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | OPT                    | text-generation                                                                                                                               |

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -471,3 +471,8 @@ class T5DecoderNeuronConfig(TextSeq2SeqNeuronConfig):
             aliases[model.past_key_values_ca[i]] = len(model.past_key_values_sa) + i + num_outputs_from_trace
 
         return aliases
+
+
+@register_in_tasks_manager("mistral", "text-generation")
+class MistralNeuronConfig(TextNeuronDecoderConfig):
+    NEURONX_CLASS = "mistral.model.MistralForSampling"

--- a/tests/generation/conftest.py
+++ b/tests/generation/conftest.py
@@ -22,11 +22,12 @@ from optimum.neuron.utils.testing_utils import requires_neuronx
 from optimum.utils.testing_utils import USER
 
 
-DECODER_MODEL_ARCHITECTURES = ["bloom", "gpt2", "llama", "opt"]
+DECODER_MODEL_ARCHITECTURES = ["bloom", "gpt2", "llama", "mistral", "opt"]
 DECODER_MODEL_NAMES = {
     "bloom": "hf-internal-testing/tiny-random-BloomForCausalLM",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "llama": "dacorvo/tiny-random-llama",
+    "mistral": "hf-internal-testing/tiny-random-MistralForCausalLM",
     "opt": "hf-internal-testing/tiny-random-OPTForCausalLM",
 }
 SEQ2SEQ_MODEL_NAMES = {

--- a/tests/generation/conftest.py
+++ b/tests/generation/conftest.py
@@ -27,7 +27,7 @@ DECODER_MODEL_NAMES = {
     "bloom": "hf-internal-testing/tiny-random-BloomForCausalLM",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "llama": "dacorvo/tiny-random-llama",
-    "mistral": "hf-internal-testing/tiny-random-MistralForCausalLM",
+    "mistral": "dacorvo/tiny-random-MistralForCausalLM",
     "opt": "hf-internal-testing/tiny-random-OPTForCausalLM",
 }
 SEQ2SEQ_MODEL_NAMES = {


### PR DESCRIPTION
This simply adds mistral to the list of supported architectures in the exporter.