### PR TITLE
Add ViT export support and image classification

### DIFF
--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -66,7 +66,7 @@ The following Neuron model classes are available for natural language processing
 ### NeuronModelForCausalLM
 
 [[autodoc]] modeling.NeuronModelForCausalLM
-
+    - forward
 
 ## Computer Vision
 
@@ -74,29 +74,17 @@ The following Neuron model classes are available for computer vision tasks.
 
 ### NeuronModelForImageClassification
 
-
 [[autodoc]] modeling.NeuronModelForImageClassification
 
-
 ### NeuronModelForSemanticSegmentation
-
-
 [[autodoc]] modeling.NeuronModelForSemanticSegmentation
 
-
 ### NeuronModelForObjectDetection
-
-
 [[autodoc]] modeling.NeuronModelForObjectDetection
-
 
 ## Stable Diffusion
 
 The following Neuron model classes are available for stable diffusion tasks.
-
-### NeuronStableDiffusionPipelineBase
-
-[[autodoc]] modeling_diffusion.NeuronStableDiffusionPipelineBase
 
 ### NeuronStableDiffusionPipeline
 

--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -67,7 +67,25 @@ The following Neuron model classes are available for natural language processing
 
 [[autodoc]] modeling.NeuronModelForCausalLM
 
+## Computer Vision
+
+The following Neuron model classes are available for computer vision tasks.
+
+### NeuronModelForImageClassification
+
+[[autodoc]] modeling.NeuronModelForImageClassification
+
+### NeuronModelForSemanticSegmentation
+
+[[autodoc]] modeling.NeuronModelForSemanticSegmentation
+
+### NeuronModelForObjectDetection
+
+[[autodoc]] modeling.NeuronModelForObjectDetection
+
 ## Stable Diffusion
+
+The following Neuron model classes are available for stable diffusion tasks.
 
 ### NeuronStableDiffusionPipelineBase
 

--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -67,21 +67,28 @@ The following Neuron model classes are available for natural language processing
 
 [[autodoc]] modeling.NeuronModelForCausalLM
 
+
 ## Computer Vision
 
 The following Neuron model classes are available for computer vision tasks.
 
 ### NeuronModelForImageClassification
 
+
 [[autodoc]] modeling.NeuronModelForImageClassification
+
 
 ### NeuronModelForSemanticSegmentation
 
+
 [[autodoc]] modeling.NeuronModelForSemanticSegmentation
+
 
 ### NeuronModelForObjectDetection
 
+
 [[autodoc]] modeling.NeuronModelForObjectDetection
+
 
 ## Stable Diffusion
 

--- a/docs/source/package_reference/supported_models.mdx
+++ b/docs/source/package_reference/supported_models.mdx
@@ -18,34 +18,45 @@ limitations under the License.
 
 ## Transformers
 
-| Architecture           | Task                                                                                                                                          |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| ALBERT                 | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| BERT                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| BLOOM                  | text-generation                                                                                                                               |
-| Beit                   | feature-extraction, image-classification                                                                                                      |
-| CamemBERT              | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| ConvBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| DeBERTa (INF2 only)    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| DeBERTa-v2 (INF2 only) | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| DistilBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| ELECTRA                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| ESM                    | feature-extraction, fill-mask, text-classification, token-classification                                                                      |
-| FlauBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| GPT2                   | text-generation                                                                                                                               |
-| Llama, Llama 2, Llama 3         | text-generation                                                                                                                               |
-| Mistral                | text-generation                                                                                                                               |
-| Mixtral                | text-generation                                                                                                                               |
-| MobileBERT             | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| MPNet                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| OPT                    | text-generation                                                                                                                               |
-| Phi                    | feature-extraction, text-classification, token-classification                                                                                 |
-| RoBERTa                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| RoFormer               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| T5                     | text2text-generation                                                                                                                          |
-| XLM                    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
-| ViT                    | feature-extraction, image-classification                                                                                                      |
-| XLM-RoBERTa            | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| Architecture              | Task                                                                                                                                          |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| ALBERT                    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| BERT                      | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| BLOOM                     | text-generation                                                                                                                               |
+| Beit                      | feature-extraction, image-classification                                                                                                      |
+| CamemBERT                 | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| ConvBERT                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| ConvNext                  | feature-extraction, image-classification                                                                                                      |
+| ConvNextV2                | feature-extraction, image-classification                                                                                                      |
+| CvT                       | feature-extraction, image-classification                                                                                                      |
+| DeBERTa (INF2 only)       | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| DeBERTa-v2 (INF2 only)    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| Deit                      | feature-extraction, image-classification                                                                                                      |
+| DistilBERT                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| DonutSwin                 | feature-extraction                                                                                                                            |
+| Dpt                       | feature-extraction                                                                                                                            |
+| ELECTRA                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| ESM                       | feature-extraction, fill-mask, text-classification, token-classification                                                                      |
+| FlauBERT                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| GPT2                      | text-generation                                                                                                                               |
+| Levit                     | feature-extraction, image-classification                                                                                                      |
+| Llama, Llama 2, Llama 3   | text-generation                                                                                                                               |
+| Mistral                   | text-generation                                                                                                                               |
+| Mixtral                   | text-generation                                                                                                                               |
+| MobileBERT                | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| MobileNetV2               | feature-extraction, image-classification, semantic-segmentation                                                                               |
+| MobileViT                 | feature-extraction, image-classification, semantic-segmentation                                                                               |
+| MPNet                     | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| OPT                       | text-generation                                                                                                                               |
+| Phi                       | feature-extraction, text-classification, token-classification                                                                                 |
+| RoBERTa                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| RoFormer                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| Swin                      | feature-extraction, image-classification                                                                                                      |
+| T5                        | text2text-generation                                                                                                                          |
+| XLM                       | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| ViT                       | feature-extraction, image-classification                                                                                                      |
+| XLM-RoBERTa               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| Yolos                     | feature-extraction, object-detection                                                                                                          |
 
 
 ## Diffusers

