### PR TITLE
Use 2.19.1 DLAMI as source AMI

### DIFF
--- a/infrastructure/ami/hcl2-files/build.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/build.pkr.hcl
@@ -14,7 +14,7 @@ build {
     ]
   }
   provisioner "shell" {
-    inline = ["echo 'source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate' >> /home/ubuntu/.bashrc"]
+    inline = ["echo 'source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate' | sudo tee -a /home/ubuntu/.bashrc"]
   }
   provisioner "file" {
     source      = "scripts/welcome-msg.sh"

--- a/infrastructure/ami/hcl2-files/build.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/build.pkr.hcl
@@ -14,7 +14,7 @@ build {
     ]
   }
   provisioner "shell" {
-    inline = ["echo 'source /opt/aws_neuron_venv_pytorch/bin/activate' >> /home/ubuntu/.bashrc"]
+    inline = ["echo 'source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate' >> /home/ubuntu/.bashrc"]
   }
   provisioner "file" {
     source      = "scripts/welcome-msg.sh"

--- a/infrastructure/ami/hcl2-files/variables.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/variables.pkr.hcl
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "source_ami" {
-  default     = "ami-0274e546d67626305"
+  default     = "ami-0bcb701dd3cace633"
   description = "Base Image"
   type        = string
   /*
@@ -18,7 +18,7 @@ variable "source_ami" {
   aws ec2 describe-images \
       --region us-east-1 \
       --owners amazon \
-      --filters 'Name=name,Values=Deep Learning AMI Neuron PyTorch 1.13 (Ubuntu 20.04) ????????' 'Name=state,Values=available' \
+      --filters 'Name=name,Values=Deep Learning AMI Neuron ????????' 'Name=state,Values=available' \
       --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
       --output text
   */

--- a/infrastructure/ami/scripts/install-huggingface-libraries.sh
+++ b/infrastructure/ami/scripts/install-huggingface-libraries.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Activate the neuron virtual environment
-source /opt/aws_neuron_venv_pytorch/bin/activate
+source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate
 
 echo "Step: install-hugging-face-libraries"
 

--- a/infrastructure/ami/scripts/validate-neuron.sh
+++ b/infrastructure/ami/scripts/validate-neuron.sh
@@ -3,7 +3,7 @@ echo "Step: validate-neuron-devices"
 neuron-ls
 
 # Activate the neuron virtual environment
-source /opt/aws_neuron_venv_pytorch/bin/activate
+source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate
 
 python -c 'import torch'
 python -c 'import torch_neuronx'

--- a/tests/decoder/test_decoder_pipelines.py
+++ b/tests/decoder/test_decoder_pipelines.py
@@ -35,7 +35,7 @@ def _test_generation(p):
             # We only ever generate one sequence per input
             sequence = output[0]
             if return_tensors:
-                input_ids = p.tokenizer(input, add_special_tokens=False).input_ids
+                input_ids = p.tokenizer(input).input_ids
                 assert sequence["generated_token_ids"][: len(input_ids)] == input_ids
             else:
                 assert sequence["generated_text"].startswith(input)


### PR DESCRIPTION
# What does this PR do?

This updates the source image when generating the HF DLAMI to the Deep Learning AMI Neuron (Ubuntu 22.04) 20240823.

This also fixes an issue with decoder pipelines tests.