### PR TITLE
Do not copy local checkpoint

### DIFF
--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -362,13 +362,16 @@ class NeuronDecoderModel(NeuronModel):
             auto_cast_type=auto_cast_type,
         )
 
-        # Instantiate the transformers model checkpoint
-        checkpoint_dir = cls._create_checkpoint(
-            model_id,
-            task=new_config.neuron["task"],
-            revision=revision,
-            **kwargs,
-        )
+        if os.path.isdir(model_id):
+            checkpoint_dir = model_id
+        else:
+            # Create the local transformers model checkpoint
+            checkpoint_dir = cls._create_checkpoint(
+                model_id,
+                task=new_config.neuron["task"],
+                revision=revision,
+                **kwargs,
+            )
 
         # Try to reload the generation config (if any)
         generation_config = None


### PR DESCRIPTION
# What does this PR do?

This avoids a redundant copy when a model is exported from a local path. This is made possible by the fact that we don;t need to split the model weights anymore.