### PR TITLE
Do not upload NeuronModelForCausalLM weights when they can be reconstructed from the hub

### DIFF
--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -648,15 +648,15 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
 
     def __init__(
         self,
-        model: torch.nn.Module,
         config: "PretrainedConfig",
-        model_path: Union[str, "Path", "TemporaryDirectory"],
+        checkpoint_dir: Union[str, "Path", "TemporaryDirectory"],
+        compiled_dir: Optional[Union[str, "Path", "TemporaryDirectory"]] = None,
         generation_config: Optional["GenerationConfig"] = None,
     ):
-        super().__init__(model, config, model_path, generation_config)
+        super().__init__(config, checkpoint_dir, compiled_dir=compiled_dir, generation_config=generation_config)
         self.cur_len = 0
-        self.batch_size = model.config.batch_size
-        self.max_length = model.config.n_positions
+        self.batch_size = self.model.config.batch_size
+        self.max_length = self.model.config.n_positions
         # The generate method from GenerationMixin expects the device attribute to be set
         self.device = torch.device("cpu")
 

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
-import torch
 from huggingface_hub import HfApi, get_token, snapshot_download
 from huggingface_hub.utils import is_google_colab
 from transformers import AutoConfig, AutoModel, GenerationConfig
@@ -34,7 +33,6 @@ from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_ver
 
 
 if is_transformers_neuronx_available():
-    from transformers_neuronx.module import PretrainedModel as NeuronxPretrainedModel
     from transformers_neuronx.module import save_split
 
 
@@ -71,17 +69,22 @@ class NeuronDecoderModel(OptimizedModel):
 
     def __init__(
         self,
-        model: torch.nn.Module,
         config: "PretrainedConfig",
-        model_path: Union[str, Path, TemporaryDirectory],
+        checkpoint_dir: Union[str, Path, TemporaryDirectory],
+        compiled_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         generation_config: Optional[GenerationConfig] = None,
     ):
-        if not is_transformers_neuronx_available() or not isinstance(model, NeuronxPretrainedModel):
-            raise ValueError("The source model must be a transformers_neuronx.PreTrainedModel.")
+        neuron_config = getattr(config, "neuron", None)
+        if neuron_config is None:
+            raise ValueError(
+                "The specified model is not a neuron model. "
+                "Please convert your model to neuron format by passing export=True."
+            )
 
-        super().__init__(model, config)
-        self.model_path = model_path
+        self.checkpoint_dir = checkpoint_dir
+        self.compiled_dir = compiled_dir
         if generation_config is None:
+            logger.info("Generation config file not found, using a generation config created from the model config.")
             generation_config = GenerationConfig.from_model_config(config)
         self.generation_config = generation_config
         # Registers the NeuronModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating
@@ -90,11 +93,45 @@ class NeuronDecoderModel(OptimizedModel):
         if hasattr(self.auto_model_class, "register"):
             self.auto_model_class.register(AutoConfig, self.__class__)
 
+        # Evaluate the configuration passed during export
+        task = neuron_config["task"]
+        batch_size = neuron_config["batch_size"]
+        sequence_length = neuron_config["sequence_length"]
+        num_cores = neuron_config["num_cores"]
+        auto_cast_type = neuron_config["auto_cast_type"]
+
+        check_compiler_compatibility(neuron_config["compiler_type"], neuron_config["compiler_version"])
+
+        exporter = get_exporter(config, task)
+
+        # transformers-neuronx uses f32/f16 instead of fp32/fp16
+        auto_cast_type = auto_cast_type.replace("p", "")
+        checkpoint_path = checkpoint_dir.name if isinstance(checkpoint_dir, TemporaryDirectory) else checkpoint_dir
+        neuronx_model = exporter.neuronx_class.from_pretrained(
+            checkpoint_path,
+            batch_size=batch_size,
+            n_positions=sequence_length,
+            tp_degree=num_cores,
+            amp=auto_cast_type,
+        )
+
+        if compiled_dir is not None:
+            # Specify the path where compiled artifacts are stored before conversion
+            neuronx_model.load(compiled_dir)
+
+        # Compile the Neuron model (if present compiled artifacts will be reloaded instead of compiled)
+        neuron_cc_flags = os.environ.get("NEURON_CC_FLAGS", "")
+        os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags + " --model-type=transformer"
+        with hub_neuronx_cache():
+            neuronx_model.to_neuron()
+        os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags
+
+        super().__init__(neuronx_model, config)
+
     @classmethod
