### PR TITLE
ci: fix inference cache pipeline

### DIFF
--- a/.github/workflows/inference_cache.yml
+++ b/.github/workflows/inference_cache.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install python and create venv
         run: |
-          sudo apt install python-venv python3-dev -y
+          sudo apt install python3-venv python3-dev -y
           python3 -m venv aws_neuron_venv_pytorch
           source aws_neuron_venv_pytorch/bin/activate
           python -m pip install -U pip


### PR DESCRIPTION
# What does this PR do?

The previous CI pull-request introduced a small mistake in the inference cache pipeline.