### PR TITLE
Bump transformers and optimum version

### DIFF
--- a/optimum/neuron/generation/utils.py
+++ b/optimum/neuron/generation/utils.py
@@ -661,17 +661,9 @@ class NeuronGenerationMixin(GenerationMixin):
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
 
-        if generation_config.pad_token_id is None and generation_config.eos_token_id is not None:
-            if model_kwargs.get("attention_mask", None) is None:
-                logger.warning(
-                    "The attention mask and the pad token id were not set. As a consequence, you may observe "
-                    "unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results."
-                )
-            eos_token_id = generation_config.eos_token_id
-            if isinstance(eos_token_id, list):
-                eos_token_id = eos_token_id[0]
-            logger.warning(f"Setting `pad_token_id` to `eos_token_id`:{eos_token_id} for open-end generation.")
-            generation_config.pad_token_id = eos_token_id
+        accepts_attention_mask = "attention_mask" in set(inspect.signature(self.forward).parameters.keys())
+        requires_attention_mask = "encoder_outputs" not in model_kwargs
+        kwargs_has_attention_mask = model_kwargs.get("attention_mask", None) is not None
 
         # 3. Define model inputs
         # inputs_tensor has to be defined
@@ -700,6 +692,9 @@ class NeuronGenerationMixin(GenerationMixin):
                 inputs_tensor, generation_config.pad_token_id, generation_config.eos_token_id
             )
 
+        device = inputs_tensor.device
+        self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
+
         # decoder-only models should use left-padding for generation
         if not self.config.is_encoder_decoder:
             if (
@@ -725,7 +720,6 @@ class NeuronGenerationMixin(GenerationMixin):
                 model_input_name=model_input_name,
                 model_kwargs=model_kwargs,
                 decoder_start_token_id=generation_config.decoder_start_token_id,
-                bos_token_id=generation_config.bos_token_id,
                 device=inputs_tensor.device,
             )
         else:

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -818,13 +818,20 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
         """
         # The actual generation configuration is a combination of config and parameters
         generation_config = copy.deepcopy(self.generation_config if generation_config is None else generation_config)
+        # Extract tokenizer if any (used only for stop strings)
+        tokenizer = kwargs.pop("tokenizer", None)
         model_kwargs = generation_config.update(**kwargs)  # All unused kwargs must be model kwargs
         # Check model kwargs are actually used by either prepare_inputs_for_generation or forward
         self._validate_model_kwargs(model_kwargs)
 
         # Instantiate a TokenSelector for the specified configuration
         selector = TokenSelector.create(
-            input_ids, generation_config, self, self.max_length, stopping_criteria=stopping_criteria
+            input_ids,
+            generation_config,
+            self,
+            self.max_length,
+            stopping_criteria=stopping_criteria,
+            tokenizer=tokenizer,
         )
 
         # Verify that the inputs are compatible with the model static input dimensions

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers == 4.40.2",
+    "transformers == 4.41.1",
     "accelerate == 0.29.2",
-    "optimum ~= 1.19.1",
+    "optimum ~= 1.20.0",
     "huggingface_hub >= 0.20.1",
     "numpy>=1.22.2, <=1.25.2",
     "protobuf<4",

--- a/tests/generation/test_tnx_llama.py
+++ b/tests/generation/test_tnx_llama.py
@@ -71,3 +71,27 @@ def test_decoder_generation_multiple_eos_token_ids(neuron_model_config):
     # Generate again an verify we stopped on that id
     outputs = model.generate(**tokens, do_sample=True, generation_config=generation_config)
     assert outputs[0, -1] == fake_eos_token_id
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_decoder_generation_stop_strings(neuron_model_config):
+    model, tokenizer = neuron_model_config
+    prompt = "Name three fruits:"
+    tokens = tokenizer(prompt, return_tensors="pt")
+    generation_config = copy.deepcopy(model.generation_config)
+    generation_config.max_new_tokens = model.max_length - tokens["input_ids"].shape[-1]
+    # Generate once
+    outputs = model.generate(**tokens, do_sample=False, generation_config=generation_config)
+    output_string = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
+    # Now create a generation_config with stop_strings corresponding to the beginning of the outputs
+    sos = len(prompt)
+    stop_string = output_string[sos : sos + 10]
+    generation_config.stop_strings = [stop_string]
+    # Generate and verify we stopped on the stop string
+    outputs = model.generate(**tokens, do_sample=False, generation_config=generation_config, tokenizer=tokenizer)
+    new_output_string = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
+    # Verify we stopped on the stop string
+    assert len(new_output_string) < len(output_string)
+    # Verify the stop string is in the generated string (but not necessarily exactly at the end because of tokenization)
+    assert stop_string in output_string

--- a/text-generation-inference/tests/fixtures/service.py
+++ b/text-generation-inference/tests/fixtures/service.py
@@ -14,8 +14,7 @@ import huggingface_hub
 import pytest
 from aiohttp import ClientConnectorError, ClientOSError, ServerDisconnectedError
 from docker.errors import NotFound
-from text_generation import AsyncClient
-from text_generation.types import Response
+from huggingface_hub import AsyncInferenceClient, TextGenerationOutput
 
 
 OPTIMUM_CACHE_REPO_ID = "optimum/neuron-testing-cache"
@@ -30,10 +29,10 @@ logging.basicConfig(
 logger = logging.getLogger(__file__)
 
 
-class TestClient(AsyncClient):
+class TestClient(AsyncInferenceClient):
 
     def __init__(self, service_name: str, base_url: str):
-        super().__init__(base_url)
+        super().__init__(model=base_url)
         self.service_name = service_name
 
 
@@ -51,7 +50,7 @@ class LauncherHandle:
                 raise RuntimeError(f"Service crashed after {i} seconds.")
 
             try:
-                await self.client.generate("test", max_new_tokens=1)
+                await self.client.text_generation("test", max_new_tokens=1)
                 logger.info(f"Service started after {i} seconds")
                 return
             except (ClientConnectorError, ClientOSError, ServerDisconnectedError):
@@ -226,12 +225,15 @@ def generate_load():
             The number of requests
 
     Returns:
-        A list of `text_generation.Response`.
+        A list of `huggingface_hub.TextGenerationOutput`.
     """
 