-    def _from_transformers(
+    def _create_checkpoint(
         cls,
         model_id: str,
-        config: "PretrainedConfig",
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
@@ -103,18 +140,8 @@ class NeuronDecoderModel(OptimizedModel):
         local_files_only: bool = False,
         trust_remote_code: bool = False,
         task: Optional[str] = None,
-        batch_size: Optional[int] = 1,
-        sequence_length: Optional[int] = None,
-        num_cores: Optional[int] = 2,
-        auto_cast_type: Optional[str] = "fp32",
         **kwargs,
-    ) -> "NeuronDecoderModel":
-        if not is_transformers_neuronx_available():
-            raise ModuleNotFoundError("The transformers_neuronx package is required to export the model.")
-
-        if task is None:
-            task = TasksManager.infer_task_from_model(cls.auto_model_class)
-
+    ) -> TemporaryDirectory:
         # Instantiate the transformers model checkpoint
         model = TasksManager.get_model_from_task(
             task=task,
@@ -135,6 +162,32 @@ class NeuronDecoderModel(OptimizedModel):
         model.save_pretrained(
             checkpoint_dir.name, save_function=save_split, safe_serialization=False, max_shard_size="10000GB"
         )
+        return checkpoint_dir
+
+    @classmethod
+    def _from_transformers(
+        cls,
+        model_id: str,
+        config: "PretrainedConfig",
+        task: Optional[str] = None,
+        batch_size: Optional[int] = 1,
+        sequence_length: Optional[int] = None,
+        num_cores: Optional[int] = 2,
+        auto_cast_type: Optional[str] = "fp32",
+        **kwargs,
+    ) -> "NeuronDecoderModel":
+        if not is_transformers_neuronx_available():
+            raise ModuleNotFoundError("The transformers_neuronx package is required to export the model.")
+
+        if task is None:
+            task = TasksManager.infer_task_from_model(cls.auto_model_class)
+
+        # Instantiate the transformers model checkpoint
+        checkpoint_dir = cls._create_checkpoint(
+            model_id,
+            task=task,
+            **kwargs,
+        )
 
         # If the sequence_length was not specified, deduce it from the model configuration
         if sequence_length is None:
@@ -152,37 +205,30 @@ class NeuronDecoderModel(OptimizedModel):
             "compiler_version": get_neuronxcc_version(),
         }
 
-        return cls._from_pretrained(checkpoint_dir, config)
+        # Try to reload the generation config (if any)
+        generation_config = None
+        try:
+            generation_config = GenerationConfig.from_pretrained(model_id)
+        except OSError:
+            pass
+
+        return cls(config, checkpoint_dir, generation_config=generation_config)
 
     @classmethod
-    def _get_neuron_paths(
-        cls, model_dir: Union[str, Path, TemporaryDirectory], token: Optional[str] = None
-    ) -> Tuple[str, str, str]:
-        if isinstance(model_dir, TemporaryDirectory):
-            model_path = model_dir.name
-            # We are in the middle of an export: the checkpoint is in the temporary model directory
-            checkpoint_path = model_path
-            # There are no compiled artifacts yet
-            compiled_path = None
-        else:
-            # The model has already been exported
-            if os.path.isdir(model_dir):
-                model_path = model_dir
-            else:
-                # Download the neuron model from the Hub
-                model_path = snapshot_download(model_dir, token=token)
-            # The checkpoint is in a subdirectory
-            checkpoint_path = os.path.join(model_path, cls.CHECKPOINT_DIR)
-            # So are the compiled artifacts
-            compiled_path = os.path.join(model_path, cls.COMPILED_DIR)
-        return model_path, checkpoint_path, compiled_path
+    def _get_neuron_dirs(cls, model_path: Union[str, Path]) -> Tuple[str, str]:
+        # The checkpoint is in a subdirectory
+        checkpoint_dir = os.path.join(model_path, cls.CHECKPOINT_DIR)
+        # So are the compiled artifacts
+        compiled_dir = os.path.join(model_path, cls.COMPILED_DIR)
+        return checkpoint_dir, compiled_dir
 
     @classmethod
     def _from_pretrained(
         cls,
-        model_id: Union[str, Path, TemporaryDirectory],
+        model_id: Union[str, Path],
         config: "PretrainedConfig",
         use_auth_token: Optional[str] = None,
+        revision: Optional[str] = None,
         **kwargs,
     ) -> "NeuronDecoderModel":
         # Verify we are actually trying to load a neuron model
@@ -192,69 +238,47 @@ class NeuronDecoderModel(OptimizedModel):
                 "The specified directory does not contain a neuron model. "
                 "Please convert your model to neuron format by passing export=True."
             )
