### PR TITLE
Fix excessive CPU memory consumption on TGI startup

### DIFF
--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -564,7 +564,9 @@ class NeuronGenerator(Generator):
         if neuron_config is None:
             export_kwargs = get_export_kwargs_from_env()
             logger.info(f"Exporting model to neuron with config: {export_kwargs}.")
-            model = NeuronModelForCausalLM.from_pretrained(model_id, revision=revision, export=True, **export_kwargs)
+            model = NeuronModelForCausalLM.from_pretrained(
+                model_id, revision=revision, low_cpu_mem_usage=True, export=True, **export_kwargs
+            )
         else:
             logger.info("Loading model on neuron devices (this can take a few minutes).")
             model = NeuronModelForCausalLM.from_pretrained(model_id, revision=revision)


### PR DESCRIPTION
# What does this PR do?

When launching a TGI instance with a non-neuron model as parameter, the model needs to be exported from cached neuron artifacts during the container startup.

Before this change, the export was done without minimizing the CPU memory, which made it impossible to use this kind of "on-the-fly" export on the smaller `ml.inf2.xlarge` instances.