### PR TITLE
fix bad link to distributed-training how-to guide in optimum-neuron docs

### DIFF
--- a/docs/source/guides/overview.mdx
+++ b/docs/source/guides/overview.mdx
@@ -24,7 +24,7 @@ These guides tackle more advanced topics and will show you how to easily get the
 - [Training and Deployment using Amazon Sagemaker](./sagemaker)
 - [Neuron model cache](./cache_system)
 - [How to fine-tune a Transformers model with AWS Trainium](./fine_tune)
-- [Distributed training with AWS Neuron](./distributed_training.mdx)
+- [Distributed training with AWS Neuron](./distributed_training)
 - [Export a model to Inferentia](./export_model)
 - [Neuron Model Inference](./models)
 - [Inference pipelines with AWS Neuron (Inf2/Trn1)](./pipelines)


### PR DESCRIPTION
# What does this PR do?

The "how-to" guides overview page has a bad link to the distributed training guide.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
