### PR TITLE
[AMI] Updates base ami to new id 

### DIFF
--- a/infrastructure/ami/hcl2-files/variables.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/variables.pkr.hcl
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "source_ami" {
-  default     = "ami-0fbea04d7389bcd4e" 
+  default     = "ami-0da38db779978a5f7" 
   description = "Base Image"
   type        = string
   /*


### PR DESCRIPTION
# What does this PR do?

Updates BASE AMI to `ami-0da38db779978a5f7` which is `Deep Learning AMI Neuron PyTorch 1.13 (Ubuntu 20.04) 20240214`