-    async def generate_load_inner(client: AsyncClient, prompt: str, max_new_tokens: int, n: int) -> List[Response]:
+    async def generate_load_inner(
+        client: AsyncInferenceClient, prompt: str, max_new_tokens: int, n: int
+    ) -> List[TextGenerationOutput]:
         futures = [
-            client.generate(prompt, max_new_tokens=max_new_tokens, decoder_input_details=True) for _ in range(n)
+            client.text_generation(prompt, max_new_tokens=max_new_tokens, details=True, decoder_input_details=True)
+            for _ in range(n)
         ]
 
         return await asyncio.gather(*futures)

--- a/text-generation-inference/tests/integration/test_generate.py
+++ b/text-generation-inference/tests/integration/test_generate.py
@@ -43,15 +43,27 @@ async def test_model_single_request(tgi_service):
         repetition_penalty=1.2,
         max_new_tokens=128,
         seed=42,
-        details=True,
-        decoder_input_details=True,
     )
     sample_expectations = {
         "gpt2": "A lot of researchers have tried to make a broad, intuitive definition of Deep Learning",
         "llama": "Deep Learning is a technique for training artificial neural networks",
         "mistral": "Why is deep learning important?",
     }
-    assert sample_expectations[service_name] in response.generated_text
+    assert sample_expectations[service_name] in response
+
+    # Sampling with stop sequence
+    stop_sequence = sample_expectations[service_name][-5:]
+    response = await tgi_service.client.text_generation(
+        "What is Deep Learning?",
+        do_sample=True,
+        top_k=50,
+        top_p=0.9,
+        repetition_penalty=1.2,
+        max_new_tokens=128,
+        seed=42,
+        stop_sequences=[stop_sequence],
+    )
+    assert response.endswith(stop_sequence)
 
 
 @pytest.mark.asyncio

