### PR TITLE
Fix MPMD detected error during training with TP

### DIFF
--- a/.github/workflows/test_trainium_common.yml
+++ b/.github/workflows/test_trainium_common.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run tests on Neuron cores
         run: |
           source aws_neuron_venv_pytorch/bin/activate
-          HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV="false" pytest -m "is_trainium_test" $TESTS_TO_IGNORE_FLAGS tests --durations=0
+          HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} USE_VENV="false" pytest -m "is_trainium_test" $TESTS_TO_IGNORE_FLAGS tests --durations=0 -v
       - name: Collect staging tests on Neuron Cores
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -521,8 +521,13 @@ class NeuronAccelerator(Accelerator):
             #   - `self.state.mixed_precision == "bf16"`
             #   - `self.state.autocast_backend is AutocastBackend.AMP`
             autocast_handler = self.autocast_handler
-        autocast_kwargs = autocast_handler.to_kwargs()
-        autocast_context = torch.autocast(dtype=torch.bfloat16, device_type="cuda", **autocast_kwargs)
+
+        if autocast_handler.enabled:
+            autocast_kwargs = autocast_handler.to_kwargs()
+            autocast_context = torch.autocast(dtype=torch.bfloat16, device_type="cuda", **autocast_kwargs)
+        else:
+            autocast_context = contextlib.nullcontext()
+
         autocast_context.__enter__()
         yield
         autocast_context.__exit__(*sys.exc_info())

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -353,7 +353,6 @@ class AugmentTrainerForNeuronMixin:
         return inputs
 
     def compute_loss(self, model, inputs, return_outputs: bool = False):
-        self.state.last_inputs = inputs
         from neuronx_distributed.pipeline import NxDPPModel
 
         if isinstance(model, NxDPPModel):
@@ -407,8 +406,6 @@ class AugmentTrainerForNeuronMixin:
         ignore_keys: Optional[List[str]] = None,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
         from neuronx_distributed.pipeline import NxDPPModel
-
-        self.state.last_inputs = inputs
 
         if isinstance(model, NxDPPModel):
             if not prediction_loss_only:

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -367,7 +367,6 @@ class AugmentTrainerForNeuronMixin:
         A helper wrapper that creates an appropriate context manager for `autocast` while feeding it the desired
         arguments, depending on the situation.
         """
-
         autocast_handler = AutocastKwargs(
             enabled=self.accelerator.autocast_handler.enabled,
             cache_enabled=cache_enabled,

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -125,12 +125,11 @@ class ExampleRunner:
             "task_name": "sst2",
         },
         "token-classification": {
-            "dataset_name": "conll2003",
+            "dataset_name": "bnsapa/cybersecurity-ner",
             "set_max_length": True,
             "extra_command_line_arguments": [
                 "--pad_to_max_length",
                 "--ignore_mismatched_sizes",
-                "--trust_remote_code",
             ],
         },
         "multiple-choice": {

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -130,6 +130,7 @@ class ExampleRunner:
             "extra_command_line_arguments": [
                 "--pad_to_max_length",
                 "--ignore_mismatched_sizes",
+                "--trust_remote_code",
             ],
         },
         "multiple-choice": {


### PR DESCRIPTION
# What does this PR do?

This PR tries to fix the issue reported here https://github.com/aws-neuron/neuronx-distributed/issues/24.

It seems to be linked to `torch.autocast`:

- Before this PR, when it was supposed to be disabled we would do: `with torch.autocast(enabled=False):`
- Now we do: `with contexlib.nullcontex():`. 

For some reason the first approach was leading to different cores trying to execute different graphs, leading to the MPMD detected error.