-
-        # Evaluate the configuration passed during export
-        task = neuron_config["task"]
-        batch_size = neuron_config["batch_size"]
-        sequence_length = neuron_config["sequence_length"]
-        num_cores = neuron_config["num_cores"]
-        auto_cast_type = neuron_config["auto_cast_type"]
-
         check_compiler_compatibility(neuron_config["compiler_type"], neuron_config["compiler_version"])
 
-        exporter = get_exporter(config, task)
+        model_path = model_id
+        if not os.path.isdir(model_id):
+            model_path = snapshot_download(model_id, token=use_auth_token, revision=revision)
 
-        model_path, checkpoint_path, compiled_path = cls._get_neuron_paths(model_id, use_auth_token)
-
-        # transformers-neuronx uses f32/f16 instead of fp32/fp16
-        auto_cast_type = auto_cast_type.replace("p", "")
-        neuronx_model = exporter.neuronx_class.from_pretrained(
-            checkpoint_path,
-            batch_size=batch_size,
-            n_positions=sequence_length,
-            tp_degree=num_cores,
-            amp=auto_cast_type,
-        )
-
-        if compiled_path is not None:
-            # Specify the path where compiled artifacts are stored before conversion
-            neuronx_model.load(compiled_path)
-
-        # Compile the Neuron model (if present compiled artifacts will be reloaded instead of compiled)
-        neuron_cc_flags = os.environ.get("NEURON_CC_FLAGS", "")
-        os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags + " --model-type=transformer"
-        with hub_neuronx_cache():
-            neuronx_model.to_neuron()
-        os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags
+        checkpoint_dir, compiled_dir = cls._get_neuron_dirs(model_path)
+        assert os.path.isdir(checkpoint_dir)
+        assert os.path.isdir(compiled_dir)
 
         # Try to reload the generation config (if any)
         generation_config = None
         try:
-            generation_config = GenerationConfig.from_pretrained(model_path)
+            generation_config = GenerationConfig.from_pretrained(model_id)
         except OSError:
-            logger.info("Generation config file not found, using a generation config created from the model config.")
+            pass
 
-        return cls(neuronx_model, config, model_id, generation_config)
+        return cls(config, checkpoint_dir, compiled_dir=compiled_dir, generation_config=generation_config)
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError()
 
     def _save_pretrained(self, save_directory: Union[str, Path]):
-        _, src_chkpt_path, src_compiled_path = self._get_neuron_paths(self.model_path)
-        _, dst_chkpt_path, dst_compiled_path = self._get_neuron_paths(save_directory)
+        dst_checkpoint_path, dst_compiled_path = self._get_neuron_dirs(save_directory)
 
-        shutil.copytree(src_chkpt_path, dst_chkpt_path)
+        def copy_dir_to_path(src_dir: Union[str, Path, TemporaryDirectory], dst_path: Union[str, Path]):
+            if isinstance(src_dir, TemporaryDirectory):
+                shutil.copytree(src_dir.name, dst_path)
+            elif not os.path.samefile(src_dir, dst_path):
+                os.symlink(dst_path, src_dir)
 
-        if src_compiled_path is None:
-            # The compiled model has never been serialized: do it now
+        # Copy checkpoint directory (it always exists)
+        copy_dir_to_path(self.checkpoint_dir, dst_checkpoint_path)
+        self.checkpoint_dir = dst_checkpoint_path
+        # Save or create compiled directory
+        if self.compiled_dir is None:
+            # The compilation artifacts have never been saved, do it now
             self.model.save(dst_compiled_path)
         else:
