### PR TITLE
Add CI workflow to push NeuronX TGI docker images

### DIFF
--- a/.github/workflows/build-neuronx-tgi.yml
+++ b/.github/workflows/build-neuronx-tgi.yml
@@ -1,0 +1,53 @@
+name: Build and push NeuronX docker image to ghcr.io
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on:
+      group: aws-general-8-plus
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      -
+        name: Checkout sources
+        uses: actions/checkout@v4
+      -
+        name: Install python and create venv
+        run: |
+          sudo apt update
+          sudo apt install python3-venv python3-dev -y
+          python3 -m venv aws_neuron_venv_pytorch
+          source aws_neuron_venv_pytorch/bin/activate
+          python -m pip install -U pip
+          python -m pip install build
+          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+          python -m build .
+      -
+        name: Extract version
+        run: |
+          pkg=$(ls dist/optimum_neuron*.tar.gz); tmp=${pkg#*-}; echo "ON_VERSION=${tmp%.tar.gz*}">> $GITHUB_ENV
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: text-generation-inference/Dockerfile
+          push: true
+          build-args: VERSION=${{ env.ON_VERSION }}
+          tags: ghcr.io/huggingface/neuronx-tgi:${{ env.ON_VERSION }}, ghcr.io/huggingface/neuronx-tgi:latest


### PR DESCRIPTION
# What does this PR do?

This adds a CI workflow to push NeuronX TGI docker images to ghcr.io.

The workflow runs when a new tag is pushed or on-demand, specifying the tag or branch.