### PR TITLE
Add support for Whisper and speech seq2seq

### DIFF
--- a/docs/source/package_reference/modeling.mdx
+++ b/docs/source/package_reference/modeling.mdx
@@ -68,6 +68,10 @@ The following Neuron model classes are available for natural language processing
 [[autodoc]] modeling.NeuronModelForCausalLM
     - forward
 
+### NeuronModelForSeq2SeqLM
+
+[[autodoc]] modeling_seq2seq.NeuronModelForSeq2SeqLM
+
 ## Computer Vision
 
 The following Neuron model classes are available for computer vision tasks.
@@ -97,6 +101,9 @@ The following auto classes are available for the following audio tasks.
 
 ### NeuronModelForXVector
 [[autodoc]] modeling.NeuronModelForXVector
+
+### NeuronModelForSpeechSeq2Seq
+[[autodoc]] modeling_seq2seq.NeuronModelForSpeechSeq2Seq
 
 ## Stable Diffusion
 

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -16,6 +16,7 @@
 
 import importlib
 import re
+import enum
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
@@ -458,3 +459,14 @@ class NeuronDecoderConfig(NeuronConfig):
     @property
     def attention_layout(self):
         return self.ATTENTION_lAYOUT
+
+
+class ConfigBehavior(str, enum.Enum):
+    """
+    Specifies the behavior of sequence-to-sequence Neuron config:
+        - ENCODER: the config can be used to export the encoder part (and the initialization of the KV cache) of the seq2seq model.
+        - DECODER: the config can be used to export the decoder part of the seq2seq model.
+    """
+
+    ENCODER = "encoder"
+    DECODER = "decoder"


### PR DESCRIPTION
# What does this PR do?

Fixes #84 

- [ ] Exporter support for Whisper

Two components will be traced:
* Encoder + Decoder without past(past key values initialization) -> "encoder"
* Decoder with past key values to reduce recompute -> "decoder"

With these two components, the `generate()` needs to be overridden, and this will be done in `NeuronGenerationMixin`.

Might start with only supporting **greedy mode**. 

- [ ] Add `NeuronModelForSeq2SeqLM` for inference
(Speculative Decoding will not be part of this PR, could support it in a coming PR if interested.)
- [ ] Tests
- [ ] Documentation


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
