### PR TITLE
Bump TGI version and fix bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ PACKAGE_FILES = $(PACKAGE_PYTHON_FILES)  \
 $(PACKAGE_DIST) $(PACKAGE_WHEEL): $(PACKAGE_FILES)
 	python -m build
 
-TGI_VERSION ?= 2.0.2
+TGI_VERSION ?= 2.1.1
 
 neuronx-tgi: $(PACKAGE_DIST)
 	docker build --rm -f text-generation-inference/Dockerfile \

--- a/text-generation-inference/Dockerfile
+++ b/text-generation-inference/Dockerfile
@@ -8,7 +8,7 @@ RUN tar -C /tgi -xf /tgi/sources.tar.gz --strip-components=1
 
 # Build cargo components (adapted from TGI original Dockerfile)
 # Note that the build image is aligned on the same Linux version as the base image (Debian bookworm/ Ubuntu 22.04)
-FROM lukemathwalker/cargo-chef:latest-rust-1.75-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.79-bookworm AS chef
 WORKDIR /usr/src
 
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
@@ -20,8 +20,6 @@ COPY --from=tgi /tgi/proto proto
 COPY --from=tgi /tgi/benchmark benchmark
 COPY --from=tgi /tgi/router router
 COPY --from=tgi /tgi/launcher launcher
-# Remove the next line when bumping rust version
-RUN cargo update ravif --precise 0.11.6
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder

--- a/text-generation-inference/Dockerfile
+++ b/text-generation-inference/Dockerfile
@@ -41,6 +41,8 @@ COPY --from=tgi /tgi/proto proto
 COPY --from=tgi /tgi/benchmark benchmark
 COPY --from=tgi /tgi/router router
 COPY --from=tgi /tgi/launcher launcher
+# Remove this line once TGI has fixed the conflict
+RUN cargo update ureq --precise 2.9.7
 RUN cargo build --release --workspace --exclude benchmark
 
 # Python base image

--- a/text-generation-inference/server/text_generation_server/cli.py
+++ b/text-generation-inference/server/text_generation_server/cli.py
@@ -17,6 +17,9 @@ def serve(
     uds_path: str = "/tmp/text-generation-server",
     logger_level: str = "INFO",
     json_output: bool = False,
+    otlp_endpoint: Optional[str] = None,
+    otlp_service_name: str = "text-generation-inference.server",
+    max_input_tokens: Optional[int] = None,
 ):
     """This is the main entry-point for the server CLI.
 
@@ -36,6 +39,12 @@ def serve(
             The server logger level. Defaults to *INFO*.
         json_output (`bool`):
             Use JSON format for log serialization.
+        otlp_endpoint (Optional[`str`]):
+            The Open Telemetry endpoint to use.
+        otlp_service_name (Optional[`str`]):
+            The name to use when pushing data to the Open Telemetry endpoint.
+        max_input_tokens (Optional[`int`]):
+            The maximum number of input tokens each request should contain.
     """
     if sharded:
         raise ValueError("Sharding is not supported.")

--- a/text-generation-inference/server/text_generation_server/cli.py
+++ b/text-generation-inference/server/text_generation_server/cli.py
@@ -39,11 +39,11 @@ def serve(
             The server logger level. Defaults to *INFO*.
         json_output (`bool`):
             Use JSON format for log serialization.
-        otlp_endpoint (Optional[`str`]):
+        otlp_endpoint (`Optional[str]`, defaults to `None`):
             The Open Telemetry endpoint to use.
-        otlp_service_name (Optional[`str`]):
+        otlp_service_name (`Optional[str]`, defaults to `None`):
             The name to use when pushing data to the Open Telemetry endpoint.
-        max_input_tokens (Optional[`int`]):
+        max_input_tokens (`Optional[int]`, defaults to `None`):
             The maximum number of input tokens each request should contain.
     """
     if sharded:

--- a/text-generation-inference/tests/integration/test_implicit_env.py
+++ b/text-generation-inference/tests/integration/test_implicit_env.py
@@ -17,8 +17,8 @@ async def tgi_service(request, launcher, neuron_model_config):
     # the tgi_env.py script will take care of setting these
     for var in [
         "MAX_BATCH_SIZE",
-        "MAX_INPUT_LENGTH",
-        "MAX_TOTAL_TOKEN",
+        "MAX_INPUT_TOKENS",
+        "MAX_TOTAL_TOKENS",
         "HF_NUM_CORES",
         "HF_AUTO_CAST_TYPE",
     ]:


### PR DESCRIPTION
# What does this PR do?

This bumps the TGI router version to 2.1.1 and fixes two issues:

- the server now supports the `--max-input-tokens/MAX_INPUT_TOKENS` parameter (instead of `MAX_INPUT_LENGTH`, that is still supported but deprecated),
- the server automatically removes obsolete request_ids (#655).
