### PR TITLE
test(tgi): workaround issue with requests 2.32.0

### DIFF
--- a/text-generation-inference/tests/requirements.txt
+++ b/text-generation-inference/tests/requirements.txt
@@ -14,5 +14,6 @@
 text-generation >= 0.6.0
 pytest >= 7.4.0
 pytest-asyncio >= 0.21.1
+requests < 2.32.0
 docker >= 6.1.3
 Levenshtein


### PR DESCRIPTION
The docker package must be updated to be compatible with the latest requests release. In the meantime we pin requests version.

