### PR TITLE
eos_token_id can be a list in configs

### DIFF
--- a/optimum/neuron/generation/token_selector.py
+++ b/optimum/neuron/generation/token_selector.py
@@ -136,7 +136,7 @@ class TokenSelector:
         # The generation requires special tokens
         eos_token_ids = eos_token_id if isinstance(eos_token_id, list) else [eos_token_id]
         if generation_config.pad_token_id is None:
-            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_ids[0]} for open-end generation.")
+            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_ids[0]} for open-ended generation.")
             generation_config.pad_token_id = eos_token_ids[0]
 
         generation_mode = model._get_generation_mode(generation_config, None)

--- a/optimum/neuron/generation/token_selector.py
+++ b/optimum/neuron/generation/token_selector.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import torch
 from transformers.generation import (
@@ -41,7 +41,7 @@ class TokenSelector:
         mode: GenerationMode,
         logits_processor: LogitsProcessorList,
         stopping_criteria: StoppingCriteriaList,
-        eos_token_id: int,
+        eos_token_ids: List[int],
         pad_token_id: int,
         logits_warper: Optional[LogitsProcessorList] = None,
         seed: Optional[int] = 0,
@@ -49,7 +49,7 @@ class TokenSelector:
         self.mode = mode
         self.logits_processor = logits_processor
         self.stopping_criteria = stopping_criteria
-        self.eos_token_id = eos_token_id
+        self.eos_token_ids = eos_token_ids
         self.pad_token_id = pad_token_id
         self.logits_warper = logits_warper
         self.generator = torch.Generator()
@@ -130,13 +130,14 @@ class TokenSelector:
             stopping_criteria = StoppingCriteriaList()
         stopping_criteria = model._get_stopping_criteria(generation_config, stopping_criteria=stopping_criteria)
 
-        # The generation requires special tokens
-        eos_token_id = generation_config.eos_token_id
         # This is not supposed to happen for any of the models we support
-        assert eos_token_id is not None and not isinstance(eos_token_id, list)
+        eos_token_id = generation_config.eos_token_id
+        assert eos_token_id is not None
+        # The generation requires special tokens
+        eos_token_ids = eos_token_id if isinstance(eos_token_id, list) else [eos_token_id]
         if generation_config.pad_token_id is None:
-            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_id} for open-end generation.")
-            generation_config.pad_token_id = eos_token_id
+            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_ids[0]} for open-end generation.")
+            generation_config.pad_token_id = eos_token_ids[0]
 
         generation_mode = model._get_generation_mode(generation_config, None)
         if generation_mode not in [GenerationMode.GREEDY_SEARCH, GenerationMode.SAMPLE]:
@@ -151,7 +152,7 @@ class TokenSelector:
             logits_processor=logits_processor,
             stopping_criteria=stopping_criteria,
             logits_warper=logits_warper,
-            eos_token_id=eos_token_id,
+            eos_token_ids=eos_token_ids,
             pad_token_id=generation_config.pad_token_id,
             seed=seed,
         )

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -283,8 +283,13 @@ class NeuronDecoderModel(OptimizedModel):
             batch_size = 1
         # If the sequence_length was not specified, deduce it from the model configuration
         if sequence_length is None:
-            # Note: for older models, max_position_embeddings is an alias for n_positions
-            sequence_length = config.max_position_embeddings
+            if hasattr(config, "n_positions"):
+                sequence_length = config.n_positions
+            elif hasattr(config, "max_position_embeddings"):
+                sequence_length = config.max_position_embeddings
+            else:
+                # Use transformers-neuronx default
+                sequence_length = 2048
         if num_cores is None:
             # Use all available cores
             num_cores = get_available_cores()

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -362,7 +362,7 @@ class NeuronDecoderModel(OptimizedModel):
         # Try to reload the generation config (if any)
         generation_config = None
         try:
-            generation_config = GenerationConfig.from_pretrained(model_id)
+            generation_config = GenerationConfig.from_pretrained(model_id, revision=revision)
         except OSError:
             pass
 
@@ -419,7 +419,7 @@ class NeuronDecoderModel(OptimizedModel):
         # Try to reload the generation config (if any)
         generation_config = None
         try:
