### PR TITLE
Add neuronx cache registry

### DIFF
--- a/docs/source/guides/cache_system.mdx
+++ b/docs/source/guides/cache_system.mdx
@@ -154,12 +154,13 @@ The Optimum CLI can be used to perform various cache-related tasks, as described
 usage: optimum-cli neuron cache [-h] {create,set,add,list} ...
 
 positional arguments:
-  {create,set,add,list}
+  {create,set,add,list,synchronize,lookup}
     create              Create a model repo on the Hugging Face Hub to store Neuron X compilation files.
     set                 Set the name of the Neuron cache repo to use locally (trainium only).
     add                 Add a model to the cache of your choice (trainium only).
     list                List models in a cache repo (trainium only).
     synchronize         Synchronize local compiler cache with the hub cache (inferentia only).
+    lookup              Lookup the neuronx compiler hub cache for the specified model id (inferentia only).
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -606,9 +606,9 @@ def main():
         # Data collator will default to DataCollatorWithPadding, so we change it.
         data_collator=default_data_collator,
         compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
-        preprocess_logits_for_metrics=preprocess_logits_for_metrics
-        if training_args.do_eval and not is_torch_tpu_available()
-        else None,
+        preprocess_logits_for_metrics=(
+            preprocess_logits_for_metrics if training_args.do_eval and not is_torch_tpu_available() else None
+        ),
     )
 
     # Training

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -631,9 +631,9 @@ def main():
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
-        preprocess_logits_for_metrics=preprocess_logits_for_metrics
-        if training_args.do_eval and not is_torch_tpu_available()
-        else None,
+        preprocess_logits_for_metrics=(
+            preprocess_logits_for_metrics if training_args.do_eval and not is_torch_tpu_available() else None
+        ),
     )
 
     # Training

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -16,7 +16,7 @@
 
 from typing import TYPE_CHECKING
 
-from ...neuron.utils import synchronize_hub_cache
+from ...neuron.utils import get_hub_cached_entries, synchronize_hub_cache
 from ...neuron.utils.cache_utils import (
     CACHE_REPO_NAME,
     HF_HOME_CACHE_REPO_FILE,
@@ -218,6 +218,27 @@ class SynchronizeRepoCommand(BaseOptimumCLICommand):
         synchronize_hub_cache(self.args.repo_id)
 
 
+class LookupRepoCommand(BaseOptimumCLICommand):
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        parser.add_argument(
+            "model_id",
+            type=str,
+            help="The model_id to lookup cached versions for.",
+        )
+        parser.add_argument("--repo_id", type=str, default=None, help="The name of the repo to use as remote cache.")
+
+    def run(self):
+        entries = get_hub_cached_entries(self.args.model_id, cache_repo_id=self.args.repo_id)
+        n_entries = len(entries)
+        output = f"\n*** {n_entries} entrie(s) found in cache for {self.args.model_id} ***\n\n"
+        for entry in entries:
+            for key, value in entry.items():
+                output += f"\n{key}: {value}"
+            output += "\n"
+        print(output)
+
+
 class CustomCacheRepoCommand(BaseOptimumCLICommand):
     SUBCOMMANDS = (
         CommandInfo(
@@ -244,5 +265,10 @@ class CustomCacheRepoCommand(BaseOptimumCLICommand):
             name="synchronize",
             help="Synchronize the neuronx compiler cache with a hub cache repo.",
             subcommand_class=SynchronizeRepoCommand,
+        ),
+        CommandInfo(
+            name="lookup",
+            help="Lookup the neuronx compiler hub cache for the specified model id.",
+            subcommand_class=LookupRepoCommand,
         ),
     )

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -248,27 +248,27 @@ class CustomCacheRepoCommand(BaseOptimumCLICommand):
         ),
         CommandInfo(
             name="set",
-            help="Set the name of the Neuron cache repo to use locally.",
+            help="Set the name of the Neuron cache repo to use locally (trainium only).",
             subcommand_class=SetCustomCacheRepoCommand,
         ),
         CommandInfo(
             name="add",
-            help="Add a model to the cache of your choice.",
+            help="Add a model to the cache of your choice (trainium only).",
             subcommand_class=AddToCacheRepoCommand,
         ),
         CommandInfo(
             name="list",
-            help="List models in a cache repo.",
+            help="List models in a cache repo (trainium only).",
             subcommand_class=ListRepoCommand,
         ),
         CommandInfo(
             name="synchronize",
-            help="Synchronize the neuronx compiler cache with a hub cache repo.",
+            help="Synchronize the neuronx compiler cache with a hub cache repo (inferentia only).",
             subcommand_class=SynchronizeRepoCommand,
         ),
         CommandInfo(
             name="lookup",
-            help="Lookup the neuronx compiler hub cache for the specified model id.",
+            help="Lookup the neuronx compiler hub cache for the specified model id (inferentia only).",
             subcommand_class=LookupRepoCommand,
         ),
     )

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -397,9 +397,11 @@ class Parallelizer(ABC):
                             tp_rank = get_tensor_model_parallel_rank()
                             size_per_rank = parameter.size(partition_dim)
                             slices = [
-                                None
-                                if idx != partition_dim
-                                else (size_per_rank * tp_rank, size_per_rank * (tp_rank + 1))
+                                (
+                                    None
+                                    if idx != partition_dim
+                                    else (size_per_rank * tp_rank, size_per_rank * (tp_rank + 1))
+                                )
                                 for idx in range(num_dims)
                             ]
                         else:

