### PR TITLE
Skip invalid gen config

### DIFF
--- a/docs/source/guides/neuronx_tgi.mdx
+++ b/docs/source/guides/neuronx_tgi.mdx
@@ -87,6 +87,7 @@ possible to export it dynamically, pending some conditions:
 The snippet below shows how you can deploy a service from a hub standard model:
 
 ```
+export HF_TOKEN=<YOUR_TOKEN>
 docker run -p 8080:80 \
        -v $(pwd)/data:/data \
        --privileged \
@@ -94,7 +95,7 @@ docker run -p 8080:80 \
        -e HF_AUTO_CAST_TYPE="fp16" \
        -e HF_NUM_CORES=2 \
        ghcr.io/huggingface/neuronx-tgi:latest \
-       --model-id NousResearch/Llama-2-7b-chat-hf \
+       --model-id meta-llama/Meta-Llama-3-8B \
        --max-batch-size 1 \
        --max-input-length 3164 \
        --max-total-tokens 4096

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import shutil
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Tuple, Union
@@ -249,6 +250,13 @@ class NeuronDecoderModel(NeuronModel):
             torch_dtype="auto",
             **kwargs,
         )
+
+        if model.generation_config is not None:
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                model.generation_config.validate()
+            if len(caught_warnings) > 0:
+                logger.warning("Invalid generation config: recreating it from model config.")
+                model.generation_config = GenerationConfig.from_model_config(model.config)
 
         # Save the model checkpoint in a temporary directory
         checkpoint_dir = TemporaryDirectory()

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.0.23.dev0"
+__version__ = "0.0.24.dev0"
 
 __sdk_version__ = "2.18.0"


### PR DESCRIPTION
# What does this PR do?

The latest version of `transformers` refuses to save invalid generation config. This triggers an exception when exporting a model to Neuron since we must first save that model to a local directory.

This modifies the export code to check the generation config and recreate it from the model config if it is invalid.