### PR TITLE
Do not split decoder checkpoint files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rwildcard=$(wildcard $1) $(foreach d,$1,$(call rwildcard,$(addsuffix /$(notdir $
 
 VERSION := $(shell gawk 'match($$0, /__version__ = "(.*)"/, a) {print a[1]}' optimum/neuron/version.py)
 
-PACKAGE_DIST = dist/optimum-neuron-$(VERSION).tar.gz
+PACKAGE_DIST = dist/optimum_neuron-$(VERSION).tar.gz
 PACKAGE_WHEEL = dist/optimum_neuron-$(VERSION)-py3-none-any.whl
 PACKAGE_PYTHON_FILES = $(call rwildcard, optimum/*.py)
 PACKAGE_FILES = $(PACKAGE_PYTHON_FILES)  \

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -839,7 +839,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
             raise ValueError(
                 f"The specified batch_size ({batch_size}) exceeds the model static batch size ({self.batch_size})"
             )
-        elif batch_size < self.batch_size:
+        elif batch_size < self.batch_size and not self.continuous_batching:
             logger.warning("Inputs will be padded to match the model static batch size. This will increase latency.")
             padding_shape = [self.batch_size - batch_size, sequence_length]
             padding = torch.full(padding_shape, fill_value=self.config.eos_token_id, dtype=torch.int64)

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -42,7 +42,6 @@ NEURON_MAJOR_LINE = re.compile(r"^\s*(\d+)\s+neuron\s*$")
 
 if is_transformers_neuronx_available():
     from transformers_neuronx.config import ContinuousBatchingConfig, NeuronConfig
-    from transformers_neuronx.module import save_split
 
 
 if TYPE_CHECKING:
@@ -249,9 +248,7 @@ class NeuronDecoderModel(OptimizedModel):
 
         # Save the model checkpoint in a temporary directory
         checkpoint_dir = TemporaryDirectory()
-        model.save_pretrained(
-            checkpoint_dir.name, save_function=save_split, safe_serialization=False, max_shard_size="10000GB"
-        )
+        model.save_pretrained(checkpoint_dir.name)
         return checkpoint_dir
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+[build-system]
+requires = ["setuptools>=69.5.1"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 119

--- a/tests/generation/test_tnx_llama.py
+++ b/tests/generation/test_tnx_llama.py
@@ -24,7 +24,7 @@ from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neur
 @requires_neuronx
 def test_generation_llama_padded_inputs():
     model_id = "NousResearch/Llama-2-7b-chat-hf"
-    model_kwargs = {"batch_size": 2, "sequence_length": 2048, "auto_cast_type": "f16", "num_cores": 2}
+    model_kwargs = {"batch_size": 4, "sequence_length": 4096, "auto_cast_type": "f16", "num_cores": 2}
     model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, **model_kwargs)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     prompt = "One of my fondest memory is of my grandmother making homemade bread"

--- a/text-generation-inference/Dockerfile
+++ b/text-generation-inference/Dockerfile
@@ -112,7 +112,7 @@ RUN pip3 install \
     hf_transfer huggingface_hub
 
 # Install optimum-neuron
-COPY dist/optimum-neuron-${VERSION}.tar.gz optimum-neuron.tar.gz
+COPY dist/optimum_neuron-${VERSION}.tar.gz optimum-neuron.tar.gz
 RUN pip3 install optimum-neuron.tar.gz
 
 # TGI base env
@@ -126,7 +126,7 @@ COPY --from=builder /usr/src/target/release/text-generation-router /usr/local/bi
 COPY --from=builder /usr/src/target/release/text-generation-launcher /usr/local/bin/text-generation-launcher
 # Install python server
 COPY --from=pyserver /pyserver/build/dist dist
-RUN pip install dist/text-generation-server*.tar.gz
+RUN pip install dist/text_generation_server*.tar.gz
 
 # AWS Sagemaker compatible image
 FROM neuron as sagemaker


### PR DESCRIPTION
# What does this PR do?

[Neuron 2.18](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/index.html#id2) introduced support for loading weights in SafeTensors format. Due to the nature of SafeTensors, it is no longer essential to split model weights to conserve memory. Weights can be loaded directly from .safetensors checkpoints and then loaded to Neuron cores directly.

Implements #565 

Edit:
- I modified a bit one of the tests to use a cached model and save compilation time,
- I had to fix the docker build broken by a recent release of setuptools

