### PR TITLE
Add support for Mixtral

### DIFF
--- a/docs/source/package_reference/supported_models.mdx
+++ b/docs/source/package_reference/supported_models.mdx
@@ -34,6 +34,7 @@ limitations under the License.
 | GPT2                   | text-generation                                                                                                                               |
 | Llama, Llama 2         | text-generation                                                                                                                               |
 | Mistral                | text-generation                                                                                                                               |
+| Mixtral                | text-generation                                                                                                                               |
 | MobileBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | MPNet                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | OPT                    | text-generation                                                                                                                               |

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -564,3 +564,9 @@ class T5DecoderNeuronConfig(TextSeq2SeqNeuronConfig):
 class MistralNeuronConfig(TextNeuronDecoderConfig):
     NEURONX_CLASS = "mistral.model.MistralForSampling"
     CONTINUOUS_BATCHING = True
+
+
+@register_in_tasks_manager("mixtral", "text-generation")
+class MixtralNeuronConfig(TextNeuronDecoderConfig):
+    NEURONX_CLASS = "mixtral.model.MixtralForSampling"
+    CONTINUOUS_BATCHING = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ ENCODER_ARCHITECTURES = [
     "xlm",
     "roberta",
 ]
-DECODER_ARCHITECTURES = ["gpt2", "llama"]
+DECODER_ARCHITECTURES = ["gpt2", "llama", "mixtral"]
 DIFFUSER_ARCHITECTURES = ["stable-diffusion", "stable-diffusion-xl"]
 
 INFERENTIA_MODEL_NAMES = {
@@ -46,6 +46,7 @@ INFERENTIA_MODEL_NAMES = {
     "flaubert": "flaubert/flaubert_small_cased",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "llama": "dacorvo/tiny-random-llama",
+    "mixtral": "dacorvo/Mixtral-tiny",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",

--- a/tests/generation/conftest.py
+++ b/tests/generation/conftest.py
@@ -22,12 +22,13 @@ from optimum.neuron.utils.testing_utils import requires_neuronx
 from optimum.utils.testing_utils import USER
 
 
-DECODER_MODEL_ARCHITECTURES = ["bloom", "gpt2", "llama", "mistral", "opt"]
+DECODER_MODEL_ARCHITECTURES = ["bloom", "gpt2", "llama", "mistral", "mixtral", "opt"]
 DECODER_MODEL_NAMES = {
     "bloom": "hf-internal-testing/tiny-random-BloomForCausalLM",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "llama": "dacorvo/tiny-random-llama",
     "mistral": "dacorvo/tiny-random-MistralForCausalLM",
+    "mixtral": "dacorvo/Mixtral-tiny",
     "opt": "hf-internal-testing/tiny-random-OPTForCausalLM",
 }
 TRN_DECODER_MODEL_ARCHITECTURES = ["bloom", "llama", "opt"]


### PR DESCRIPTION
# What does this PR do?

Beta support for Mixtral has been added to AWS Neuron SDK 2.18. This enables this model type for `NeuronModelForCausalLM` and adds the corresponding unit tests.