-            shutil.copytree(src_compiled_path, dst_compiled_path)
-
-        if isinstance(self.model_path, TemporaryDirectory):
-            # Let temporary directory go out-of-scope to release disk space
-            self.model_path = save_directory
-
+            copy_dir_to_path(self.compiled_dir, dst_compiled_path)
+        self.compiled_dir = dst_compiled_path
         self.generation_config.save_pretrained(save_directory)
 
     def push_to_hub(

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -29,6 +29,7 @@ from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
 from ..modeling_base import OptimizedModel
 from .utils import hub_neuronx_cache, is_transformers_neuronx_available
+from .utils.require_utils import requires_transformers_neuronx
 from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 
 
@@ -67,6 +68,7 @@ class NeuronDecoderModel(OptimizedModel):
     CHECKPOINT_DIR = "checkpoint"
     COMPILED_DIR = "compiled"
 
+    @requires_transformers_neuronx
     def __init__(
         self,
         config: "PretrainedConfig",
@@ -165,6 +167,7 @@ class NeuronDecoderModel(OptimizedModel):
         return checkpoint_dir
 
     @classmethod
+    @requires_transformers_neuronx
     def _from_transformers(
         cls,
         model_id: str,
@@ -178,9 +181,6 @@ class NeuronDecoderModel(OptimizedModel):
         auto_cast_type: Optional[str] = "fp32",
         **kwargs,
     ) -> "NeuronDecoderModel":
-        if not is_transformers_neuronx_available():
-            raise ModuleNotFoundError("The transformers_neuronx package is required to export the model.")
-
         if task is None:
             task = TasksManager.infer_task_from_model(cls.auto_model_class)
 
@@ -238,6 +238,7 @@ class NeuronDecoderModel(OptimizedModel):
         return checkpoint_dir, compiled_dir
 
     @classmethod
+    @requires_transformers_neuronx
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -22,7 +22,7 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import torch
-from huggingface_hub import HfApi, HfFolder, snapshot_download
+from huggingface_hub import HfApi, get_token, snapshot_download
 from huggingface_hub.utils import is_google_colab
 from transformers import AutoConfig, AutoModel, GenerationConfig
 
@@ -269,7 +269,7 @@ class NeuronDecoderModel(OptimizedModel):
         if isinstance(use_auth_token, str):
             huggingface_token = use_auth_token
         elif use_auth_token:
-            huggingface_token = HfFolder.get_token()
+            huggingface_token = get_token()
         else:
             raise ValueError("You need to provide `use_auth_token` to be able to push to the hub")
         api = HfApi(endpoint=endpoint)

--- a/optimum/neuron/utils/require_utils.py
+++ b/optimum/neuron/utils/require_utils.py
@@ -19,7 +19,12 @@ from typing import Any, Callable, Dict
 
 from transformers.utils import is_safetensors_available
 
-from .import_utils import is_neuronx_distributed_available, is_torch_neuronx_available, is_torch_xla_available
+from .import_utils import (
+    is_neuronx_distributed_available,
+    is_torch_neuronx_available,
+    is_torch_xla_available,
+    is_transformers_neuronx_available,
+)
 
 
 _AVAILABILITIES: Dict[str, Callable[[], bool]] = {
@@ -27,6 +32,7 @@ _AVAILABILITIES: Dict[str, Callable[[], bool]] = {
     "torch_xla": is_torch_xla_available,
     "neuronx_distributed": is_neuronx_distributed_available,
     "torch_neuronx": is_torch_neuronx_available,
+    "transformers_neuronx": is_transformers_neuronx_available,
 }
 
 
@@ -52,3 +58,4 @@ requires_safetensors = _create_requires_function("safetensors")
 requires_torch_xla = _create_requires_function("torch_xla")
 requires_neuronx_distributed = _create_requires_function("neuronx_distributed")
 requires_torch_neuronx = _create_requires_function("torch_neuronx")
+requires_transformers_neuronx = _create_requires_function("transformers_neuronx")

--- a/tests/pipelines/test_decoder_pipelines.py
+++ b/tests/pipelines/test_decoder_pipelines.py
@@ -82,6 +82,6 @@ def test_error_needs_export(inf_decoder_model):
 @requires_neuronx
 def test_from_hub():
     model_id = "dacorvo/tiny-random-gpt2-neuronx"
-    revision = "b8f1aec89f9b278721068bfe616fa9227c1d0238"
+    revision = "1b3456cf877cc42c053ee8464f1067021eccde4b"
     p = pipeline("text-generation", model_id, revision=revision)
     _test_generation(p)


### PR DESCRIPTION
When serializing a model, the checkpoint files (i.e. the original
weights formatted for neuron) and the compiled artifacts are stored
under two folders in the model directory.
This modifies the `NeuronForCausalLM.push_to_hub` method to exclude
the folder containing the checkpoint files if they can be instead
reconstructed from a model on the hub.

Note that it is still possible to upload checkpoint files by using the
`huggingface_cli` directly on the saved model folder instead of
push_to_hub.

To allow `optimum-neuron` to fetch and reconstruct the checkpoint when
fetchin a neuron model from the hub, the original repository that was
used to export the model and its revision are stored in the neuron config.

Example model here:

https://huggingface.co/dacorvo/llama-2-7b-chat-hf-neuronx-bs1-seq2048-no-checkpoint/tree/main

```json

"neuron": {
  "auto_cast_type": "fp16",
  "batch_size": 1,
  "checkpoint_id": "meta-llama/Llama-2-7b-chat-hf",
  "checkpoint_revision": "c1b0db933684edbfe29a06fa47eb19cc48025e93",
  "compiler_type": "neuronx-cc",
  "compiler_version": "2.12.54.0+f631c2365",
  "num_cores": 2,
  "sequence_length": 2048,
  "task": "text-generation"
}

```