### PR TITLE
Correctly identify special tokens during generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ $(PACKAGE_DIST) $(PACKAGE_WHEEL): $(PACKAGE_FILES)
 
 neuronx-tgi: $(PACKAGE_DIST)
 	docker build --rm -f text-generation-inference/Dockerfile --build-arg VERSION=$(VERSION) -t neuronx-tgi:$(VERSION) .
+	docker tag neuronx-tgi:$(VERSION) neuronx-tgi:latest
 
 neuronx-tgi-sagemaker: $(PACKAGE_DIST)
 	docker build --rm -f text-generation-inference/Dockerfile --target sagemaker --build-arg VERSION=$(VERSION) -t neuronx-tgi:$(VERSION) .

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -459,7 +459,7 @@ class NeuronGenerator(Generator):
                     token_id=next_token,
                     token_logprob=None,
                     token_text=next_token_text,
-                    token_is_special=(next_token in [self.special_tokens]),
+                    token_is_special=(next_token in self.special_tokens),
                     generated_text=generated_text,
                 )
             )

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -291,7 +291,7 @@ class NeuronGenerator(Generator):
         tokenizer.pad_token_id = tokenizer.eos_token_id
         tokenizer.padding_side = "left"
         self.tokenizer = tokenizer
-        self.special_tokens = [self.tokenizer.eos_token_id, self.tokenizer.pad_token_id]
+        self.special_tokens = self.tokenizer.all_special_ids
         self.slots = [Slot(i, tokenizer) for i in range(self.model.batch_size)]
 
     @property


### PR DESCRIPTION
The special tokens were never identified as such. This fixes #437.