--- a/text-generation-inference/tests/integration/test_generate.py
+++ b/text-generation-inference/tests/integration/test_generate.py
@@ -16,10 +16,8 @@ async def test_model_single_request(tgi_service):
     service_name = tgi_service.client.service_name
     prompt = "What is Deep Learning?"
     # Greedy bounded without input
-    response = await tgi_service.client.generate(
-        prompt,
-        max_new_tokens=17,
-        decoder_input_details=True,
+    response = await tgi_service.client.text_generation(
+        prompt, max_new_tokens=17, details=True, decoder_input_details=True
     )
     assert response.details.generated_tokens == 17
     greedy_expectations = {
@@ -30,17 +28,14 @@ async def test_model_single_request(tgi_service):
     assert response.generated_text == greedy_expectations[service_name]
 
     # Greedy bounded with input
-    response = await tgi_service.client.generate(
-        "What is Deep Learning?",
-        max_new_tokens=17,
-        return_full_text=True,
-        decoder_input_details=True,
+    response = await tgi_service.client.text_generation(
+        "What is Deep Learning?", max_new_tokens=17, return_full_text=True, details=True, decoder_input_details=True
     )
     assert response.details.generated_tokens == 17
     assert response.generated_text == prompt + greedy_expectations[service_name]
 
     # Sampling
-    response = await tgi_service.client.generate(
+    response = await tgi_service.client.text_generation(
         "What is Deep Learning?",
         do_sample=True,
         top_k=50,
@@ -48,6 +43,7 @@ async def test_model_single_request(tgi_service):
         repetition_penalty=1.2,
         max_new_tokens=128,
         seed=42,
+        details=True,
         decoder_input_details=True,
     )
     sample_expectations = {

--- a/text-generation-inference/tests/integration/test_implicit_env.py
+++ b/text-generation-inference/tests/integration/test_implicit_env.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from text_generation.errors import ValidationError
+from huggingface_hub.errors import ValidationError
 
 
 @pytest.fixture(scope="module", params=["hub-neuron", "hub", "local-neuron"])
@@ -42,20 +42,21 @@ async def test_model_single_request(tgi_service):
     # Just verify that the generation works, and nothing is raised, with several set of params
 
     # No params
-    await tgi_service.client.generate(
+    await tgi_service.client.text_generation(
         "What is Deep Learning?",
     )
 
-    response = await tgi_service.client.generate(
+    response = await tgi_service.client.text_generation(
         "How to cook beans ?",
         max_new_tokens=17,
+        details=True,
         decoder_input_details=True,
     )
     assert response.details.generated_tokens == 17
 
     # check error
     try:
-        await tgi_service.client.generate("What is Deep Learning?", max_new_tokens=170000)
+        await tgi_service.client.text_generation("What is Deep Learning?", max_new_tokens=170000)
     except ValidationError:
         pass
     else:
@@ -65,7 +66,7 @@ async def test_model_single_request(tgi_service):
         )
 
     # Sampling
-    await tgi_service.client.generate(
+    await tgi_service.client.text_generation(
         "What is Deep Learning?",
         do_sample=True,
         top_k=50,
@@ -73,5 +74,4 @@ async def test_model_single_request(tgi_service):
         repetition_penalty=1.2,
         max_new_tokens=128,
         seed=42,
-        decoder_input_details=True,
     )


### PR DESCRIPTION
# What does this PR do?

This bumps `transformers` to `4.41.1` and optimum to `1.20.0`.

This also adds the new `transformers` "stop strings" generation feature to `NeuronModelForCausalLM`, allowing to support the "stop_sequences" parameter in NeuronX TGI.  