### PR TITLE
Disable weights / neff separation of SDXL's UNET for neuron sdk 2.18

### DIFF
--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -342,6 +342,14 @@ def export_models(
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
+
+            # TODO: Remove after the weights/neff separation compilation of sdxl is patched by a neuron sdk release: https://github.com/aws-neuron/aws-neuron-sdk/issues/859
+            if not inline_weights_to_neff and getattr(sub_neuron_config, "is_sdxl", False):
+                logger.warning(
+                    "The compilation of SDXL's unet with the weights/neff separation is broken since the Neuron sdk 2.18 release. `inline_weights_to_neff` will be set to True and the caching will be disabled. If you still want to separate the neff and weights, please downgrade your Neuron setup to the 2.17.1 release."
+                )
+                inline_weights_to_neff = True
+
             start_time = time.time()
             neuron_inputs, neuron_outputs = export(
                 model=submodel,

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -272,35 +272,35 @@ def test_stable_diffusion_cache(cache_repos):
     assert len(get_local_cached_files(cache_path, ".neuron")) == 0
 
 
-# TODO: Disable the test due to https://github.com/aws-neuron/aws-neuron-sdk/issues/859
-# @is_inferentia_test
-# @requires_neuronx
-# def test_stable_diffusion_xl_cache(cache_repos):
-#     cache_path, cache_repo_id = cache_repos
-#     model_id = "echarlaix/tiny-random-stable-diffusion-xl"
-#     # Export the model a first time to populate the local cache
-#     model = export_stable_diffusion_xl_model(model_id)
-#     check_stable_diffusion_inference(model)
-#     # check registry
-#     check_traced_cache_entry(cache_path)
-#     # Synchronize the hub cache with the local cache
-#     synchronize_hub_cache(cache_repo_id=cache_repo_id)
-#     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
-#     # Verify we are able to fetch the cached entry for the model
-#     model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
-#     assert len(model_entries) == 1
-#     # Clear the local cache
-#     for root, dirs, files in os.walk(cache_path):
-#         for f in files:
-#             os.unlink(os.path.join(root, f))
-#         for d in dirs:
-#             shutil.rmtree(os.path.join(root, d))
-#     assert local_cache_size(cache_path) == 0
-#     # Export the model again: the compilation artifacts should be fetched from the Hub
-#     model = export_stable_diffusion_xl_model(model_id)
-#     check_stable_diffusion_inference(model)
-#     # Verify the local cache directory has not been populated
-#     assert len(get_local_cached_files(cache_path, ".neuron")) == 0
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.skip("Disable the test due to https://github.com/aws-neuron/aws-neuron-sdk/issues/859")
+def test_stable_diffusion_xl_cache(cache_repos):
+    cache_path, cache_repo_id = cache_repos
+    model_id = "echarlaix/tiny-random-stable-diffusion-xl"
+    # Export the model a first time to populate the local cache
+    model = export_stable_diffusion_xl_model(model_id)
+    check_stable_diffusion_inference(model)
+    # check registry
+    check_traced_cache_entry(cache_path)
+    # Synchronize the hub cache with the local cache
+    synchronize_hub_cache(cache_repo_id=cache_repo_id)
+    assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
+    # Verify we are able to fetch the cached entry for the model
+    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+    assert len(model_entries) == 1
+    # Clear the local cache
+    for root, dirs, files in os.walk(cache_path):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))
+    assert local_cache_size(cache_path) == 0
+    # Export the model again: the compilation artifacts should be fetched from the Hub
+    model = export_stable_diffusion_xl_model(model_id)
+    check_stable_diffusion_inference(model)
+    # Verify the local cache directory has not been populated
+    assert len(get_local_cached_files(cache_path, ".neuron")) == 0
 
 
 @is_inferentia_test

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -272,34 +272,35 @@ def test_stable_diffusion_cache(cache_repos):
     assert len(get_local_cached_files(cache_path, ".neuron")) == 0
 
 
-@is_inferentia_test
-@requires_neuronx
-def test_stable_diffusion_xl_cache(cache_repos):
-    cache_path, cache_repo_id = cache_repos
-    model_id = "echarlaix/tiny-random-stable-diffusion-xl"
-    # Export the model a first time to populate the local cache
-    model = export_stable_diffusion_xl_model(model_id)
-    check_stable_diffusion_inference(model)
-    # check registry
-    check_traced_cache_entry(cache_path)
-    # Synchronize the hub cache with the local cache
-    synchronize_hub_cache(cache_repo_id=cache_repo_id)
-    assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
-    # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
-    assert len(model_entries) == 1
-    # Clear the local cache
-    for root, dirs, files in os.walk(cache_path):
-        for f in files:
-            os.unlink(os.path.join(root, f))
-        for d in dirs:
-            shutil.rmtree(os.path.join(root, d))
-    assert local_cache_size(cache_path) == 0
-    # Export the model again: the compilation artifacts should be fetched from the Hub
-    model = export_stable_diffusion_xl_model(model_id)
-    check_stable_diffusion_inference(model)
-    # Verify the local cache directory has not been populated
-    assert len(get_local_cached_files(cache_path, ".neuron")) == 0
+# TODO: Disable the test due to https://github.com/aws-neuron/aws-neuron-sdk/issues/859
+# @is_inferentia_test
+# @requires_neuronx
+# def test_stable_diffusion_xl_cache(cache_repos):
+#     cache_path, cache_repo_id = cache_repos
+#     model_id = "echarlaix/tiny-random-stable-diffusion-xl"
+#     # Export the model a first time to populate the local cache
+#     model = export_stable_diffusion_xl_model(model_id)
+#     check_stable_diffusion_inference(model)
+#     # check registry
+#     check_traced_cache_entry(cache_path)
+#     # Synchronize the hub cache with the local cache
+#     synchronize_hub_cache(cache_repo_id=cache_repo_id)
+#     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
+#     # Verify we are able to fetch the cached entry for the model
+#     model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+#     assert len(model_entries) == 1
+#     # Clear the local cache
+#     for root, dirs, files in os.walk(cache_path):
+#         for f in files:
+#             os.unlink(os.path.join(root, f))
+#         for d in dirs:
+#             shutil.rmtree(os.path.join(root, d))
+#     assert local_cache_size(cache_path) == 0
+#     # Export the model again: the compilation artifacts should be fetched from the Hub
+#     model = export_stable_diffusion_xl_model(model_id)
+#     check_stable_diffusion_inference(model)
+#     # Verify the local cache directory has not been populated
+#     assert len(get_local_cached_files(cache_path, ".neuron")) == 0
 
 
 @is_inferentia_test


### PR DESCRIPTION
# What does this PR do?

Issue reported here: https://github.com/aws-neuron/aws-neuron-sdk/issues/859

Force `inline_weights_to_neff=True` for sdxl's unet for now to be able to bump optimum-neuron to neuron SDK 2.18, to remove after it's patched by the Annapurna team.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
