### PR TITLE
Fix llama test

### DIFF
--- a/tests/generation/test_tnx_llama.py
+++ b/tests/generation/test_tnx_llama.py
@@ -25,7 +25,7 @@ from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neur
 
 @pytest.fixture(scope="module")
 def neuron_model_config():
-    model_id = "NousResearch/Meta-Llama-3-8B-Instruct"
+    model_id = "HuggingFaceTB/cosmo-1b"
     model_kwargs = {"batch_size": 4, "sequence_length": 4096, "auto_cast_type": "f16", "num_cores": 2}
     model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, **model_kwargs)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -61,7 +61,7 @@ def test_decoder_generation_multiple_eos_token_ids(neuron_model_config):
     prompt = "Name three fruits:"
     tokens = tokenizer(prompt, return_tensors="pt")
     generation_config = copy.deepcopy(model.generation_config)
-    if not isinstance(generation_config, list):
+    if not isinstance(generation_config.eos_token_id, list):
         generation_config.eos_token_id = [generation_config.eos_token_id]
     generation_config.max_new_tokens = model.max_length - tokens["input_ids"].shape[-1]
     # Generate and verify we stopped on an eos_token_id, and not on max_new_tokens
@@ -71,6 +71,6 @@ def test_decoder_generation_multiple_eos_token_ids(neuron_model_config):
     # Extract the last non-eos generated token and use it as a fake eos_token_id
     fake_eos_token_id = outputs[0, -2]
     generation_config.eos_token_id.append(fake_eos_token_id)
-    # Generate againg an verify we stopped on that id
+    # Generate again an verify we stopped on that id
     outputs = model.generate(**tokens, do_sample=True, generation_config=generation_config)
     assert outputs[0, -1] == fake_eos_token_id

--- a/text-generation-inference/tgi_env.py
+++ b/text-generation-inference/tgi_env.py
@@ -184,8 +184,6 @@ def main():
     work properly
     :return:
     """
-    logging.basicConfig(level=logging.DEBUG, force=True)
-
     args = parse_cmdline_and_set_env()
 
     for env_var in env_vars:


### PR DESCRIPTION
# What does this PR do?

There is an error in one of the generation tests that was revealed only by using a model that already uses multiple eos token ids. This fixes the test, and also switches to a smaller model that is already cached for faster CI.

Unrelated, this pull-request also reduces the verbosity on TGI startup.