### PR TITLE
Deprecate resume_download

### DIFF
--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -1123,7 +1123,7 @@ def from_pretrained_for_mp(
     kwargs.pop("state_dict", None)
     kwargs.pop("from_tf", False)
     kwargs.pop("from_flax", False)
-    resume_download = kwargs.pop("resume_download", False)
+    resume_download = kwargs.pop("resume_download", None)
     proxies = kwargs.pop("proxies", None)
     kwargs.pop("output_loading_info", False)
     kwargs.pop("use_auth_token", None)

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -261,7 +261,7 @@ def download_checkpoints_in_cache(
     kwargs.pop("state_dict", None)
     from_tf = kwargs.pop("from_tf", False)
     from_flax = kwargs.pop("from_flax", False)
-    resume_download = kwargs.pop("resume_download", False)
+    resume_download = kwargs.pop("resume_download", None)
     proxies = kwargs.pop("proxies", None)
     kwargs.pop("output_loading_info", False)
     kwargs.pop("use_auth_token", None)


### PR DESCRIPTION
Same as https://github.com/huggingface/transformers/pull/30620 and https://github.com/huggingface/diffusers/pull/7843.

With `0.23.0` release, it's best to set the default value of `resume_download` to `None` instead of `False` which will prevent from having a FutureWarning by default.