--- a/optimum/neuron/distributed/checkpointing.py
+++ b/optimum/neuron/distributed/checkpointing.py
@@ -46,9 +46,11 @@ def consolidate_tensor_parallel_checkpoints(checkpoint_dir: Union[str, Path]) ->
     parameter_names = state_dicts[0]["model"].keys()
     sharded_metadatas = {
         name: [
-            ParameterMetadata(**state_dict["sharded_metadata"][name])
-            if name in state_dict["sharded_metadata"]
-            else ParameterMetadata("tied")
+            (
+                ParameterMetadata(**state_dict["sharded_metadata"][name])
+                if name in state_dict["sharded_metadata"]
+                else ParameterMetadata("tied")
+            )
             for state_dict in state_dicts
         ]
         for name in parameter_names

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -28,7 +28,7 @@ from transformers import AutoConfig, AutoModel, GenerationConfig
 from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
 from ..modeling_base import OptimizedModel
-from .utils import hub_neuronx_cache, is_transformers_neuronx_available
+from .utils import CacheEntry, hub_neuronx_cache, is_transformers_neuronx_available
 from .utils.require_utils import requires_transformers_neuronx
 from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 
@@ -124,7 +124,10 @@ class NeuronDecoderModel(OptimizedModel):
         # Compile the Neuron model (if present compiled artifacts will be reloaded instead of compiled)
         neuron_cc_flags = os.environ.get("NEURON_CC_FLAGS", "")
         os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags + " --model-type=transformer"
-        with hub_neuronx_cache():
+        checkpoint_id = neuron_config.get("checkpoint_id", None)
+        # Only create a cache entry if the model comes from the hub
+        cache_entry = None if checkpoint_id is None else CacheEntry(neuron_config["checkpoint_id"], neuron_config)
+        with hub_neuronx_cache(entry=cache_entry):
             neuronx_model.to_neuron()
         os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags
 

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -24,7 +24,7 @@ from .constant import (
     ENCODER_NAME,
     NEURON_FILE_NAME,
 )
-from .hub_neuronx_cache import hub_neuronx_cache, synchronize_hub_cache
+from .hub_neuronx_cache import CacheEntry, hub_neuronx_cache, synchronize_hub_cache
 from .import_utils import (
     is_accelerate_available,
     is_neuron_available,

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -24,7 +24,7 @@ from .constant import (
     ENCODER_NAME,
     NEURON_FILE_NAME,
 )
-from .hub_neuronx_cache import CacheEntry, hub_neuronx_cache, synchronize_hub_cache
+from .hub_neuronx_cache import CacheEntry, get_hub_cached_entries, hub_neuronx_cache, synchronize_hub_cache
 from .import_utils import (
     is_accelerate_available,
     is_neuron_available,

--- a/optimum/neuron/utils/hub_neuronx_cache.py
+++ b/optimum/neuron/utils/hub_neuronx_cache.py
@@ -207,7 +207,7 @@ class CacheEntry:
     metadata: Dict[str, Any]
 
 
-REGISTRY_FOLDER = "registry"
+REGISTRY_FOLDER = "0_REGISTRY"
 
 
 @requires_torch_neuronx

--- a/optimum/neuron/utils/hub_neuronx_cache.py
+++ b/optimum/neuron/utils/hub_neuronx_cache.py
@@ -216,7 +216,7 @@ def hub_neuronx_cache(entry: Optional[CacheEntry] = None):
     """A context manager to activate the Hugging Face Hub proxy compiler cache.
 
     Args:
-        entry (`CacheEntry`):
+        entry (`Optional[CacheEntry]`, defaults to `None`):
             An optional dataclass containing metadata associated with the cache session.
             Will create a dedicated entry in the cache registry.
     """

--- a/optimum/neuron/utils/hub_neuronx_cache.py
+++ b/optimum/neuron/utils/hub_neuronx_cache.py
@@ -12,10 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import hashlib
+import json
 import logging
 import os
 from contextlib import contextmanager
-from typing import Optional
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 from huggingface_hub import HfApi, get_token
 
@@ -196,10 +200,25 @@ def _create_hub_compile_cache_proxy(
     return CompileCacheHfProxy(cache_repo_id, default_cache, endpoint=endpoint, token=token)
 
 
+@dataclass
+class CacheEntry:
+    key: str
+    metadata: Dict[str, Any]
+
+
+REGISTRY_FOLDER = "registry"
+
+
 @requires_torch_neuronx
 @contextmanager
-def hub_neuronx_cache():
-    """A context manager to trigger the Hugging Face Hub proxy compiler cache"""
+def hub_neuronx_cache(entry: Optional[CacheEntry] = None):
+    """A context manager to activate the Hugging Face Hub proxy compiler cache.
+
+    Args:
+        entry (`CacheEntry`):
+            An optional dataclass containing metadata associated with the cache session.
+            Will create a dedicated entry in the cache registry.
+    """
 
     def hf_create_compile_cache(cache_url):
         try:
@@ -209,8 +228,27 @@ def hub_neuronx_cache():
             return create_compile_cache(cache_url)
 
     try:
+        default_cache = create_compile_cache(CacheUrl.get_cache_url())
         patch_everywhere("create_compile_cache", hf_create_compile_cache, "libneuronxla")
         yield
+        # The cache session ended without error
+        if entry is not None:
+            if isinstance(default_cache, CompileCacheS3):
+                logger.warning("Skipping cache metadata update on S3 cache.")
+            else:
+                # Create cache entry in local cache: it can be later synchronized with the hub cache
+                registry_path = default_cache.get_cache_dir_with_cache_key(REGISTRY_FOLDER)
+                entry_path = f"{registry_path}/{entry.key}"
+                metadata_json = json.dumps(entry.metadata, indent=4)
+                hash_gen = hashlib.sha512()
+                hash_gen.update(metadata_json.encode("utf-8"))
+                metadata_key = str(hash_gen.hexdigest())[:20]
+                metadata_path = f"{entry_path}/{metadata_key}.json"
+                if not default_cache.exists(metadata_path):
+                    oldmask = os.umask(000)
+                    Path(entry_path).mkdir(parents=True, exist_ok=True)
+                    os.umask(oldmask)
+                    default_cache.upload_string_to_file(metadata_path, metadata_json)
     finally:
         patch_everywhere("create_compile_cache", create_compile_cache, "libneuronxla")
 

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -165,12 +165,19 @@ def test_decoder_cache_unavailable(cache_repos, var, value, match):
 @requires_neuronx
 def test_optimum_neuron_cli_cache_synchronize(cache_repos):
     cache_path, cache_repo_id = cache_repos
+    model_id = "hf-internal-testing/tiny-random-gpt2"
     # Export a model to populate the local cache
-    export_decoder_model("hf-internal-testing/tiny-random-gpt2")
+    export_decoder_model(model_id)
     # Synchronize the hub cache with the local cache
     command = "optimum-cli neuron cache synchronize".split()
+    p = subprocess.Popen(command, stdout=subprocess.PIPE)
+    p.communicate()
+    assert p.returncode == 0
+    assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
+    # Check the model entry in the hub
+    command = f"optimum-cli neuron cache lookup {model_id}".split()
     p = subprocess.Popen(command, stdout=subprocess.PIPE)
     stdout, _ = p.communicate()
     stdout = stdout.decode("utf-8")
     assert p.returncode == 0
-    assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
+    assert f"1 entrie(s) found in cache for {model_id}" in stdout

--- a/tests/distributed/distributed.py
+++ b/tests/distributed/distributed.py
@@ -97,8 +97,7 @@ class DistributedExec(ABC):
     exec_timeout: int = TEST_TIMEOUT
 
     @abstractmethod
-    def run(self):
-        ...
+    def run(self): ...
 
     def __call__(self, request=None):
         self._fixture_kwargs = self._get_fixture_kwargs(request, self.run)

--- a/tests/generation/conftest.py
+++ b/tests/generation/conftest.py
@@ -163,13 +163,6 @@ def neuron_seq2seq_greedy_path_with_optional_outputs(export_seq2seq_id):
     yield model_path
 
 
-@pytest.fixture(scope="session")
-def neuron_push_decoder_id(export_decoder_id):
-    model_name = export_decoder_id.split("/")[-1]
-    repo_id = f"{USER}/{model_name}-neuronx"
-    return repo_id
-
-
 @pytest.fixture(scope="module")
 def neuron_push_seq2seq_id(export_seq2seq_id):
     model_name = export_seq2seq_id.split("/")[-1]

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -83,9 +83,9 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
         assert get_neuron_cache_path() is None
 
         custom_cache_dir_name = Path("_this/is_/my1/2custom/cache/dir")
-        os.environ[
-            "NEURON_CC_FLAGS"
-        ] = f"--some --parameters --here --cache_dir={custom_cache_dir_name} --other --paremeters --here"
+        os.environ["NEURON_CC_FLAGS"] = (
+            f"--some --parameters --here --cache_dir={custom_cache_dir_name} --other --paremeters --here"
+        )
 
         self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name)
 
@@ -99,9 +99,9 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
         set_neuron_cache_path(new_cache_path, ignore_no_cache=True)
         self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
 
-        os.environ[
-            "NEURON_CC_FLAGS"
-        ] = "--some --parameters --here --cache_dir=original_cache_dir --other --paremeters"
+        os.environ["NEURON_CC_FLAGS"] = (
+            "--some --parameters --here --cache_dir=original_cache_dir --other --paremeters"
+        )
         set_neuron_cache_path(new_cache_path)
         self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -193,7 +193,7 @@ MODELS_TO_TEST_MAPPING = {
         TPSupport.FULL,
         Coverage.HIGH,
         {"num_hidden_layers": 2},
-    )
+    ),
     # "wav2vec2": "facebook/wav2vec2-base",
     # Remaning: XLNet, Deberta-v2, MPNet, CLIP
 }


### PR DESCRIPTION
This extends the neuronx caching for decoder models to store the cached neuron configurations under a specific `registry` folder for each `neuronxcc` compiler version.

```
aws-neuron/optimum-neuron-cache/                                                
└── neuronxcc-2.12.54.0+f631c2365
    └── registry
       ├── hf-internal-testing
       │   └── tiny-random-gpt2
       │       └── 8019d93dd8eda6d8da82.json
       └── mistralai
            └── Mistral-7B-Instruct-v0.1
                └── b12f53f65aebf02fdfa9.json
```

This also adds a `get_hub_cached_entries` helper and CLI command to lookup cached configurations for a specific `model_id`. 

The output looks like this:

```
$ optimum-cli neuron cache lookup mistralai/Mistral-7B-Instruct-v0.1
*** 1 entrie(s) found in cache for mistralai/Mistral-7B-Instruct-v0.1 ***


task: text-generation
batch_size: 1
num_cores: 2
auto_cast_type: bf16
sequence_length: 2048
compiler_type: neuronx-cc
compiler_version: 2.12.54.0+f631c2365
checkpoint_id: mistralai/Mistral-7B-Instruct-v0.1
checkpoint_revision: 9ab9e76e2b09f9f29ea2d56aa5bd139e4445c59e

```