### PR TITLE
fixing format in getting-started.ipynb

### DIFF
--- a/notebooks/sentence-transformers/getting-started.ipynb
+++ b/notebooks/sentence-transformers/getting-started.ipynb
@@ -35,8 +35,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we will use the `NeuronModelForSentenceTransformers`, which can convert any Sntence Transformers model to a format compatible with AWS Inferentia2 or load already converted models. 
-    When exporting models with the `NeuronModelForSentenceTransformers` you need to set `export=True` and define the input shape and batch size. The input shape is defined by the `sequence_length` and the batch size by `batch_size`. "
+    "Here we will use the `NeuronModelForSentenceTransformers`, which can convert any Sntence Transformers model to a format compatible with AWS Inferentia2 or load already converted models. \n When exporting models with the `NeuronModelForSentenceTransformers` you need to set `export=True` and define the input shape and batch size. The input shape is defined by the `sequence_length` and the batch size by `batch_size`. "
    ]
   },
   {


### PR DESCRIPTION
Something about the carriage return broke things.  This makes the notebook viewable in github.




## Before submitting
- [ x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
