### PR TITLE
Add setup runtime step for K8S

### DIFF
--- a/.github/workflows/test_inf2.yml
+++ b/.github/workflows/test_inf2.yml
@@ -31,10 +31,8 @@ jobs:
           EOF
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          sudo apt-get install aws-neuronx-tools=2.17.0.0 aws-neuronx-oci-hook=2.2.45.0 aws-neuronx-runtime-lib=2.20.11.0-b7d33e68b aws-neuronx-collectives=2.20.11.0-c101c322e  -y
           export PATH=/opt/aws/neuron/bin:$PATH
-      - name: Check AMI
-        run: dpkg -l | grep neuron
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install python dependencies

--- a/.github/workflows/test_inf2.yml
+++ b/.github/workflows/test_inf2.yml
@@ -23,6 +23,16 @@ jobs:
     env:
       AWS_REGION: us-east-1
     steps:
+      - name: Install Neuron runtime
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Check AMI
         run: dpkg -l | grep neuron
       - name: Checkout

--- a/.github/workflows/test_inf2_export.yml
+++ b/.github/workflows/test_inf2_export.yml
@@ -31,10 +31,8 @@ jobs:
           EOF
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          sudo apt-get install aws-neuronx-tools=2.17.0.0 aws-neuronx-oci-hook=2.2.45.0 aws-neuronx-runtime-lib=2.20.11.0-b7d33e68b aws-neuronx-collectives=2.20.11.0-c101c322e  -y
           export PATH=/opt/aws/neuron/bin:$PATH
-      - name: Check AMI
-        run: dpkg -l | grep neuron
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install python dependencies

--- a/.github/workflows/test_inf2_export.yml
+++ b/.github/workflows/test_inf2_export.yml
@@ -23,6 +23,16 @@ jobs:
     env:
       AWS_REGION: us-east-1
     steps:
+      - name: Install Neuron runtime
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Check AMI
         run: dpkg -l | grep neuron
       - name: Checkout

--- a/.github/workflows/test_inf2_full_export.yml
+++ b/.github/workflows/test_inf2_full_export.yml
@@ -21,6 +21,16 @@ jobs:
     env:
       AWS_REGION: us-east-1
     steps:
+      - name: Install Neuron runtime
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Check AMI
         run: dpkg -l | grep neuron
       - name: Checkout

--- a/.github/workflows/test_inf2_full_export.yml
+++ b/.github/workflows/test_inf2_full_export.yml
@@ -29,10 +29,8 @@ jobs:
           EOF
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          sudo apt-get install aws-neuronx-tools=2.17.0.0 aws-neuronx-oci-hook=2.2.45.0 aws-neuronx-runtime-lib=2.20.11.0-b7d33e68b aws-neuronx-collectives=2.20.11.0-c101c322e  -y
           export PATH=/opt/aws/neuron/bin:$PATH
-      - name: Check AMI
-        run: dpkg -l | grep neuron
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install python dependencies

--- a/.github/workflows/test_inf2_inference.yml
+++ b/.github/workflows/test_inf2_inference.yml
@@ -31,10 +31,8 @@ jobs:
           EOF
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          sudo apt-get install aws-neuronx-tools=2.17.0.0 aws-neuronx-oci-hook=2.2.45.0 aws-neuronx-runtime-lib=2.20.11.0-b7d33e68b aws-neuronx-collectives=2.20.11.0-c101c322e  -y
           export PATH=/opt/aws/neuron/bin:$PATH
-      - name: Check AMI
-        run: dpkg -l | grep neuron
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install python dependencies

--- a/.github/workflows/test_inf2_inference.yml
+++ b/.github/workflows/test_inf2_inference.yml
@@ -23,6 +23,16 @@ jobs:
     env:
       AWS_REGION: us-east-1
     steps:
+      - name: Install Neuron runtime
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Check AMI
         run: dpkg -l | grep neuron
       - name: Checkout

--- a/.github/workflows/test_inf2_tgi.yml
+++ b/.github/workflows/test_inf2_tgi.yml
@@ -33,7 +33,7 @@ jobs:
           EOF
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          sudo apt-get install aws-neuronx-tools=2.17.0.0 aws-neuronx-oci-hook=2.2.45.0 aws-neuronx-runtime-lib=2.20.11.0-b7d33e68b aws-neuronx-collectives=2.20.11.0-c101c322e  -y
           export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test_inf2_tgi.yml
+++ b/.github/workflows/test_inf2_tgi.yml
@@ -25,6 +25,16 @@ jobs:
     env:
       AWS_REGION: us-east-1
     steps:
+      - name: Install Neuron runtime
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools aws-neuronx-oci-hook aws-neuronx-runtime-lib aws-neuronx-collectives -y
+          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install python and create venv


### PR DESCRIPTION
# What does this PR do?

After moving the Inferentia2 builder to Kubernetes, only the AWS Neuron dkms driver is installed on each builder.
This adds an installation step to add other tools.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
