### PR TITLE
Allow download subfolder for caching models with subfolder

### DIFF
--- a/optimum/neuron/accelerate/utils/dataclasses.py
+++ b/optimum/neuron/accelerate/utils/dataclasses.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 import torch
 
 from ...distributed import ParallelizersManager
-from ...utils import is_torch_xla_available
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
# What does this PR do?

The stable diffusion cache actually doesn't work when they have subfolder structure. This PR fixes this.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
