### PR TITLE
TGI: export model if configuration is cached

### DIFF
--- a/docs/source/benchmarks/inferentia-llama2.mdx
+++ b/docs/source/benchmarks/inferentia-llama2.mdx
@@ -48,7 +48,7 @@ while 768 is more typical of a Retrieval Augmented Generation (RAG) use-case.
 
 Encoding time is expressed in **seconds**.
 
-![Llama2 inferentia2 encoding-time](https://raw.githubusercontent.com/huggingface/optimum-neuron/main/docs/assets/benchmarks/inferentia-llama2/encoding-times.png "Encoding time")
+![Llama2 inferentia2 encoding-time](https://raw.githubusercontent.com/huggingface/optimum-neuron/main/docs/assets/benchmarks/inferentia-llama2/encoding_times.png "Encoding time")
 
 We can see that all deployed models exhibit excellent response times, even for long contexts.
 

--- a/docs/source/guides/cache_system.mdx
+++ b/docs/source/guides/cache_system.mdx
@@ -17,31 +17,101 @@ It is integrated into the [`NeuronTrainer` and `NeuronModelForCausalLM`] classes
 
 The Neuron Model Cache is hosted on the [Hugging Face Hub](https://huggingface.co/aws-neuron/optimum-neuron-cache) and includes compiled files for all popular and supported `optimum-neuron` pre-trained models.
 
-When loading a Transformers or Diffusion model, it needs to be compiled to neuron format with [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx),
-in order to run on Neuron platforms.
-The compilation produces several compilation files stored in a local directory, usually `/var/tmp/neuron-compile-cache`.
-This means that every time you train or export a model on a new host, you need to recompile it, which takes a lot of time.
+Before loading a Transformers or Diffusion model on Neuron platforms, it needs to be exported to neuron format with [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx).
+When exporting a model, [`torch-neuronx`] will:
+- convert it to a set of [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs, stored as `model.hlo.pb` files,
+- compile each subgraph with the neuronx compiler into a Neuron Executable File Format (NEFF) binary file.
 
-We created the Neuron Model Cache to solve this limitation by providing a public cache of precompiled available models and a private cache to create your private, secured, remote model cache.
+During inference, the [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx) module will reload the graph files, and (by default) always recompile the corresponding NEFF files.
+To avoid these recompilations, [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx) stores NEFF files in a local directory, usually `/var/tmp/neuron-compile-cache`.
 
-## How the caching system works
+However, this local cache is not shared between platforms, which means that every time you train or export a model on a new host, you need to recompile it, which takes a lot of time.
 
-### Hash computation
+We created the Neuron Model Cache to solve this limitation by providing a public repository of precompiled model graphs.
 
-Many factors can trigger compilation among which:
+Note: we also support the creation of private, secured, remote model cache.
 
-- The input shapes,
-- The precision of the model, full-precision or bf16,
-- The version of the Neuron X compiler,
-- The number of Neuron cores used.
-
-These parameters are used to compute a hash that uniquely identifies each compilation file.
-
-**It is important to keep in mind that even a small change in the model configuration will trigger a recompilation.**
-
-### How to use the Neuron model cache
+## How to use the Neuron model cache
 
 The public model cache will be used when you use the [`NeuronTrainer` or `NeuronModelForCausalLM`] classes. There are no additional changes needed.
+
+When exporting a model to neuron format, `optimum-neuron` will simply look for cached NEFF files in the hub repository during the compilation of the
+model converted to [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs.
+
+If the NEFF files are cached, they will be fetched from the hub and directly loaded instead of being recompiled.
+
+## How caching works
+
+The Optimum Neuron Cache is built on top of the [NeuronX compiler cache](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/arch/neuron-features/neuron-caching.html).
+
+It is important to understand that the cache operates on NEFF binaries, and not on the model itself.
+
+As explained previously, each model is first converted to a set of [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs.
+
+Each subgraph is unique, and results from the combination of:
+- the `transformers` or `transformers_neuronx` python modeling code,
+- the `transformers` model config,
+- the `input_shapes` selected during the export,
+- The precision of the model, full-precision, fp16 or bf16.
+
+When compiling a subgraph to a NEFF file, other parameters influence the result:
+- The version of the Neuron X compiler,
+- The number of Neuron cores used,
+- The compilation parameters (such as the optimization level).
+
+All these parameters are combined together to create a unique hash that identifies a NEFF file.
+
+This has two very important consequences:
+- it is only when actually exporting a model that the associated NEFF files can be identified,
+- even a small change in the model configuration will lead to a different set of NEFF files.
+
+It is therefore very difficult to know in advance if the NEFFs associated to a specific model configuration are cached.
+
+## Neuron model cache lookup (inferentia only)
+
+The neuron cache lookup is a feature allowing users to look for compatible cached model configurations before exporting
+a model for inference.
+
+It is based on a dedicated registry composed of stored cached configurations.
+
+Cached model configurations are stored as entries under a specific subfolder in the Neuron Model Cache:
+
+```
+neuronxcc-2.12.54.0+f631c2365
+├── 0_REGISTRY
+│   └── 0.0.18
+│       └── llama
+│           └── meta-llama
+│               └── Llama-2-7b-chat-hf
+│                   └── 54c1f6689cd88f246fce.json
+```
+
+Each entry corresponds to the combination of a model configuration and its export parameters: this is as close as we can get to
+uniquely identify the exported model.
+
+You can use the `optimum-cli` to lookup for compatible cached entries by passing it a hub model_id or the path to a file
+containing a model `config.json`.
+
+```shell
+$ optimum-cli neuron cache lookup meta-llama/Llama-2-7b-chat-hf
+
+*** 1 entrie(s) found in cache for meta-llama/Llama-2-7b-chat-hf ***
+
+task: text-generation
+batch_size: 1
+num_cores: 24
+auto_cast_type: fp16
+sequence_length: 2048
+compiler_type: neuronx-cc
+compiler_version: 2.12.54.0+f631c2365
+checkpoint_id: meta-llama/Llama-2-7b-chat-hf
+checkpoint_revision: c1b0db933684edbfe29a06fa47eb19cc48025e93
+```
+
+**Note that even if compatible cached entries exist, this does not always guarantee that the model will not be recompiled during export
+if you modified the compilation parameters or updated the neuronx packages.**
+
+## Advanced usage (trainium only)
 
 ### How to use a private Neuron model cache (trainium only)
 

--- a/docs/source/guides/cache_system.mdx
+++ b/docs/source/guides/cache_system.mdx
@@ -13,19 +13,25 @@ specific language governing permissions and limitations under the License.
 # Neuron Model Cache
 
 The Neuron Model Cache is a remote cache for compiled Neuron models in the `neff` format.
-It is integrated into the [`NeuronTrainer` and `NeuronModelForCausalLM`] classes to enable loading pretrained models from the cache instead of compiling them locally.
+It is integrated into the `NeuronTrainer` and `NeuronModelForCausalLM` classes to enable loading pretrained models from the cache instead of compiling them locally.
+
+**Note: it is not available for models exported using any other NeuronModelXX classes, that use a different export mechanism.**
 
 The Neuron Model Cache is hosted on the [Hugging Face Hub](https://huggingface.co/aws-neuron/optimum-neuron-cache) and includes compiled files for all popular and supported `optimum-neuron` pre-trained models.
 
-Before loading a Transformers or Diffusion model on Neuron platforms, it needs to be exported to neuron format with [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx).
-When exporting a model, [`torch-neuronx`] will:
-- convert it to a set of [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs, stored as `model.hlo.pb` files,
+Before training a Transformers or Diffusion model or loading a NeuronModelForCausalLM on Neuron platforms, it needs to be exported to neuron format
+with [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx).
+
+When exporting a model, [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx) will:
+
+- convert it to a set of [XLA](https://github.com/pytorch/xla/) subgraphs,
 - compile each subgraph with the neuronx compiler into a Neuron Executable File Format (NEFF) binary file.
 
-During inference, the [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx) module will reload the graph files, and (by default) always recompile the corresponding NEFF files.
-To avoid these recompilations, [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx) stores NEFF files in a local directory, usually `/var/tmp/neuron-compile-cache`.
+The first step is relatively fast, but the compilation takes a lot of time.
+To avoid recompiling all NEFF files every time a model is loaded on a NeuronX host, [`torch-neuronx`](https://github.com/aws-neuron/aws-neuron-samples/tree/master/torch-neuronx)
+ stores NEFF files in a local directory, usually `/var/tmp/neuron-compile-cache`.
 
-However, this local cache is not shared between platforms, which means that every time you train or export a model on a new host, you need to recompile it, which takes a lot of time.
+However, this local cache is not shared between platforms, which means that every time you train or export a model on a new host, you need to recompile it.
 
 We created the Neuron Model Cache to solve this limitation by providing a public repository of precompiled model graphs.
 
@@ -33,10 +39,10 @@ Note: we also support the creation of private, secured, remote model cache.
 
 ## How to use the Neuron model cache
 
-The public model cache will be used when you use the [`NeuronTrainer` or `NeuronModelForCausalLM`] classes. There are no additional changes needed.
+The public model cache will be used when you use the `NeuronTrainer` or `NeuronModelForCausalLM` classes. There are no additional changes needed.
 
 When exporting a model to neuron format, `optimum-neuron` will simply look for cached NEFF files in the hub repository during the compilation of the
-model converted to [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs.
+model subgraphs.
 
 If the NEFF files are cached, they will be fetched from the hub and directly loaded instead of being recompiled.
 
@@ -46,7 +52,7 @@ The Optimum Neuron Cache is built on top of the [NeuronX compiler cache](https:/
 
 It is important to understand that the cache operates on NEFF binaries, and not on the model itself.
 
-As explained previously, each model is first converted to a set of [TorchScript](https://pytorch.org/docs/stable/jit.html) subgraphs.
+As explained previously, each model exported to Neuron using the `NeuronTrainer` or `NeuronModelForCausalLM` is composed of [XLA](https://github.com/pytorch/xla/) subgraphs.
 
 Each subgraph is unique, and results from the combination of:
 - the `transformers` or `transformers_neuronx` python modeling code,

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -182,7 +182,7 @@ class NeuronDecoderModel(OptimizedModel):
         sequence_length: Optional[int] = None,
         num_cores: Optional[int] = None,
         auto_cast_type: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> "PretrainedConfig":
         if task is None:
             task = TasksManager.infer_task_from_model(cls.auto_model_class)
 

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from huggingface_hub import HfApi, get_token, snapshot_download
 from huggingface_hub.utils import is_google_colab

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -28,7 +28,7 @@ from transformers import AutoConfig, AutoModel, GenerationConfig
 from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
 from ..modeling_base import OptimizedModel
-from .utils import CacheEntry, hub_neuronx_cache, is_transformers_neuronx_available
+from .utils import ModelCacheEntry, hub_neuronx_cache, is_transformers_neuronx_available
 from .utils.require_utils import requires_transformers_neuronx
 from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 
@@ -126,7 +126,7 @@ class NeuronDecoderModel(OptimizedModel):
         os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags + " --model-type=transformer"
         checkpoint_id = neuron_config.get("checkpoint_id", None)
         # Only create a cache entry if the model comes from the hub
-        cache_entry = None if checkpoint_id is None else CacheEntry(neuron_config["checkpoint_id"], neuron_config)
+        cache_entry = None if checkpoint_id is None else ModelCacheEntry(checkpoint_id, config)
         with hub_neuronx_cache(entry=cache_entry):
             neuronx_model.to_neuron()
         os.environ["NEURON_CC_FLAGS"] = neuron_cc_flags

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 """Base class for text-generation model architectures on neuron devices."""
 
+import copy
 import logging
 import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 from huggingface_hub import HfApi, get_token, snapshot_download
 from huggingface_hub.utils import is_google_colab
@@ -170,6 +171,62 @@ class NeuronDecoderModel(OptimizedModel):
         return checkpoint_dir
 
     @classmethod
+    def get_export_config(
+        cls,
+        model_id: str,
+        config: "PretrainedConfig",
+        use_auth_token: Optional[str] = None,
+        revision: Optional[str] = None,
+        task: Optional[str] = None,
+        batch_size: Optional[int] = None,
+        sequence_length: Optional[int] = None,
+        num_cores: Optional[int] = None,
+        auto_cast_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if task is None:
+            task = TasksManager.infer_task_from_model(cls.auto_model_class)
+
+        if os.path.isdir(model_id):
+            checkpoint_id = None
+            checkpoint_revision = None
+        else:
+            checkpoint_id = model_id
+            # Get the exact checkpoint revision (SHA1)
+            api = HfApi(token=use_auth_token)
+            model_info = api.repo_info(model_id, revision=revision)
+            checkpoint_revision = model_info.sha
+
+        if batch_size is None:
+            batch_size = 1
+        # If the sequence_length was not specified, deduce it from the model configuration
+        if sequence_length is None:
+            # Note: for older models, max_position_embeddings is an alias for n_positions
+            sequence_length = config.max_position_embeddings
+        if num_cores is None:
+            # Use all available cores
+            num_cores = len(os.listdir("/sys/class/neuron_device/")) * 2
+        if auto_cast_type is None:
+            auto_cast_type = "fp32"
+            if config.torch_dtype == "float16":
+                auto_cast_type = "fp16"
+            elif config.torch_dtype == "bfloat16":
+                auto_cast_type = "bf16"
+
+        new_config = copy.deepcopy(config)
+        new_config.neuron = {
+            "task": task,
+            "batch_size": batch_size,
+            "num_cores": num_cores,
+            "auto_cast_type": auto_cast_type,
+            "sequence_length": sequence_length,
+            "compiler_type": "neuronx-cc",
+            "compiler_version": get_neuronxcc_version(),
+            "checkpoint_id": checkpoint_id,
+            "checkpoint_revision": checkpoint_revision,
+        }
+        return new_config
+
+    @classmethod
     @requires_transformers_neuronx
     def _from_transformers(cls, *args, **kwargs):
         # Deprecate it when optimum uses `_export` as from_pretrained_method in a stable release.
@@ -193,49 +250,26 @@ class NeuronDecoderModel(OptimizedModel):
         if not os.path.isdir("/sys/class/neuron_device/"):
             raise SystemError("Decoder models can only be exported on a neuron platform.")
 
-        if task is None:
-            task = TasksManager.infer_task_from_model(cls.auto_model_class)
+        # Update the config
+        new_config = cls.get_export_config(
+            model_id,
+            config,
+            use_auth_token=use_auth_token,
+            revision=revision,
+            task=task,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            num_cores=num_cores,
+            auto_cast_type=auto_cast_type,
+        )
 
         # Instantiate the transformers model checkpoint
         checkpoint_dir = cls._create_checkpoint(
             model_id,
-            task=task,
+            task=new_config.neuron["task"],
             revision=revision,
             **kwargs,
         )
-
-        if os.path.isdir(model_id):
-            checkpoint_id = None
-            checkpoint_revision = None
-        else:
-            checkpoint_id = model_id
-            # Get the exact checkpoint revision (SHA1)
-            api = HfApi(token=use_auth_token)
-            model_info = api.repo_info(model_id, revision=revision)
-            checkpoint_revision = model_info.sha
-
-        if batch_size is None:
-            batch_size = 1
-        # If the sequence_length was not specified, deduce it from the model configuration
-        if sequence_length is None:
-            # Note: for older models, max_position_embeddings is an alias for n_positions
-            sequence_length = config.max_position_embeddings
-        if num_cores is None:
-            # Use all available cores
-            num_cores = len(os.listdir("/sys/class/neuron_device/")) * 2
-
-        # Update the config
-        config.neuron = {
-            "task": task,
-            "batch_size": batch_size,
-            "num_cores": num_cores,
-            "auto_cast_type": auto_cast_type,
-            "sequence_length": sequence_length,
-            "compiler_type": "neuronx-cc",
-            "compiler_version": get_neuronxcc_version(),
-            "checkpoint_id": checkpoint_id,
-            "checkpoint_revision": checkpoint_revision,
-        }
 
         # Try to reload the generation config (if any)
         generation_config = None
@@ -244,7 +278,7 @@ class NeuronDecoderModel(OptimizedModel):
         except OSError:
             pass
 
-        return cls(config, checkpoint_dir, generation_config=generation_config)
+        return cls(new_config, checkpoint_dir, generation_config=generation_config)
 
     @classmethod
     def _get_neuron_dirs(cls, model_path: Union[str, Path]) -> Tuple[str, str]:

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -24,7 +24,7 @@ from .constant import (
     ENCODER_NAME,
     NEURON_FILE_NAME,
 )
-from .hub_neuronx_cache import CacheEntry, get_hub_cached_entries, hub_neuronx_cache, synchronize_hub_cache
+from .hub_neuronx_cache import ModelCacheEntry, get_hub_cached_entries, hub_neuronx_cache, synchronize_hub_cache
 from .import_utils import (
     is_accelerate_available,
     is_neuron_available,

--- a/optimum/neuron/utils/hub_neuronx_cache.py
+++ b/optimum/neuron/utils/hub_neuronx_cache.py
@@ -207,7 +207,7 @@ class ModelCacheEntry:
     Args:
         model_id (`str`):
             The model id, used as a key for the cache entry.
-        config (`~transformers.PretrainedConfig`):
+        config (`transformers.PretrainedConfig`):
             The configuration of the model.
 
     """

--- a/optimum/neuron/utils/hub_neuronx_cache.py
+++ b/optimum/neuron/utils/hub_neuronx_cache.py
@@ -207,7 +207,7 @@ class CacheEntry:
     metadata: Dict[str, Any]
 
 
-REGISTRY_FOLDER = "0_REGISTRY"
+REGISTRY_FOLDER = f"0_REGISTRY/{__version__}"
 
 
 @requires_torch_neuronx

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -85,7 +85,8 @@ def check_decoder_generation(model):
 
 
 def get_local_cached_files(cache_path, extension="*"):
-    return glob.glob(f"{cache_path}/**/*/*.{extension}", recursive=True)
+    links = glob.glob(f"{cache_path}/**/*/*.{extension}", recursive=True)
+    return [link for link in links if os.path.isfile(link)]
 
 
 def check_cache_entry(model, cache_path):

--- a/text-generation-inference/server/text_generation_server/cli.py
+++ b/text-generation-inference/server/text_generation_server/cli.py
@@ -56,9 +56,11 @@ def serve(
         logger.warning("'trust_remote_code' argument is not supported and will be ignored.")
 
     # Import here after the logger is added to log potential import exceptions
+    from .model import fetch_model
     from .server import serve
 
-    serve(model_id, revision, uds_path)
+    model_path = fetch_model(model_id, revision)
+    serve(model_path, uds_path)
 
 
 @app.command()

--- a/text-generation-inference/server/text_generation_server/model.py
+++ b/text-generation-inference/server/text_generation_server/model.py
@@ -1,9 +1,53 @@
 import os
+import time
 from typing import Optional
 
 from huggingface_hub import snapshot_download
+from huggingface_hub.constants import HF_HUB_CACHE
 from loguru import logger
-from transformers import AutoConfig
+from transformers import AutoConfig, AutoTokenizer
+
+from optimum.neuron import NeuronModelForCausalLM
+from optimum.neuron.utils import ModelCacheEntry, get_hub_cached_entries
+
+
+def get_export_kwargs_from_env():
+    batch_size = os.environ.get("HF_BATCH_SIZE", None)
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    sequence_length = os.environ.get("HF_SEQUENCE_LENGTH", None)
+    if sequence_length is not None:
+        sequence_length = int(sequence_length)
+    num_cores = os.environ.get("HF_NUM_CORES", None)
+    if num_cores is not None:
+        num_cores = int(num_cores)
+    auto_cast_type = os.environ.get("HF_AUTO_CAST_TYPE", None)
+    return {
+        "task": "text-generation",
+        "batch_size": batch_size,
+        "sequence_length": sequence_length,
+        "num_cores": num_cores,
+        "auto_cast_type": auto_cast_type,
+    }
+
+
+def is_cached(model_id, neuron_config):
+    # Look for cached entries for the specified model
+    in_cache = False
+    entries = get_hub_cached_entries(model_id)
+    # Look for compatible entries
+    for entry in entries:
+        compatible = True
+        for key, value in neuron_config.items():
+            # Only weights can be different
+            if key in ["checkpoint_id", "checkpoint_revision"]:
+                continue
+            if entry[key] != value:
+                compatible = False
+        if compatible:
+            in_cache = True
+            break
+    return in_cache
 
 
 def fetch_model(
@@ -21,17 +65,51 @@ def fetch_model(
     Returns:
         Local folder path (string) of the model.
     """
+    if not os.path.isdir("/sys/class/neuron_device/"):
+        raise SystemError("No neuron cores detected on the host.")
     if os.path.isdir(model_id):
         if revision is not None:
             logger.warning("Revision {} ignored for local model at {}".format(revision, model_id))
-        model_path = model_id
-    else:
-        # Download the model from the Hub (HUGGING_FACE_HUB_TOKEN must be set for a private or gated model)
-        # Note that the model may already be present in the cache.
-        logger.info("Fetching revision {} for {}".format(revision, model_id))
-        model_path = snapshot_download(model_id, revision=revision)
-    config = AutoConfig.from_pretrained(model_path)
+        return model_id
+    # Download the model from the Hub (HUGGING_FACE_HUB_TOKEN must be set for a private or gated model)
+    # Note that the model may already be present in the cache.
+    config = AutoConfig.from_pretrained(model_id, revision=revision)
     neuron_config = getattr(config, "neuron", None)
-    if neuron_config is None:
-        raise ValueError("The target model is not a Neuron model. Please export it to neuron first.")
-    return model_path
+    if neuron_config is not None:
+        logger.info("Fetching revision {} for neuron model {}".format(revision, model_id))
+        return snapshot_download(model_id, revision=revision)
+    # Not a neuron model: evaluate the export config and check if it has been exported locally
+    export_kwargs = get_export_kwargs_from_env()
+    export_config = NeuronModelForCausalLM.get_export_config(model_id, config, revision=revision, **export_kwargs)
+    entry = ModelCacheEntry(model_id, export_config)
+    export_path = f"{HF_HUB_CACHE}/{entry.hash}"
+    if os.path.exists(export_path):
+        # The model has already been exported for that configuration
+        logger.info(f"Neuron model for {model_id} with {export_config.neuron} found under {export_path}.")
+        return export_path
+    # Look for compatible cached entries on the hub
+    neuron_config = export_config.neuron
+    if not is_cached(model_id, neuron_config):
+        error_msg = (
+            f"No cached version found for {model_id} with {neuron_config}."
+            "You can start a discussion to request it on https://huggingface.co/aws-neuron/optimum-neuron-cache."
+        )
+        raise ValueError(error_msg)
+    # Export the model
+    logger.warning(f"{model_id} is not a neuron model: it will be exported using cached artifacts.")
+    start = time.time()
+    logger.info(f"Fetching revision {revision} of model {model_id}.")
+    model_path = snapshot_download(model_id, revision=revision)
+    end = time.time()
+    logger.info(f"Model successfully fetched in {end - start:.2f} s.")
+    logger.info(f"Exporting model to neuron with config {neuron_config}.")
+    start = time.time()
+    model = NeuronModelForCausalLM.from_pretrained(model_path, export=True, **export_kwargs)
+    # Save for later retrieval
+    model.save_pretrained(export_path)
+    end = time.time()
+    # We also need to fetch and save the tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
+    tokenizer.save_pretrained(export_path)
+    logger.info(f"Model successfully exported in {end - start:.2f} s under {export_path}.")
+    return export_path

--- a/text-generation-inference/server/text_generation_server/server.py
+++ b/text-generation-inference/server/text_generation_server/server.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from grpc import aio
 from grpc_reflection.v1alpha import reflection
@@ -49,17 +49,16 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
 
 def serve(
-    model_id: str,
-    revision: Optional[str],
+    model_path: str,
     uds_path: Path,
 ):
-    async def serve_inner(model_id: str, revision: Optional[str]):
+    async def serve_inner(model_path: str):
         unix_socket_template = "unix://{}-{}"
         local_url = unix_socket_template.format(uds_path, 0)
         server_urls = [local_url]
 
         try:
-            generator = NeuronGenerator.from_pretrained(model_id, revision)
+            generator = NeuronGenerator.from_pretrained(model_path)
         except Exception:
             logger.exception("Error when initializing model")
             raise
@@ -85,4 +84,4 @@ def serve(
             logger.info("Signal received. Shutting down")
             await server.stop(0)
 
-    asyncio.run(serve_inner(model_id, revision))
+    asyncio.run(serve_inner(model_path))


### PR DESCRIPTION
This pull-request is two-fold.

First, it modifies the cache registry to use the `model_type` (i.e '`llama`, `mistral`, ...) as the primary key for lookups.
This allows to detect compatible configurations for models with different weights or even for local models.

Second, it modifies the NeuronX TGI server to export models under specific conditions.

Instead of raising an error if the model passed to Neuron X TGI is not a neuron model, we now try to lookup for cached artifacts in the hub cache.

If a compatible cached configuration is detected in the cache registry, the model is exported by the TGI server using cached artifacts (and thus in a much shorter time than a vanilla compilation).

The TGI server is extended with new environment variables to define the configuration for the export:

- HF_BATCH_SIZE, default to 1,
- HF_SEQUENCE_LENGTH, default to the model maximum,
- HF_NUM_CORES, default to all cores,
- HF_AUTO_CAST_TYPE, default to config.torch_dtype.