### PR TITLE
Save checkpoint weights in safetensors format when exporting decoder models

### DIFF
--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -42,7 +42,6 @@ NEURON_MAJOR_LINE = re.compile(r"^\s*(\d+)\s+neuron\s*$")
 
 if is_transformers_neuronx_available():
     from transformers_neuronx.config import ContinuousBatchingConfig, NeuronConfig
-    from transformers_neuronx.module import save_split
 
 
 if TYPE_CHECKING:
@@ -250,7 +249,7 @@ class NeuronDecoderModel(OptimizedModel):
         # Save the model checkpoint in a temporary directory
         checkpoint_dir = TemporaryDirectory()
         model.save_pretrained(
-            checkpoint_dir.name, save_function=save_split, safe_serialization=False, max_shard_size="10000GB"
+            checkpoint_dir.name, max_shard_size="10000GB"
         )
         return checkpoint_dir
 


### PR DESCRIPTION
# What does this PR do?

This PR changes model export to save model weights as .safetensors, rather than the Transformers-NeuronX split model format. Model loading is unchanged, as the [from_pretrained()](https://github.com/huggingface/optimum-neuron/blob/f9360898130d82b01902419e26e1d19f66e192d5/optimum/neuron/modeling_decoder.py#L190) function in Transformers-NeuronX supports .safetensors natively in Neuron 2.18. 

This fixes issue #565 

Submitting this as a draft, because the changes are untested. I haven't been able to install the modified version of optimum-neuron from source.