### PR TITLE
chore: bump transformers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers == 4.41.1",
+    "transformers == 4.43.1",
     "accelerate == 0.29.2",
     "optimum ~= 1.20.0",
     "huggingface_hub >= 0.20.1",


### PR DESCRIPTION
# What does this PR do?

This bumps the `transformers` version to support Llama 3.1.