### PR TITLE
Add full path to TGI in benchmark docker-compose.yaml

### DIFF
--- a/benchmark/text-generation-inference/docker-compose.yaml
+++ b/benchmark/text-generation-inference/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   tgi-1:
-    image: neuronx-tgi:latest
+    image: ghcr.io/huggingface/neuronx-tgi:latest
     ports:
       - "8081:8081"
     environment:
@@ -23,7 +23,7 @@ services:
       - "/dev/neuron3"
 
   tgi-2:
-    image: neuronx-tgi:latest
+    image: ghcr.io/huggingface/neuronx-tgi:latest
     ports:
       - "8082:8082"
     environment:
@@ -44,7 +44,7 @@ services:
       - "/dev/neuron7"
 
   tgi-3:
-    image: neuronx-tgi:latest
+    image: ghcr.io/huggingface/neuronx-tgi:latest
     ports:
       - "8083:8083"
     environment:


### PR DESCRIPTION
added the full path to neuronx-tgi.  When testing on HF DLAMI, docker said:
```
(aws_neuron_venv_pytorch) ubuntu@ip-512-31-1-343:~/optimum-neuron/benchmark/text-generation-inference$ docker compose --env-file llama-7b/.env up
WARN[0000] /home/ubuntu/optimum-neuron/benchmark/text-generation-inference/docker-compose.yaml: `version` is obsolete
[+] Running 4/4
 ✘ tgi-1 Error                                                                                                                                                                                                                                       0.9s
 ✘ tgi-2 Error                                                                                                                                                                                                                                       0.9s
 ✘ tgi-3 Error                                                                                                                                                                                                                                       0.9s
 ✘ loadbalancer Error                                                                                                                                                                                                                                0.9s
Error response from daemon: pull access denied for neuronx-tgi, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```
However, I didn't need the full path for the loadbalancer (not sure why-- probably docker hub related).

Alternatively, you could change the instructions to have a docker pull command before you run docker compose.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