-            generation_config = GenerationConfig.from_pretrained(model_id)
+            generation_config = GenerationConfig.from_pretrained(model_id, revision=revision)
         except OSError:
             pass
 

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -255,7 +255,10 @@ def pipeline(
             batch_size = model.config.neuron[attr]
     if batch_size > 1 and tokenizer is not None and tokenizer.pad_token_id is None:
         # The pipeline needs a pad token to be able to batch
-        tokenizer.pad_token_id = model.config.eos_token_id
+        if isinstance(model.config.eos_token_id, list):
+            tokenizer.pad_token_id = model.config.eos_token_id[0]
+        else:
+            tokenizer.pad_token_id = model.config.eos_token_id
 
     return transformers_pipeline(
         task,

--- a/tests/generation/conftest.py
+++ b/tests/generation/conftest.py
@@ -72,9 +72,7 @@ def export_seq2seq_model_class(request):
 @pytest.fixture(scope="session")
 @requires_neuronx
 def neuron_decoder_path(export_decoder_id):
-    model = NeuronModelForCausalLM.from_pretrained(
-        export_decoder_id, export=True, batch_size=2, sequence_length=100, num_cores=2
-    )
+    model = NeuronModelForCausalLM.from_pretrained(export_decoder_id, export=True, batch_size=2, num_cores=2)
     model_dir = TemporaryDirectory()
     model_path = model_dir.name
     model.save_pretrained(model_path)

--- a/tests/generation/test_tnx_llama.py
+++ b/tests/generation/test_tnx_llama.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
+import pytest
 import torch
 from transformers import AutoTokenizer
 
@@ -20,13 +23,19 @@ from optimum.neuron import NeuronModelForCausalLM
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
-@is_inferentia_test
-@requires_neuronx
-def test_generation_llama_padded_inputs():
+@pytest.fixture(scope="module")
+def neuron_model_config():
     model_id = "NousResearch/Llama-2-7b-chat-hf"
     model_kwargs = {"batch_size": 4, "sequence_length": 4096, "auto_cast_type": "f16", "num_cores": 2}
     model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, **model_kwargs)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
+    yield (model, tokenizer)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_generation_llama_padded_inputs(neuron_model_config):
+    model, tokenizer = neuron_model_config
     prompt = "One of my fondest memory is of my grandmother making homemade bread"
     first_input = tokenizer(prompt)
     first_ids = first_input["input_ids"]
@@ -43,3 +52,25 @@ def test_generation_llama_padded_inputs():
         )
         # Verify we did not generate any unknown token
         assert torch.all(outputs[:, -1] != 0)
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_decoder_generation_multiple_eos_token_ids(neuron_model_config):
+    model, tokenizer = neuron_model_config
+    prompt = "Name three fruits:"
+    tokens = tokenizer(prompt, return_tensors="pt")
+    generation_config = copy.deepcopy(model.generation_config)
+    if not isinstance(generation_config, list):
+        generation_config.eos_token_id = [generation_config.eos_token_id]
+    generation_config.max_new_tokens = model.max_length - tokens["input_ids"].shape[-1]
+    # Generate and verify we stopped on an eos_token_id, and not on max_new_tokens
+    outputs = model.generate(**tokens, do_sample=True, generation_config=generation_config)
+    assert outputs.shape[-1] < model.max_length
+    assert outputs[0, -1].numpy() in generation_config.eos_token_id
+    # Extract the last non-eos generated token and use it as a fake eos_token_id
+    fake_eos_token_id = outputs[0, -2]
+    generation_config.eos_token_id.append(fake_eos_token_id)
+    # Generate againg an verify we stopped on that id
+    outputs = model.generate(**tokens, do_sample=True, generation_config=generation_config)
+    assert outputs[0, -1] == fake_eos_token_id

--- a/text-generation-inference/tests/integration/test_generate.py
+++ b/text-generation-inference/tests/integration/test_generate.py
@@ -1,4 +1,3 @@
-
 import Levenshtein
 import pytest
 


### PR DESCRIPTION
# What does this PR do?

llama3 instruct models have a list of eos_token_ids instead of a single token id. Before this change, this triggered an assertion in the optimum-neuron code during generation.