### PR TITLE
update container URIs

### DIFF
--- a/docs/source/containers.mdx
+++ b/docs/source/containers.mdx
@@ -15,15 +15,26 @@ specific language governing permissions and limitations under the License.
 We provide pre-built Optimum Neuron containers for Amazon SageMaker. These containers come with all of the Hugging Face libraries and dependencies pre-installed, so you can start using them right away.
 We have containers for training and inference, and optimized text generation containers with TGI. The table is up to date and only includes the latest versions of each container. You can find older versions in the [Deep Learning Container Release Notes](https://github.com/aws/deep-learning-containers/releases?q=hf-neuronx&expanded=true)
 
-We recommend using the `sagemaker` Python SDK to retrieve the image URI for the container you want to use.
+We recommend using the `sagemaker` Python SDK to retrieve the image URI for the container you want to use. Here is a code snippet to retrieve the latest Text Generation Inference container Image URI:
+```python
+from sagemaker.huggingface import get_huggingface_llm_image_uri
+ 
+# retrieve the llm image uri
+llm_image = get_huggingface_llm_image_uri(
+  "huggingface-neuronx"
+)
+
+print(f"llm image uri: {llm_image}")
+
+```
 
 ## Available Optimum Neuron Containers
 
 | Type                       | Optimum Version | Image URI                                   |
 |-----------------------------|-----------------|---------------------------------------------|
-| Training  | 0.0.21           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training-neuronx:1.13.1-transformers4.36.2-neuronx-py310-sdk2.18.0-ubuntu20.04`   |
-| Inference      | 0.0.22           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference-neuronx:2.1.2-transformers4.36.2-neuronx-py310-sdk2.18.0-ubuntu20.04`      |
-| Text Generation Inference        | 0.0.22           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.2-optimum0.0.22-neuronx-py310-ubuntu22.04`        |
+| Training  | 0.0.24           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training-neuronx:2.1.2-transformers4.41.1-neuronx-py310-sdk2.19.1-ubuntu20.04-v1.0`   |
+| Inference      | 0.0.24           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference-neuronx:2.1.2-transformers4.41.1-neuronx-py310-sdk2.19.1-ubuntu20.04-v1.0`      |
+| Text Generation Inference        | 0.0.23           | `763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.2-optimum0.0.23-neuronx-py310-ubuntu22.04`        |
 
 
 Please replace `763104351884` with the correct [AWS account ID](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/huggingface-neuronx.json) and `region` with the AWS region you are working in.


### PR DESCRIPTION
# What does this PR do?

This PR updates the doc according to the latest containers available:
- TGI - https://github.com/awslabs/llm-hosting-container/pull/79 
- Inference - https://github.com/aws/deep-learning-containers/releases/tag/v1.0-hf-4.41.1-pt-2.1.2-inf-neuronx-sdk2.19.1-py310
- Training - https://github.com/aws/deep-learning-containers/releases/tag/v1.0-hf-4.41.1-pt-2.1.2-tr-neuronx-sdk2.19.1-py310

Another PR will come once we have TGI - https://github.com/awslabs/llm-hosting-container/pull/87 officially released (usually a couple of days after merging)

Also, I try to be more explicit on how to get the latest URI using sagemakerSDK. I know a command for TGI, would be great if there is an equivalent for training and inference containers.