### PR TITLE
Do not use deprecated list_files_info

### DIFF
--- a/tests/generation/test_hub.py
+++ b/tests/generation/test_hub.py
@@ -45,8 +45,7 @@ def _test_push_to_hub(model, model_path, repo_id, ignore_patterns=[]):
     model.push_to_hub(model_path, repo_id, use_auth_token=TOKEN, endpoint=ENDPOINT_STAGING)
     api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
     try:
-        hub_files_info = api.list_files_info(repo_id)
-        hub_files_path = [info.rfilename for info in hub_files_info]
+        hub_files_path = api.list_repo_files(repo_id)
         for path, _, files in os.walk(model_path):
             for name in files:
                 local_file_path = os.path.join(path, name)


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2156.

`list_files_info` is deprecated in `huggingface_hub`'s package since release 0.19 and will be removed in next one (0.23). Better to use `list_repo_files` in your case here :) cc @mfuntowicz 