--- a/docs/source/package_reference/supported_models.mdx
+++ b/docs/source/package_reference/supported_models.mdx
@@ -23,6 +23,7 @@ limitations under the License.
 | ALBERT                 | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | BERT                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | BLOOM                  | text-generation                                                                                                                               |
+| Beit                   | feature-extraction, image-classification                                                                                                      |
 | CamemBERT              | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | ConvBERT               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | DeBERTa (INF2 only)    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
@@ -43,6 +44,7 @@ limitations under the License.
 | RoFormer               | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | T5                     | text2text-generation                                                                                                                          |
 | XLM                    | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| ViT                    | feature-extraction, image-classification                                                                                                      |
 | XLM-RoBERTa            | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 
 

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -227,6 +227,16 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help=f"Image tasks only. Height {doc_input}",
     )
     input_group.add_argument(
+        "--image_size",
+        type=int,
+        help="Image tasks only. Size (resolution) of each image.",
+    )
+    input_group.add_argument(
+        "--patch_size",
+        type=int,
+        help="Image tasks only. Size (resolution) of patch.",
+    )
+    input_group.add_argument(
         "--num_images_per_prompt",
         type=int,
         default=1,

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -120,10 +120,12 @@ class NeuronDefaultConfig(NeuronConfig, ABC):
     MODEL_TYPE = None
 
     _TASK_TO_COMMON_OUTPUTS = {
+        "depth-estimation": ["predicted_depth"],
         "feature-extraction": ["last_hidden_state", "pooler_output"],
         "fill-mask": ["logits"],
         "image-classification": ["logits"],
-        "image-segmentation": ["logits", "pred_boxes", "pred_masks"],
+        "image-segmentation": ["logits"],
+        "image-to-image": ["reconstruction"],
         "masked-im": ["logits"],
         "multiple-choice": ["logits"],
         "object-detection": ["logits", "pred_boxes"],

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -151,6 +151,8 @@ class NeuronDefaultConfig(NeuronConfig, ABC):
         num_choices: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
+        image_size: Optional[int] = None,
+        patch_size: Optional[int] = None,
         num_channels: Optional[int] = None,
         feature_size: Optional[int] = None,
         nb_max_frames: Optional[int] = None,
@@ -184,13 +186,15 @@ class NeuronDefaultConfig(NeuronConfig, ABC):
             "num_choices": num_choices,
             "width": width,
             "height": height,
-            "num_channels": num_channels,
+            "num_channels": num_channels or getattr(self._config, "num_channels", None),
             "feature_size": feature_size,
             "nb_max_frames": nb_max_frames,
             "audio_sequence_length": audio_sequence_length,
             "point_batch_size": point_batch_size,
             "nb_points_per_image": nb_points_per_image,
             "num_beams": num_beams,
+            "image_size": image_size or getattr(self._config, "image_size", None),
+            "patch_size": patch_size or getattr(self._config, "patch_size", None),
         }
         input_shapes = {}
         for name, value in axes_values.items():

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -330,6 +330,77 @@ class ViTNeuronConfig(VisionNeuronConfig):
         return common_inputs
 
 
+@register_in_tasks_manager("beit", *["feature-extraction", "image-classification"])
+class BeitNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("convnext", *["feature-extraction", "image-classification"])
+class ConvNextNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("convnextv2", *["feature-extraction", "image-classification"])
+class ConvNextV2NeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("cvt", *["feature-extraction", "image-classification"])
+class CvTNeuronConfig(ViTNeuronConfig):
+    @property
+    def outputs(self) -> List[str]:
+        common_outputs = super().outputs
+        if self.task == "feature-extraction":
+            return ["last_hidden_state", "cls_token_value"]
+        else:
+            return common_outputs
+
+
+@register_in_tasks_manager("deit", *["feature-extraction", "image-classification"])
+class DeiTNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("donut-swin", *["feature-extraction"])
+class DonutSwinNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("dpt", *["feature-extraction"])
+class DptNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("levit", *["feature-extraction", "image-classification"])
+class LevitNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("mobilenet-v2", *["feature-extraction", "image-classification", "semantic-segmentation"])
+class MobileNetV2NeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("mobilevit", *["feature-extraction", "image-classification", "semantic-segmentation"])
+class MobileViTNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("swin", *["feature-extraction", "image-classification"])
+class SwinNeuronConfig(ViTNeuronConfig):
+    pass
+
+
+@register_in_tasks_manager("yolos", *["feature-extraction", "object-detection"])
+class YolosTNeuronConfig(ViTNeuronConfig):
+    @property
+    def outputs(self) -> List[str]:
+        common_outputs = super().outputs
+        if self.task == "object-detection":
+            common_outputs.append("last_hidden_state")
+        return common_outputs
+
+
 @register_in_tasks_manager("unet", *["semantic-segmentation"], library_name="diffusers")
 class UNetNeuronConfig(VisionNeuronConfig):
     ATOL_FOR_VALIDATION = 1e-3

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -39,6 +39,7 @@ _import_structure = {
         "NeuronModelForTokenClassification",
         "NeuronModelForMultipleChoice",
         "NeuronModelForCausalLM",
+        "NeuronModelForImageClassification",
     ],
     "modeling_diffusion": [
         "NeuronStableDiffusionPipeline",
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
     from .modeling import (
         NeuronModelForCausalLM,
         NeuronModelForFeatureExtraction,
+        NeuronModelForImageClassification,
         NeuronModelForMaskedLM,
         NeuronModelForMultipleChoice,
         NeuronModelForQuestionAnswering,

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -40,6 +40,8 @@ _import_structure = {
         "NeuronModelForMultipleChoice",
         "NeuronModelForCausalLM",
         "NeuronModelForImageClassification",
+        "NeuronModelForSemanticSegmentation",
+        "NeuronModelForObjectDetection",
     ],
     "modeling_diffusion": [
         "NeuronStableDiffusionPipeline",
@@ -70,7 +72,9 @@ if TYPE_CHECKING:
         NeuronModelForImageClassification,
         NeuronModelForMaskedLM,
         NeuronModelForMultipleChoice,
+        NeuronModelForObjectDetection,
         NeuronModelForQuestionAnswering,
+        NeuronModelForSemanticSegmentation,
         NeuronModelForSentenceTransformers,
         NeuronModelForSequenceClassification,
         NeuronModelForTokenClassification,

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -647,7 +647,7 @@ IMAGE_CLASSIFICATION_EXAMPLE = r"""
 )
 class NeuronModelForImageClassification(NeuronTracedModel):
     """
-    ONNX Model for image-classification tasks. This class officially supports beit, convnext, convnextv2, data2vec_vision, deit, levit, mobilenet_v1, mobilenet_v2, mobilevit, poolformer, resnet, segformer, swin, vit.
+    Neuron Model for image-classification tasks. This class officially supports beit, convnext, convnextv2, data2vec_vision, deit, levit, mobilenet_v1, mobilenet_v2, mobilevit, poolformer, resnet, segformer, swin, vit.
     """
 
     auto_model_class = AutoModelForImageClassification

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -25,7 +25,9 @@ from transformers import (
     AutoModelForImageClassification,
     AutoModelForMaskedLM,
     AutoModelForMultipleChoice,
+    AutoModelForObjectDetection,
     AutoModelForQuestionAnswering,
+    AutoModelForSemanticSegmentation,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
 )
@@ -37,12 +39,13 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     ImageClassifierOutput,
     MaskedLMOutput,
+    ModelOutput,
     MultipleChoiceModelOutput,
     QuestionAnsweringModelOutput,
+    SemanticSegmenterOutput,
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
-from transformers.utils import ModelOutput
 
 from .generation import TokenSelector
 from .modeling_decoder import NeuronDecoderModel
@@ -636,18 +639,33 @@ IMAGE_CLASSIFICATION_EXAMPLE = r"""
     >>> logits = outputs.logits
     >>> predicted_label = logits.argmax(-1).item()
     ```
+    Example using `transformers.pipeline`:
+
+    ```python
+    >>> import requests
+    >>> from PIL import Image
+    >>> from transformers import {processor_class}, pipeline
+    >>> from optimum.neuron import {model_class}
+
+    >>> preprocessor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+    >>> pipe = pipeline("image-classification", model=model, feature_extractor=preprocessor)
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> pred = pipe(url)
+    ```
 """
 
 
 @add_start_docstrings(
     """
-    Neuron Model with  with an image classification head on top (a linear layer on top of the final hidden state of the [CLS] token) e.g. for ImageNet.
+    Neuron Model with an image classification head on top (a linear layer on top of the final hidden state of the [CLS] token) e.g. for ImageNet.
     """,
     NEURON_MODEL_START_DOCSTRING,
 )
 class NeuronModelForImageClassification(NeuronTracedModel):
     """
-    Neuron Model for image-classification tasks. This class officially supports beit, convnext, convnextv2, data2vec_vision, deit, levit, mobilenet_v1, mobilenet_v2, mobilevit, poolformer, resnet, segformer, swin, vit.
+    Neuron Model for image-classification tasks. This class officially supports beit, convnext, convnextv2, deit, levit, mobilenet_v2, mobilevit, vit, etc.
     """
 
     auto_model_class = AutoModelForImageClassification
@@ -677,6 +695,165 @@ class NeuronModelForImageClassification(NeuronTracedModel):
         logits = outputs[0]
 
         return ImageClassifierOutput(logits=logits)
+
+
+SEMANTIC_SEGMENTATION_EXAMPLE = r"""
+    Example of semantic segmentation:
+
+    ```python
+    >>> import requests
+    >>> from PIL import Image
+    >>> from optimum.neuronimport {model_class}
+    >>> from transformers import {processor_class}
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> image = Image.open(requests.get(url, stream=True).raw)
+
+    >>> preprocessor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+
+    >>> inputs = preprocessor(images=image, return_tensors="pt")
+
+    >>> outputs = model(**inputs)
+    >>> logits = outputs.logits
+    ```
+
+    Example using `transformers.pipeline`:
+
+    ```python
+    >>> import requests
+    >>> from PIL import Image
+    >>> from transformers import {processor_class}, pipeline
+    >>> from optimum.neuron import {model_class}
+
+    >>> preprocessor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+    >>> pipe = pipeline("image-segmentation", model=model, feature_extractor=preprocessor)
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> pred = pipe(url)
+"""
+
+
+@add_start_docstrings(
+    """
+    Neuron Model with a semantic segmentation head on top, e.g. for Pascal VOC.
+    """,
+    NEURON_MODEL_START_DOCSTRING,
+)
+class NeuronModelForSemanticSegmentation(NeuronTracedModel):
+    """
+    Neuron Model for semantic-segmentation, with an all-MLP decode head on top e.g. for ADE20k, CityScapes. This class officially supports mobilevit, mobilenet-v2, etc.
+    """
+
+    auto_model_class = AutoModelForSemanticSegmentation
+
+    @add_start_docstrings_to_model_forward(
+        NEURON_IMAGE_INPUTS_DOCSTRING.format("batch_size, num_channels, height, width")
+        + SEMANTIC_SEGMENTATION_EXAMPLE.format(
+            processor_class=_PROCESSOR_FOR_IMAGE,
+            model_class="NeuronModelForSemanticSegmentation",
+            checkpoint="optimum/deeplabv3-mobilevit-small-neuronx",
+        )
+    )
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        **kwargs,
+    ):
+        neuron_inputs = {"pixel_values": pixel_values}
+
+        # run inference
+        with self.neuron_padding_manager(neuron_inputs) as inputs:
+            outputs = self.model(*inputs)  # shape: [batch_size, num_channels, image_size, image_size]
+            outputs = self.remove_padding(
+                outputs, dims=[0], indices=[pixel_values.shape[0]]
+            )  # Remove padding on batch_size(0)
+
+        logits = outputs[0]
+
+        return SemanticSegmenterOutput(logits=logits)
+
+
+OBJECT_DETECTION_EXAMPLE = r"""
+    Example of object detection:
+
+    ```python
+    >>> import requests
+    >>> from PIL import Image
+    >>> from optimum.neuronimport {model_class}
+    >>> from transformers import {processor_class}
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> image = Image.open(requests.get(url, stream=True).raw)
+
+    >>> preprocessor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}", export=True, batch_size=1)
+
+    >>> inputs = preprocessor(images=image, return_tensors="pt")
+
+    >>> outputs = model(**inputs)
+    >>> target_sizes = torch.tensor([image.size[::-1]])
+    >>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[0]
+    ```
+
+    Example using `transformers.pipeline`:
+
+    ```python
+    >>> import requests
+    >>> from PIL import Image
+    >>> from transformers import {processor_class}, pipeline
+    >>> from optimum.neuron import {model_class}
+
+    >>> preprocessor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+    >>> pipe = pipeline("object-detection", model=model, feature_extractor=preprocessor)
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> pred = pipe(url)
+"""
+
+
+@add_start_docstrings(
+    """
+    Neuron Model with object detection heads on top, for tasks such as COCO detection.
+    """,
+    NEURON_MODEL_START_DOCSTRING,
+)
+class NeuronModelForObjectDetection(NeuronTracedModel):
+    """
+    Neuron Model for object-detection, with object detection heads on top, for tasks such as COCO detection.
+    """
+
+    auto_model_class = AutoModelForObjectDetection
+
+    @add_start_docstrings_to_model_forward(
+        NEURON_IMAGE_INPUTS_DOCSTRING.format("batch_size, num_channels, height, width")
+        + OBJECT_DETECTION_EXAMPLE.format(
+            processor_class=_PROCESSOR_FOR_IMAGE,
+            model_class="NeuronModelForObjectDetection",
+            checkpoint="hustvl/yolos-tiny",
+        )
+    )
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        **kwargs,
+    ):
+        neuron_inputs = {"pixel_values": pixel_values}
+
+        # run inference
+        with self.neuron_padding_manager(neuron_inputs) as inputs:
+            outputs = self.model(*inputs)  # shape: [batch_size, num_channels, image_size, image_size]
+            outputs = self.remove_padding(
+                outputs, dims=[0], indices=[pixel_values.shape[0]]
+            )  # Remove padding on batch_size(0)
+
+        logits = outputs[0]
+        pred_boxes = outputs[1]
+        last_hidden_state = outputs[2]
+
+        return ModelOutput(logits=logits, pred_boxes=pred_boxes, last_hidden_state=last_hidden_state)
 
 
 NEURON_CAUSALLM_MODEL_START_DOCSTRING = r"""

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -732,6 +732,7 @@ SEMANTIC_SEGMENTATION_EXAMPLE = r"""
 
     >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     >>> pred = pipe(url)
+    ```
 """
 
 
@@ -811,6 +812,7 @@ OBJECT_DETECTION_EXAMPLE = r"""
 
     >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     >>> pred = pipe(url)
+    ```
 """
 
 

--- a/optimum/neuron/modeling_traced.py
+++ b/optimum/neuron/modeling_traced.py
@@ -465,6 +465,7 @@ class NeuronTracedModel(NeuronModel):
         task = getattr(config, "task") or TasksManager.infer_task_from_model(cls.auto_model_class)
         task = TasksManager.map_from_synonym(task)
         model_type = neuron_config.get("model_type", None) or config.model_type
+        model_type = model_type.replace("_", "-")
         neuron_config_constructor = TasksManager.get_exporter_config_constructor(
             model_type=model_type,
             exporter="neuron",
@@ -540,7 +541,7 @@ class NeuronTracedModel(NeuronModel):
             if (
                 self.preprocessors is not None
                 and len(self.preprocessors) > 0
-                and self.preprocessors[0].pad_token_id is not None
+                and getattr(self.preprocessors[0], "pad_token_id", None)
                 and input_name == "input_ids"
             ):
                 pad_id = self.preprocessors[0].pad_token_id

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -20,6 +20,9 @@ from typing import Any, Dict, Optional, Union
 from transformers import (
     AutoConfig,
     FillMaskPipeline,
+    ImageClassificationPipeline,
+    ImageSegmentationPipeline,
+    ObjectDetectionPipeline,
     Pipeline,
     PreTrainedModel,
     PreTrainedTokenizer,
@@ -43,8 +46,10 @@ from optimum.neuron.pipelines.transformers.sentence_transformers import (
 from ...modeling import (
     NeuronModelForCausalLM,
     NeuronModelForFeatureExtraction,
+    NeuronModelForImageClassification,
     NeuronModelForMaskedLM,
     NeuronModelForQuestionAnswering,
+    NeuronModelForSemanticSegmentation,
     NeuronModelForSentenceTransformers,
     NeuronModelForSequenceClassification,
     NeuronModelForTokenClassification,
@@ -90,6 +95,24 @@ NEURONX_SUPPORTED_TASKS = {
         "class": (NeuronModelForCausalLM,),
         "default": "gpt2",
         "type": "text",
+    },
+    "image-classification": {
+        "impl": ImageClassificationPipeline,
+        "class": (NeuronModelForImageClassification,),
+        "default": "microsoft/beit-base-patch16-224-pt22k-ft22k",
+        "type": "image",
+    },
+    "image-segmentation": {
+        "impl": ImageSegmentationPipeline,
+        "class": (NeuronModelForSemanticSegmentation,),
+        "default": "apple/deeplabv3-mobilevit-small",
+        "type": "image",
+    },
+    "object-detection": {
+        "impl": ObjectDetectionPipeline,
+        "class": (NeuronModelForSemanticSegmentation,),
+        "default": "apple/deeplabv3-mobilevit-small",
+        "type": "image",
     },
 }
 

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -40,7 +40,7 @@ _import_structure = {
         "is_torch_xla_available",
         "is_transformers_neuronx_available",
     ],
-    "input_generators": ["DummyBeamValuesGenerator"],
+    "input_generators": ["DummyBeamValuesGenerator", "DummyMaskedPosGenerator"],
     "misc": [
         "DiffusersPretrainedConfig",
         "check_if_weights_replacable",
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
         is_torch_xla_available,
         is_transformers_neuronx_available,
     )
-    from .input_generators import DummyBeamValuesGenerator
+    from .input_generators import DummyBeamValuesGenerator, DummyMaskedPosGenerator
     from .misc import (
         DiffusersPretrainedConfig,
         check_if_weights_replacable,

--- a/tests/cli/test_export_cli.py
+++ b/tests/cli/test_export_cli.py
@@ -114,10 +114,6 @@ class TestExportCLI(unittest.TestCase):
         model_id = "hf-internal-testing/tiny-random-BertModel"
         with tempfile.TemporaryDirectory() as tempdir:
             save_path = f"{tempdir}/neff"
-            if is_neuronx_available():
-                neff_path = os.path.join(save_path, "graph.neff")
-            else:
-                neff_path = os.path.join(save_path, "32", "neff.json")
             subprocess.run(
                 [
                     "optimum-cli",
@@ -138,7 +134,11 @@ class TestExportCLI(unittest.TestCase):
                 shell=False,
                 check=True,
             )
-            self.assertTrue(os.path.exists(neff_path))
+            if is_neuronx_available():
+                neff_path = os.path.join(save_path, "graph.neff")
+                self.assertTrue(os.path.exists(neff_path))
+            else:
+                neff_path = os.path.join(save_path, "32", "neff.json")
 
     @requires_neuronx
     def test_stable_diffusion(self):

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -16,23 +16,35 @@
 
 EXPORT_MODELS_TINY = {
     "albert": "hf-internal-testing/tiny-random-AlbertModel",
+    "beit": "hf-internal-testing/tiny-random-BeitForImageClassification",
     "bert": "hf-internal-testing/tiny-random-BertModel",
     "camembert": "hf-internal-testing/tiny-random-camembert",
     "convbert": "hf-internal-testing/tiny-random-ConvBertModel",
+    "convnext": "hf-internal-testing/tiny-random-convnext",
+    "convnextv2": "hf-internal-testing/tiny-random-ConvNextV2Model",
+    "cvt": "hf-internal-testing/tiny-random-CvTModel",
     "deberta": "hf-internal-testing/tiny-random-DebertaModel",  # Failed for INF1: 'XSoftmax'
     "deberta-v2": "hf-internal-testing/tiny-random-DebertaV2Model",  # Failed for INF1: 'XSoftmax'
+    "deit": "hf-internal-testing/tiny-random-DeiTModel",
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
+    "donut-swin": "hf-internal-testing/tiny-random-DonutSwinModel",
+    "dpt": "hf-internal-testing/tiny-random-DPTModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "esm": "hf-internal-testing/tiny-random-EsmModel",
     "flaubert": "flaubert/flaubert_small_cased",
+    "levit": "hf-internal-testing/tiny-random-LevitModel",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
+    "mobilenet-v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
+    "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "phi": "bumblebee-testing/tiny-random-PhiModel",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
+    "swin": "hf-internal-testing/tiny-random-SwinModel",
     "vit": "hf-internal-testing/tiny-random-vit",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
     "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+    "yolos": "hf-internal-testing/tiny-random-YolosModel",
 }
 
 ENCODER_DECODER_MODELS_TINY = {

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -30,6 +30,7 @@ EXPORT_MODELS_TINY = {
     "phi": "bumblebee-testing/tiny-random-PhiModel",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
+    "vit": "hf-internal-testing/tiny-random-vit",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
     "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
 }

--- a/tests/inference/inference_utils.py
+++ b/tests/inference/inference_utils.py
@@ -30,25 +30,38 @@ SEED = 42
 
 MODEL_NAMES = {
     "albert": "hf-internal-testing/tiny-random-AlbertModel",
+    "beit": "hf-internal-testing/tiny-random-BeitForImageClassification",
     "bert": "hf-internal-testing/tiny-random-BertModel",
     "camembert": "hf-internal-testing/tiny-random-camembert",
     "convbert": "hf-internal-testing/tiny-random-ConvBertModel",
+    "convnext": "hf-internal-testing/tiny-random-convnext",
+    "convnextv2": "hf-internal-testing/tiny-random-ConvNextV2Model",
+    "cvt": "hf-internal-testing/tiny-random-CvTModel",
     "deberta": "hf-internal-testing/tiny-random-DebertaModel",  # Failed for INF1: 'XSoftmax'
     "deberta-v2": "hf-internal-testing/tiny-random-DebertaV2Model",  # Failed for INF1: 'XSoftmax'
+    "deit": "hf-internal-testing/tiny-random-DeiTModel",
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
+    "donut-swin": "hf-internal-testing/tiny-random-DonutSwinModel",
+    "dpt": "hf-internal-testing/tiny-random-DPTModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "flaubert": "flaubert/flaubert_small_cased",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "latent-consistency": "echarlaix/tiny-random-latent-consistency",
+    "levit": "hf-internal-testing/tiny-random-LevitModel",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
+    "mobilenet-v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
+    "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "phi": "bumblebee-testing/tiny-random-PhiModel",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
+    "swin": "hf-internal-testing/tiny-random-SwinModel",
+    "vit": "hf-internal-testing/tiny-random-vit",
     "stable-diffusion": "hf-internal-testing/tiny-stable-diffusion-torch",
     "stable-diffusion-xl": "echarlaix/tiny-random-stable-diffusion-xl",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
     "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+    "yolos": "hf-internal-testing/tiny-random-YolosModel",
 }
 
 LORA_WEIGHTS_TINY = {

--- a/tests/inference/test_modeling.py
+++ b/tests/inference/test_modeling.py
@@ -18,13 +18,16 @@ import shutil
 import tempfile
 import warnings
 
+import requests
 import torch
 from huggingface_hub.constants import default_cache_path
 from parameterized import parameterized
 from PIL import Image
 from sentence_transformers import SentenceTransformer, util
 from transformers import (
+    AutoImageProcessor,
     AutoModel,
+    AutoModelForImageClassification,
     AutoModelForMaskedLM,
     AutoModelForMultipleChoice,
     AutoModelForQuestionAnswering,
@@ -39,6 +42,7 @@ from transformers.onnx.utils import get_preprocessor
 
 from optimum.neuron import (
     NeuronModelForFeatureExtraction,
+    NeuronModelForImageClassification,
     NeuronModelForMaskedLM,
     NeuronModelForMultipleChoice,
     NeuronModelForQuestionAnswering,
@@ -1345,3 +1349,117 @@ class NeuronModelForMultipleChoiceIntegrationTest(NeuronModelTestMixin):
         )
 
         gc.collect()
+
+
+@is_inferentia_test
+class NeuronModelForImageClassificationIntegrationTest(NeuronModelTestMixin):
+    NEURON_MODEL_CLASS = NeuronModelForImageClassification
+    TASK = "image-classification"
+    if is_neuron_available():
+        ATOL_FOR_VALIDATION = 1e-3
+        SUPPORTED_ARCHITECTURES = []
+    elif is_neuronx_available():
+        ATOL_FOR_VALIDATION = 1e-3
+        SUPPORTED_ARCHITECTURES = [
+            "beit",
+            "convnext",
+            "convnextv2",
+            "cvt",
+            "deit",
+            "levit",
+            "mobilenet-v2",
+            "mobilevit",
+            "swin",
+            "vit",
+        ]
+    else:
+        ATOL_FOR_VALIDATION = 1e-5
+        SUPPORTED_ARCHITECTURES = []
+
+    def _load_neuron_model_and_processor(self, model_arch, suffix):
+        model_id = self.ARCH_MODEL_MAP[model_arch] if model_arch in self.ARCH_MODEL_MAP else MODEL_NAMES[model_arch]
+        neuron_model = NeuronModelForImageClassification.from_pretrained(self.neuron_model_dirs[model_arch + suffix])
+        preprocessor = AutoImageProcessor.from_pretrained(model_id)
+        self.assertIsInstance(neuron_model.model, torch.jit._script.ScriptModule)
+        self.assertIsInstance(neuron_model.config, PretrainedConfig)
+        return neuron_model, preprocessor
+
+    def _load_transformers_model(self, model_arch):
+        model_id = self.ARCH_MODEL_MAP[model_arch] if model_arch in self.ARCH_MODEL_MAP else MODEL_NAMES[model_arch]
+        set_seed(SEED)
+        transformers_model = AutoModelForImageClassification.from_pretrained(model_id)
+        return transformers_model
+
+    def _prepare_inputs(self, preprocessor, batch_size=1):
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        inputs = preprocessor(images=image, return_tensors="pt")
+        if batch_size > 1:
+            for name, tensor in inputs.items():
+                inputs[name] = torch.cat(batch_size * [tensor])
+        return inputs
+
+    def _validate_outputs(self, model_arch, suffix):
+        neuron_model, preprocessor = self._load_neuron_model_and_processor(model_arch, suffix)
+        transformers_model = self._load_transformers_model(model_arch)
+        inputs = self._prepare_inputs(preprocessor)
+
+        with torch.no_grad():
+            transformers_outputs = transformers_model(**inputs)
+
+        # Numeric validation
+        atol = neuron_model.neuron_config.ATOL_FOR_VALIDATION or self.ATOL_FOR_VALIDATION
+        neuron_outputs = neuron_model(**inputs)
+        self.assertIn("logits", neuron_outputs)
+        self.assertIsInstance(neuron_outputs.logits, torch.Tensor)
+        result_close = torch.allclose(
+            neuron_outputs.logits,
+            transformers_outputs.logits,
+            atol=atol,
+        )
+        if not result_close:
+            warnings.warn(
+                f"Inference results between pytorch model and neuron model of {model_arch} not close enough."
+            )
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
+    @requires_neuronx
+    def test_compare_to_transformers_dyn_bs(self, model_arch):
+        # Neuron model with dynamic batching
+        model_args = {
+            "test_name": model_arch + "_dyn_bs_true",
+            "model_arch": model_arch,
+            "dynamic_batch_size": True,
+        }
+        self._setup(model_args)
+        self._validate_outputs(model_arch, "_dyn_bs_true")
+
+        gc.collect()
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
+    def test_compare_to_transformers_non_dyn_bs(self, model_arch):
+        model_args = {
+            "test_name": model_arch + "_dyn_bs_false",
+            "model_arch": model_arch,
+            "dynamic_batch_size": False,
+        }
+        self._setup(model_args)
+        self._validate_outputs(model_arch, "_dyn_bs_false")
+
+        gc.collect()
+
+    def test_non_dyn_bs_neuron_model_on_false_batch_size(self):
+        model_arch = "vit"
+        model_args = {
+            "test_name": model_arch + "_dyn_bs_false",
+            "model_arch": model_arch,
+            "dynamic_batch_size": False,
+        }
+        self._setup(model_args)
+        neuron_model, preprocessor = self._load_neuron_model_and_processor(model_arch, "_dyn_bs_false")
+        inputs = self._prepare_inputs(preprocessor, batch_size=2)
+
+        with self.assertRaises(Exception) as context:
+            _ = neuron_model(**inputs)
+
+        self.assertIn("set `dynamic_batch_size=True` during the compilation", str(context.exception))


### PR DESCRIPTION
# What does this PR do?

### Export

* CLI

```bash
optimum-cli export neuron --model facebook/deit-base-patch16-224 --batch_size 1 --task image-classification vit_neuron/
```

* API

```python
import requests
from PIL import Image
from transformers import AutoImageProcessor
from optimum.neuron import NeuronModelForImageClassification

# Create the feature extractor and model
model_id = "facebook/deit-base-patch16-224"
feature_extractor = AutoImageProcessor.from_pretrained(model_id)
model = NeuronModelForImageClassification.from_pretrained(model_id, export=True, batch_size=1)
save_directory = "vit_neuron"
model.save_pretrained(save_directory)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
