### PR TITLE
Use AWS 2.18.0 AMI as base

### DIFF
--- a/infrastructure/ami/hcl2-files/variables.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/variables.pkr.hcl
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "source_ami" {
-  default     = "ami-0da38db779978a5f7" 
+  default     = "ami-0274e546d67626305"
   description = "Base Image"
   type        = string
   /*


### PR DESCRIPTION
# What does this PR do?

Unfortunately, the 0.0.21 HFDLAMI was generated from an outdated AWS DLAMI, leading to system packages out-of-sync with python packages. This bumps the base AWS DLAMI version to address this and allow the regeneration of a working 0.0.21 HFDLAMI.