### PR TITLE
Fix Non-Contiguous Tensor Issue in Checkpoint Consolidation

### DIFF
--- a/docs/source/training_tutorials/finetune_llm.py
+++ b/docs/source/training_tutorials/finetune_llm.py
@@ -57,10 +57,7 @@ def pack_dataset(dataset, chunk_length=2048):
         return result
 
     # tokenize and chunk dataset
-    lm_dataset = dataset.map(
-        partial(chunk, chunk_length=chunk_length),
-        batched=True,
-    )
+    lm_dataset = dataset.map(partial(chunk, chunk_length=chunk_length), batched=True,)
     print(f"Total number of samples: {len(lm_dataset)}")
     return lm_dataset
 

--- a/docs/source/training_tutorials/sft_lora_finetune_llm.py
+++ b/docs/source/training_tutorials/sft_lora_finetune_llm.py
@@ -43,11 +43,7 @@ def training_function(script_args, training_args):
     )
 
     args = training_args.to_dict()
-    sft_config = NeuronSFTConfig(
-        max_seq_length=1024,
-        packing=False,
-        **args,
-    )
+    sft_config = NeuronSFTConfig(max_seq_length=1024, packing=False, **args,)
 
     trainer = NeuronSFTTrainer(
         args=sft_config,

--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -266,10 +266,7 @@ def main():
         if data_args.validation_dir is not None:
             data_files["validation"] = os.path.join(data_args.validation_dir, "**")
         dataset = load_dataset(
-            "imagefolder",
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            task="image-classification",
+            "imagefolder", data_files=data_files, cache_dir=model_args.cache_dir, task="image-classification",
         )
 
     # If we don't have a validation split, split off a percentage of train as validation.
@@ -340,22 +337,8 @@ def main():
         if hasattr(image_processor, "image_mean") and hasattr(image_processor, "image_std")
         else Lambda(lambda x: x)
     )
-    _train_transforms = Compose(
-        [
-            RandomResizedCrop(size),
-            RandomHorizontalFlip(),
-            ToTensor(),
-            normalize,
-        ]
-    )
-    _val_transforms = Compose(
-        [
-            Resize(size),
-            CenterCrop(size),
-            ToTensor(),
-            normalize,
-        ]
-    )
+    _train_transforms = Compose([RandomResizedCrop(size), RandomHorizontalFlip(), ToTensor(), normalize,])
+    _val_transforms = Compose([Resize(size), CenterCrop(size), ToTensor(), normalize,])
 
     def train_transforms(example_batch):
         """Apply _train_transforms across a batch."""

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -221,8 +221,7 @@ class DataTrainingArguments:
         },
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     keep_linebreaks: bool = field(
         default=True, metadata={"help": "Whether to keep line breaks when using TXT files or not."}
@@ -363,11 +362,7 @@ def main():
             extension = "text"
             dataset_args["keep_linebreaks"] = data_args.keep_linebreaks
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
-            **dataset_args,
+            extension, data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token, **dataset_args,
         )
         # If no validation data is there, validation_split_percentage will be used to divide the dataset.
         if "validation" not in raw_datasets.keys():
@@ -503,11 +498,7 @@ def main():
                 desc="Running tokenizer on dataset",
             )
         else:
-            tokenized_datasets = raw_datasets.map(
-                tokenize_function,
-                batched=True,
-                remove_columns=column_names,
-            )
+            tokenized_datasets = raw_datasets.map(tokenize_function, batched=True, remove_columns=column_names,)
 
     if data_args.block_size is None:
         block_size = tokenizer.model_max_length
@@ -558,10 +549,7 @@ def main():
                 desc=f"Grouping texts in chunks of {block_size}",
             )
         else:
-            lm_datasets = tokenized_datasets.map(
-                group_texts,
-                batched=True,
-            )
+            lm_datasets = tokenized_datasets.map(group_texts, batched=True,)
 
     if training_args.do_train:
         if "train" not in tokenized_datasets:

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -187,8 +187,7 @@ class DataTrainingArguments:
         },
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
@@ -359,10 +358,7 @@ def main():
         if extension == "txt":
             extension = "text"
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
         )
 
         # If no validation data is there, validation_split_percentage will be used to divide the dataset.
@@ -511,9 +507,7 @@ def main():
                 )
             else:
                 tokenized_datasets = raw_datasets.map(
-                    tokenize_function,
-                    batched=True,
-                    remove_columns=[text_column_name],
+                    tokenize_function, batched=True, remove_columns=[text_column_name],
                 )
     else:
         # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
@@ -533,11 +527,7 @@ def main():
                     desc="Running tokenizer on every text in dataset",
                 )
             else:
-                tokenized_datasets = raw_datasets.map(
-                    tokenize_function,
-                    batched=True,
-                    remove_columns=column_names,
-                )
+                tokenized_datasets = raw_datasets.map(tokenize_function, batched=True, remove_columns=column_names,)
 
         # Main data processing function that will concatenate all texts from our dataset and generate chunks of
         # max_seq_length.
@@ -572,10 +562,7 @@ def main():
                     desc=f"Grouping texts in chunks of {max_seq_length}",
                 )
             else:
-                tokenized_datasets = tokenized_datasets.map(
-                    group_texts,
-                    batched=True,
-                )
+                tokenized_datasets = tokenized_datasets.map(group_texts, batched=True,)
 
     if training_args.do_train:
         if "train" not in tokenized_datasets:

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -123,8 +123,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_seq_length: Optional[int] = field(
         default=None,
@@ -316,19 +315,11 @@ def main():
             data_files["validation"] = data_args.validation_file
         extension = data_args.train_file.split(".")[-1]
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
         )
     else:
         # Downloading and loading the swag dataset from the hub.
-        raw_datasets = load_dataset(
-            "swag",
-            "regular",
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
-        )
+        raw_datasets = load_dataset("swag", "regular", cache_dir=model_args.cache_dir, token=model_args.token,)
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading_datasets.html.
 

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -133,8 +133,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_seq_length: int = field(
         default=384,
@@ -331,11 +330,7 @@ def main():
             data_files["test"] = data_args.test_file
             extension = data_args.test_file.split(".")[-1]
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            field="data",
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, field="data", cache_dir=model_args.cache_dir, token=model_args.token,
         )
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading_datasets.html.

--- a/examples/question-answering/run_seq2seq_qa.py
+++ b/examples/question-answering/run_seq2seq_qa.py
@@ -146,8 +146,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_seq_length: int = field(
         default=384,
@@ -376,11 +375,7 @@ def main():
             data_files["test"] = data_args.test_file
             extension = data_args.test_file.split(".")[-1]
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            field="data",
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, field="data", cache_dir=model_args.cache_dir, token=model_args.token,
         )
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading_datasets.html.
@@ -485,10 +480,7 @@ def main():
     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
 
     def preprocess_squad_batch(
-        examples,
-        question_column: str,
-        context_column: str,
-        answer_column: str,
+        examples, question_column: str, context_column: str, answer_column: str,
     ) -> Tuple[List[str], List[str]]:
         questions = examples[question_column]
         contexts = examples[context_column]

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -90,8 +90,7 @@ class ModelArguments:
         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
     )
     cache_dir: Optional[str] = field(
-        default=None,
-        metadata={"help": "Where to store the pretrained models downloaded from huggingface.co"},
+        default=None, metadata={"help": "Where to store the pretrained models downloaded from huggingface.co"},
     )
     use_fast_tokenizer: bool = field(
         default=True,
@@ -180,8 +179,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_source_length: Optional[int] = field(
         default=1024,
@@ -427,10 +425,7 @@ def main():
             data_files["test"] = data_args.test_file
             extension = data_args.test_file.split(".")[-1]
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
         )
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading_datasets.html.

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -80,8 +80,7 @@ class DataTrainingArguments:
     """
 
     task_name: Optional[str] = field(
-        default=None,
-        metadata={"help": "The name of the task to train on: " + ", ".join(task_to_keys.keys())},
+        default=None, metadata={"help": "The name of the task to train on: " + ", ".join(task_to_keys.keys())},
     )
     dataset_name: Optional[str] = field(
         default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
@@ -305,10 +304,7 @@ def main():
     if data_args.task_name is not None:
         # Downloading and loading a dataset from the hub.
         raw_datasets = load_dataset(
-            "glue",
-            data_args.task_name,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            "glue", data_args.task_name, cache_dir=model_args.cache_dir, token=model_args.token,
         )
     elif data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
@@ -342,18 +338,12 @@ def main():
         if data_args.train_file.endswith(".csv"):
             # Loading a dataset from local csv files
             raw_datasets = load_dataset(
-                "csv",
-                data_files=data_files,
-                cache_dir=model_args.cache_dir,
-                token=model_args.token,
+                "csv", data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
             )
         else:
             # Loading a dataset from local json files
             raw_datasets = load_dataset(
-                "json",
-                data_files=data_files,
-                cache_dir=model_args.cache_dir,
-                token=model_args.token,
+                "json", data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
             )
     # See more about loading any type of standard or custom dataset at
     # https://huggingface.co/docs/datasets/loading_datasets.html.

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -255,11 +255,7 @@ def main():
     if training_args.do_train:
         if model_args.train_language is None:
             train_dataset = load_dataset(
-                "xnli",
-                model_args.language,
-                split="train",
-                cache_dir=model_args.cache_dir,
-                token=model_args.token,
+                "xnli", model_args.language, split="train", cache_dir=model_args.cache_dir, token=model_args.token,
             )
         else:
             train_dataset = load_dataset(
@@ -273,21 +269,13 @@ def main():
 
     if training_args.do_eval:
         eval_dataset = load_dataset(
-            "xnli",
-            model_args.language,
-            split="validation",
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            "xnli", model_args.language, split="validation", cache_dir=model_args.cache_dir, token=model_args.token,
         )
         label_list = eval_dataset.features["label"].names
 
     if training_args.do_predict:
         predict_dataset = load_dataset(
-            "xnli",
-            model_args.language,
-            split="test",
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            "xnli", model_args.language, split="test", cache_dir=model_args.cache_dir, token=model_args.token,
         )
         label_list = predict_dataset.features["label"].names
 

--- a/examples/text-generation/generation.py
+++ b/examples/text-generation/generation.py
@@ -31,10 +31,7 @@ if __name__ == "__main__":
     parent_parser.add_argument("model", type=str, help="The HF Hub model id or a local directory.")
     export_parser = subparsers.add_parser("export", parents=[parent_parser], help="Convert model to Neuron.")
     export_parser.add_argument(
-        "--batch_size",
-        type=int,
-        default=1,
-        help="The batch size.",
+        "--batch_size", type=int, default=1, help="The batch size.",
     )
     export_parser.add_argument("--sequence_length", type=int, help="The maximum sequence length.")
     export_parser.add_argument(

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -129,12 +129,10 @@ class DataTrainingArguments:
         default=None, metadata={"help": "The input training data file (a csv or JSON file)."}
     )
     validation_file: Optional[str] = field(
-        default=None,
-        metadata={"help": "An optional input evaluation data file to evaluate on (a csv or JSON file)."},
+        default=None, metadata={"help": "An optional input evaluation data file to evaluate on (a csv or JSON file)."},
     )
     test_file: Optional[str] = field(
-        default=None,
-        metadata={"help": "An optional input test data file to predict on (a csv or JSON file)."},
+        default=None, metadata={"help": "An optional input test data file to predict on (a csv or JSON file)."},
     )
     text_column_name: Optional[str] = field(
         default=None, metadata={"help": "The column name of text to input in the file (a csv or JSON file)."}
@@ -146,8 +144,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_seq_length: int = field(
         default=None,

--- a/examples/translation/run_translation.py
+++ b/examples/translation/run_translation.py
@@ -80,8 +80,7 @@ class ModelArguments:
         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
     )
     cache_dir: Optional[str] = field(
-        default=None,
-        metadata={"help": "Where to store the pretrained models downloaded from huggingface.co"},
+        default=None, metadata={"help": "Where to store the pretrained models downloaded from huggingface.co"},
     )
     use_fast_tokenizer: bool = field(
         default=True,
@@ -148,8 +147,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     preprocessing_num_workers: Optional[int] = field(
-        default=None,
-        metadata={"help": "The number of processes to use for the preprocessing."},
+        default=None, metadata={"help": "The number of processes to use for the preprocessing."},
     )
     max_source_length: Optional[int] = field(
         default=1024,
@@ -376,10 +374,7 @@ def main():
             data_files["test"] = data_args.test_file
             extension = data_args.test_file.split(".")[-1]
         raw_datasets = load_dataset(
-            extension,
-            data_files=data_files,
-            cache_dir=model_args.cache_dir,
-            token=model_args.token,
+            extension, data_files=data_files, cache_dir=model_args.cache_dir, token=model_args.token,
         )
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading.

--- a/notebooks/text-classification/scripts/train.py
+++ b/notebooks/text-classification/scripts/train.py
@@ -39,10 +39,7 @@ def parse_args():
     parser.add_argument("--lr", type=float, default=5e-5, help="Learning rate to use for training.")
     parser.add_argument("--seed", type=int, default=42, help="Seed to use for training.")
     parser.add_argument(
-        "--bf16",
-        type=bool,
-        default=False,
-        help="Whether to use bf16.",
+        "--bf16", type=bool, default=False, help="Whether to use bf16.",
     )
     parser.add_argument(
         "--hf_token",

--- a/notebooks/text-generation/scripts/run_clm.py
+++ b/notebooks/text-generation/scripts/run_clm.py
@@ -65,8 +65,7 @@ class ScriptArguments:
         },
     )
     dataset_path: str = field(
-        metadata={"help": "Path to the preprocessed and tokenized dataset."},
-        default=None,
+        metadata={"help": "Path to the preprocessed and tokenized dataset."}, default=None,
     )
 
 

--- a/notebooks/text-generation/scripts/utils/pack_dataset.py
+++ b/notebooks/text-generation/scripts/utils/pack_dataset.py
@@ -34,9 +34,6 @@ def pack_dataset(dataset, chunk_length=2048):
         return result
 
     # tokenize and chunk dataset
-    lm_dataset = dataset.map(
-        partial(chunk, chunk_length=chunk_length),
-        batched=True,
-    )
+    lm_dataset = dataset.map(partial(chunk, chunk_length=chunk_length), batched=True,)
     print(f"Total number of samples: {len(lm_dataset)}")
     return lm_dataset

--- a/optimum/commands/export/neuron.py
+++ b/optimum/commands/export/neuron.py
@@ -119,19 +119,13 @@ def parse_args_neuron(parser: "ArgumentParser"):
     input_group = parser.add_argument_group("Input shapes")
     doc_input = "that the Neuron-cc compiler exported model will be able to take as input."
     input_group.add_argument(
-        "--batch_size",
-        type=int,
-        help=f"Batch size {doc_input}",
+        "--batch_size", type=int, help=f"Batch size {doc_input}",
     )
     input_group.add_argument(
-        "--sequence_length",
-        type=int,
-        help=f"Sequence length {doc_input}",
+        "--sequence_length", type=int, help=f"Sequence length {doc_input}",
     )
     input_group.add_argument(
-        "--num_choices",
-        type=int,
-        help=f"Only for the multiple-choice task. Num choices {doc_input}",
+        "--num_choices", type=int, help=f"Only for the multiple-choice task. Num choices {doc_input}",
     )
 
 

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -145,11 +145,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
-        "--lora_weight_names",
-        default=None,
-        nargs="*",
-        type=str,
-        help="List of lora weights file names.",
+        "--lora_weight_names", default=None, nargs="*", type=str, help="List of lora weights file names.",
     )
     optional_group.add_argument(
         "--lora_adapter_names",
@@ -159,11 +155,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help="List of the adapter names to be used for referencing the loaded adapter models.",
     )
     optional_group.add_argument(
-        "--lora_scales",
-        default=None,
-        nargs="*",
-        type=float,
-        help="List of scaling factors for the lora adapters.",
+        "--lora_scales", default=None, nargs="*", type=float, help="List of scaling factors for the lora adapters.",
     )
     optional_group.add_argument(
         "--controlnet_ids",
@@ -181,9 +173,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
     input_group = parser.add_argument_group("Input shapes")
     doc_input = "that the Neuronx-cc compiler exported model will be able to take as input."
     input_group.add_argument(
-        "--batch_size",
-        type=int,
-        help=f"Batch size {doc_input}",
+        "--batch_size", type=int, help=f"Batch size {doc_input}",
     )
     input_group.add_argument(
         "--text_batch_size",
@@ -196,45 +186,28 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help=f"Batch size of the vision inputs {doc_input} (Only applied for multi-modal models)",
     )
     input_group.add_argument(
-        "--sequence_length",
-        type=int,
-        help=f"Sequence length {doc_input}",
+        "--sequence_length", type=int, help=f"Sequence length {doc_input}",
     )
     input_group.add_argument(
-        "--num_beams",
-        type=int,
-        default=1,
-        help=f"Number of beams for beam search {doc_input}",
+        "--num_beams", type=int, default=1, help=f"Number of beams for beam search {doc_input}",
     )
     input_group.add_argument(
-        "--num_choices",
-        type=int,
-        help=f"Only for the multiple-choice task. Num choices {doc_input}",
+        "--num_choices", type=int, help=f"Only for the multiple-choice task. Num choices {doc_input}",
     )
     input_group.add_argument(
-        "--num_channels",
-        type=int,
-        help=f"Image tasks only. Number of channels {doc_input}",
+        "--num_channels", type=int, help=f"Image tasks only. Number of channels {doc_input}",
     )
     input_group.add_argument(
-        "--width",
-        type=int,
-        help=f"Image tasks only. Width {doc_input}",
+        "--width", type=int, help=f"Image tasks only. Width {doc_input}",
     )
     input_group.add_argument(
-        "--height",
-        type=int,
-        help=f"Image tasks only. Height {doc_input}",
+        "--height", type=int, help=f"Image tasks only. Height {doc_input}",
     )
     input_group.add_argument(
-        "--image_size",
-        type=int,
-        help="Image tasks only. Size (resolution) of each image.",
+        "--image_size", type=int, help="Image tasks only. Size (resolution) of each image.",
     )
     input_group.add_argument(
-        "--patch_size",
-        type=int,
-        help="Image tasks only. Size (resolution) of patch.",
+        "--patch_size", type=int, help="Image tasks only. Size (resolution) of patch.",
     )
     input_group.add_argument(
         "--num_images_per_prompt",
@@ -243,9 +216,7 @@ def parse_args_neuronx(parser: "ArgumentParser"):
         help=f"Stable diffusion only. Number of images per prompt {doc_input}",
     )
     input_group.add_argument(
-        "--audio_sequence_length",
-        type=int,
-        help=f"Audio tasks only. Audio sequence length {doc_input}",
+        "--audio_sequence_length", type=int, help=f"Audio tasks only. Audio sequence length {doc_input}",
     )
 
     level_group = parser.add_mutually_exclusive_group()

--- a/optimum/commands/neuron/base.py
+++ b/optimum/commands/neuron/base.py
@@ -27,11 +27,7 @@ logger.setLevel(logging.INFO)
 class NeuronCommand(BaseOptimumCLICommand):
     COMMAND = CommandInfo(name="neuron", help="Optimum Neuron CLI")
     SUBCOMMANDS = (
-        CommandInfo(
-            name="cache",
-            help="Manage the Neuron cache.",
-            subcommand_class=CustomCacheRepoCommand,
-        ),
+        CommandInfo(name="cache", help="Manage the Neuron cache.", subcommand_class=CustomCacheRepoCommand,),
         CommandInfo(
             name="consolidate",
             help="Consolidate checkpoints that were produced during a parallel training setting.",

--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -181,9 +181,7 @@ class LookupRepoCommand(BaseOptimumCLICommand):
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
         parser.add_argument(
-            "model_id",
-            type=str,
-            help="The model_id to lookup cached versions for.",
+            "model_id", type=str, help="The model_id to lookup cached versions for.",
         )
         parser.add_argument(
             "--mode",

--- a/optimum/commands/neuron/subcommands.py
+++ b/optimum/commands/neuron/subcommands.py
@@ -32,14 +32,10 @@ class ConsolidateCommand(BaseOptimumCLICommand):
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
         parser.add_argument(
-            "checkpoint_dir",
-            type=str,
-            help="The path to the directory containing the checkpoints.",
+            "checkpoint_dir", type=str, help="The path to the directory containing the checkpoints.",
         )
         parser.add_argument(
-            "output_dir",
-            type=str,
-            help="The path to the output directory containing the consolidated checkpoint.",
+            "output_dir", type=str, help="The path to the output directory containing the consolidated checkpoint.",
         )
         parser.add_argument(
             "-f",
@@ -54,8 +50,6 @@ class ConsolidateCommand(BaseOptimumCLICommand):
         checkpoint_format = "safetensors" if self.args.format == "safetensors" else "pytorch"
         logger.info(f"Consolidating checkpoints from {self.args.checkpoint_dir} to the {checkpoint_format} format...")
         consolidate_model_parallel_checkpoints_to_unified_checkpoint(
-            self.args.checkpoint_dir,
-            self.args.output_dir,
-            save_format=self.args.format,
+            self.args.checkpoint_dir, self.args.output_dir, save_format=self.args.format,
         )
         logger.info(f"Consolidated checkpoint saved at {self.args.output_dir}")

--- a/optimum/exporters/neuron/__init__.py
+++ b/optimum/exporters/neuron/__init__.py
@@ -54,9 +54,4 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(
-        __name__,
-        globals()["__file__"],
-        _import_structure,
-        module_spec=__spec__,
-    )
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__,)

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -38,9 +38,7 @@ from ...neuron.utils import (
     is_neuronx_available,
 )
 from ...neuron.utils.misc import maybe_save_preprocessors
-from ...neuron.utils.version_utils import (
-    check_compiler_compatibility_for_stable_diffusion,
-)
+from ...neuron.utils.version_utils import check_compiler_compatibility_for_stable_diffusion
 from ...utils import is_diffusers_available, logging
 from ..error_utils import AtolError, OutputMatchError, ShapeError
 from ..tasks import TasksManager
@@ -127,10 +125,7 @@ def get_neuron_config_class(task: str, model_id: str) -> NeuronConfig:
         model_type = model_type + "-encoder"
 
     neuron_config_constructor = TasksManager.get_exporter_config_constructor(
-        model_type=model_type,
-        exporter="neuron",
-        task=task,
-        library_name="transformers",
+        model_type=model_type, exporter="neuron", task=task, library_name="transformers",
     )
     return neuron_config_constructor
 
@@ -180,9 +175,7 @@ def parse_optlevel(args: argparse.Namespace) -> Dict[str, bool]:
     return optlevel
 
 
-def normalize_stable_diffusion_input_shapes(
-    args: argparse.Namespace,
-) -> Dict[str, Dict[str, int]]:
+def normalize_stable_diffusion_input_shapes(args: argparse.Namespace,) -> Dict[str, Dict[str, int]]:
     args = vars(args) if isinstance(args, argparse.Namespace) else args
     mandatory_axes = set(getattr(inspect.getfullargspec(build_stable_diffusion_components_mandatory_shapes), "args"))
     # Remove `sequence_length` as diffusers will pad it to the max and remove number of channels.
@@ -309,10 +302,7 @@ def get_submodels_and_neuron_configs(
                 f"`output_attentions` and `output_hidden_states` are not supported by the {task} task yet."
             )
         neuron_config_constructor = TasksManager.get_exporter_config_constructor(
-            model=model,
-            exporter="neuron",
-            task=task,
-            library_name=library_name,
+            model=model, exporter="neuron", task=task, library_name=library_name,
         )
         input_shapes = check_mandatory_input_shapes(neuron_config_constructor, task, input_shapes)
         neuron_config = neuron_config_constructor(model.config, dynamic_batch_size=dynamic_batch_size, **input_shapes)
@@ -364,9 +354,7 @@ def _get_submodels_and_neuron_configs_for_stable_diffusion(
             "Stable diffusion export is not supported by neuron-cc on inf1, please use neuronx-cc on either inf2/trn1 instead."
         )
     input_shapes = infer_stable_diffusion_shapes_from_diffusers(
-        input_shapes=input_shapes,
-        model=model,
-        has_controlnets=controlnet_ids is not None,
+        input_shapes=input_shapes, model=model, has_controlnets=controlnet_ids is not None,
     )
 
     # Saving the model config and preprocessor as this is needed sometimes.
@@ -636,10 +624,7 @@ def main_export(
 
 
 def decoder_export(
-    model_name_or_path: str,
-    output: Union[str, Path],
-    trust_remote_code: Optional[bool] = None,
-    **kwargs,
+    model_name_or_path: str, output: Union[str, Path], trust_remote_code: Optional[bool] = None, **kwargs,
 ):
     from ...neuron import NeuronModelForCausalLM
 

--- a/optimum/exporters/neuron/config.py
+++ b/optimum/exporters/neuron/config.py
@@ -148,9 +148,7 @@ class TextSeq2SeqNeuronConfig(NeuronDefaultConfig):
             self.task, self._normalized_config, **kwargs
         )
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
-            self.task,
-            self._normalized_config,
-            **kwargs,
+            self.task, self._normalized_config, **kwargs,
         )
         dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
             self.task,

--- a/optimum/exporters/neuron/model_configs.py
+++ b/optimum/exporters/neuron/model_configs.py
@@ -440,11 +440,7 @@ class Wav2Vec2NeuronConfig(AudioNeuronConfig):
 
 
 @register_in_tasks_manager(
-    "audio-spectrogram-transformer",
-    *[
-        "feature-extraction",
-        "audio-classification",
-    ],
+    "audio-spectrogram-transformer", *["feature-extraction", "audio-classification",],
 )
 class ASTNeuronConfig(AudioNeuronConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
@@ -458,12 +454,7 @@ class ASTNeuronConfig(AudioNeuronConfig):
 
 
 @register_in_tasks_manager(
-    "hubert",
-    *[
-        "feature-extraction",
-        "automatic-speech-recognition",
-        "audio-classification",
-    ],
+    "hubert", *["feature-extraction", "automatic-speech-recognition", "audio-classification",],
 )
 class HubertNeuronConfig(Wav2Vec2NeuronConfig):
     @property
@@ -501,12 +492,7 @@ class HubertNeuronConfig(Wav2Vec2NeuronConfig):
 
 
 @register_in_tasks_manager(
-    "unispeech",
-    *[
-        "feature-extraction",
-        "automatic-speech-recognition",
-        "audio-classification",
-    ],
+    "unispeech", *["feature-extraction", "automatic-speech-recognition", "audio-classification",],
 )
 class UniSpeechNeuronConfig(Wav2Vec2NeuronConfig):
     pass
@@ -713,10 +699,7 @@ class VaeEncoderNeuronConfig(VisionNeuronConfig):
     ATOL_FOR_VALIDATION = 1e-3
     MODEL_TYPE = "vae-encoder"
 
-    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
-        num_channels="in_channels",
-        allow_new=True,
-    )
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(num_channels="in_channels", allow_new=True,)
 
     @property
     def inputs(self) -> List[str]:
@@ -740,10 +723,7 @@ class VaeDecoderNeuronConfig(VisionNeuronConfig):
     ATOL_FOR_VALIDATION = 1e-3
     MODEL_TYPE = "vae-decoder"
 
-    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
-        num_channels="latent_channels",
-        allow_new=True,
-    )
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(num_channels="latent_channels", allow_new=True,)
 
     @property
     def inputs(self) -> List[str]:
@@ -754,10 +734,7 @@ class VaeDecoderNeuronConfig(VisionNeuronConfig):
         return ["sample"]
 
     def patch_model_for_export(
-        self,
-        model: "VaeDecoder",
-        dummy_inputs: Dict[str, torch.Tensor],
-        **kwargs,
+        self, model: "VaeDecoder", dummy_inputs: Dict[str, torch.Tensor], **kwargs,
     ):
         return super().patch_model_for_export(model=model, dummy_inputs=dummy_inputs, forward_with_tuple=True)
 
@@ -837,10 +814,7 @@ class T5DecoderNeuronConfig(TextSeq2SeqNeuronConfig):
     def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_inputs_generators = super()._create_dummy_input_generator_classes(**kwargs)
         dummy_beam_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[-1](
-            self.task,
-            self._normalized_config,
-            num_beams=kwargs.pop("num_beams", 1),
-            **kwargs,
+            self.task, self._normalized_config, num_beams=kwargs.pop("num_beams", 1), **kwargs,
         )
         dummy_inputs_generators.append(dummy_beam_values_generator)
         return dummy_inputs_generators

--- a/optimum/exporters/neuron/model_wrappers.py
+++ b/optimum/exporters/neuron/model_wrappers.py
@@ -120,11 +120,7 @@ class T5EncoderWrapper(torch.nn.Module):
     """Wrapper to trace the encoder and the kv cache initialization in the decoder."""
 
     def __init__(
-        self,
-        model: "PreTrainedModel",
-        num_beams: int = 1,
-        device: str = "xla",
-        tp_degree: Optional[int] = None,
+        self, model: "PreTrainedModel", num_beams: int = 1, device: str = "xla", tp_degree: Optional[int] = None,
     ):
         super().__init__()
         self.model = model
@@ -343,7 +339,7 @@ class T5DecoderWrapper(torch.nn.Module):
         if self.config.tie_word_embeddings:
             # Rescale output before projecting on vocab
             # See https://github.com/tensorflow/mesh/blob/fa19d69eafc9a482aff0b59ddd96b025c0cb207d/mesh_tensorflow/transformer/transformer.py#L586
-            last_hidden_state = last_hidden_state * (self.model.config.d_model**-0.5)
+            last_hidden_state = last_hidden_state * (self.model.config.d_model ** -0.5)
 
         lm_logits = self.model.lm_head(last_hidden_state)
 
@@ -421,10 +417,7 @@ class SentenceTransformersCLIPNeuronWrapper(torch.nn.Module):
         vision_outputs = self.model[0].model.vision_model(pixel_values=pixel_values)
         image_embeds = self.model[0].model.visual_projection(vision_outputs[1])
 
-        text_outputs = self.model[0].model.text_model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-        )
+        text_outputs = self.model[0].model.text_model(input_ids=input_ids, attention_mask=attention_mask,)
         text_embeds = self.model[0].model.text_projection(text_outputs[1])
 
         if len(self.model) > 1:

--- a/optimum/exporters/neuron/utils.py
+++ b/optimum/exporters/neuron/utils.py
@@ -179,10 +179,7 @@ def get_stable_diffusion_models_for_export(
     if DIFFUSION_MODEL_TEXT_ENCODER_NAME in models_for_export:
         text_encoder = models_for_export[DIFFUSION_MODEL_TEXT_ENCODER_NAME]
         text_encoder_config_constructor = TasksManager.get_exporter_config_constructor(
-            model=text_encoder,
-            exporter="neuron",
-            task="feature-extraction",
-            library_name=library_name,
+            model=text_encoder, exporter="neuron", task="feature-extraction", library_name=library_name,
         )
         text_encoder_neuron_config = text_encoder_config_constructor(
             text_encoder.config,
@@ -214,17 +211,10 @@ def get_stable_diffusion_models_for_export(
     # U-NET
     unet = models_for_export[DIFFUSION_MODEL_UNET_NAME]
     unet_neuron_config_constructor = TasksManager.get_exporter_config_constructor(
-        model=unet,
-        exporter="neuron",
-        task="semantic-segmentation",
-        model_type="unet",
-        library_name=library_name,
+        model=unet, exporter="neuron", task="semantic-segmentation", model_type="unet", library_name=library_name,
     )
     unet_neuron_config = unet_neuron_config_constructor(
-        unet.config,
-        task="semantic-segmentation",
-        dynamic_batch_size=dynamic_batch_size,
-        **unet_input_shapes,
+        unet.config, task="semantic-segmentation", dynamic_batch_size=dynamic_batch_size, **unet_input_shapes,
     )
     is_stable_diffusion_xl = isinstance(
         pipeline, (StableDiffusionXLImg2ImgPipeline, StableDiffusionXLInpaintPipeline, StableDiffusionXLPipeline)
@@ -497,27 +487,18 @@ def get_encoder_decoder_models_for_export(
     # Encoder
     model_type = getattr(model.config, "model_type") + "-encoder"
     encoder_config_constructor = TasksManager.get_exporter_config_constructor(
-        exporter="neuron",
-        model_type=model_type,
-        task=task,
-        library_name="transformers",
+        exporter="neuron", model_type=model_type, task=task, library_name="transformers",
     )
     check_mandatory_input_shapes(encoder_config_constructor, task, input_shapes)
     encoder_neuron_config = encoder_config_constructor(
-        config=model.config,
-        task=task,
-        dynamic_batch_size=dynamic_batch_size,
-        **input_shapes,
+        config=model.config, task=task, dynamic_batch_size=dynamic_batch_size, **input_shapes,
     )
     models_for_export[ENCODER_NAME] = (model, encoder_neuron_config)
 
     # Decoder
     model_type = getattr(model.config, "model_type") + "-decoder"
     decoder_config_constructor = TasksManager.get_exporter_config_constructor(
-        exporter="neuron",
-        model_type=model_type,
-        task=task,
-        library_name="transformers",
+        exporter="neuron", model_type=model_type, task=task, library_name="transformers",
     )
     check_mandatory_input_shapes(encoder_config_constructor, task, input_shapes)
     decoder_neuron_config = decoder_config_constructor(

--- a/optimum/neuron/__init__.py
+++ b/optimum/neuron/__init__.py
@@ -62,12 +62,7 @@ _import_structure = {
     ],
     "modeling_decoder": ["NeuronDecoderModel"],
     "modeling_seq2seq": ["NeuronModelForSeq2SeqLM"],
-    "accelerate": [
-        "NeuronAccelerator",
-        "NeuronAcceleratorState",
-        "NeuronPartialState",
-        "ModelParallelismPlugin",
-    ],
+    "accelerate": ["NeuronAccelerator", "NeuronAcceleratorState", "NeuronPartialState", "ModelParallelismPlugin",],
     "pipelines": ["pipeline"],
     "utils": ["NeuronSFTConfig", "get_peft_model"],
 }
@@ -116,12 +111,7 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(
-        __name__,
-        globals()["__file__"],
-        _import_structure,
-        module_spec=__spec__,
-    )
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__,)
 
 
 from .utils import is_neuron_available, is_neuronx_available, patch_transformers_for_neuron_sdk

--- a/optimum/neuron/accelerate/utils/dataclasses.py
+++ b/optimum/neuron/accelerate/utils/dataclasses.py
@@ -78,9 +78,7 @@ class ModelParallelismPlugin:
         return self.tensor_parallel_size > 1 or self.pipeline_parallel_size > 1
 
     def parallelize_model(
-        self,
-        model: "PreTrainedModel",
-        device: Optional["torch.device"] = None,
+        self, model: "PreTrainedModel", device: Optional["torch.device"] = None,
     ) -> Union["PreTrainedModel", Tuple["PreTrainedModel", Dict[int, "torch.nn.Parameter"]]]:
         parallelizer = ParallelizersManager.parallelizer_for_model(model)
         parallelized_model = parallelizer.parallelize(

--- a/optimum/neuron/distributed/base.py
+++ b/optimum/neuron/distributed/base.py
@@ -404,9 +404,7 @@ class Parallelizer(ABC):
                     modules_to_initialize[module].append(attribute_name)
 
                 setattr(
-                    module,
-                    attribute_name,
-                    new_parameter,
+                    module, attribute_name, new_parameter,
                 )
                 tied_weights[parameter] = new_parameter
                 new_parameters.add(new_parameter)
@@ -718,8 +716,7 @@ class Parallelizer(ABC):
 
             # 2. Taking care of scattering / gathering on the sequence axis in the model via the IOSequenceParallelizer.
             io_sequence_parallelizer = IOSequenceParallelizer(
-                sequence_parallel_enabled,
-                sequence_collective_op_infos=sequence_collective_op_infos,
+                sequence_parallel_enabled, sequence_collective_op_infos=sequence_collective_op_infos,
             )
             io_sequence_parallelizer.sequence_parallelize(model)
 
@@ -1025,10 +1022,7 @@ class Parallelizer(ABC):
             raise FileNotFoundError(f"Could not find a sharded checkpoint directory under {load_dir.as_posix()}.")
 
         neuronx_distributed.trainer.load_checkpoint(
-            load_dir.as_posix(),
-            tag=MODEL_PARALLEL_SHARDS_DIR_NAME,
-            model=model,
-            optimizer=optimizer,
+            load_dir.as_posix(), tag=MODEL_PARALLEL_SHARDS_DIR_NAME, model=model, optimizer=optimizer,
         )
 
     @classmethod

--- a/optimum/neuron/distributed/checkpointing.py
+++ b/optimum/neuron/distributed/checkpointing.py
@@ -145,7 +145,7 @@ def consolidate_tensor_parallel_checkpoints(
         # This might not be the case anymore when `ParameterMetadata` uses slices.
         sharded_metadata = sharded_metadatas[name]
         if sharded_metadata.is_tied:
-            consolidated_state_dict[original_name] = state_dicts[0][name].to("cpu")
+            consolidated_state_dict[original_name] = state_dicts[0][name].to("cpu").contiguous()
         else:
             # Ensure that all tensors are contiguous before concatenating or further processing
             weights = [state_dict[name].contiguous() for state_dict in state_dicts]
@@ -154,7 +154,7 @@ def consolidate_tensor_parallel_checkpoints(
             full_weight = torch.cat(
                 weights,
                 dim=sharded_metadata.partition_dim,
-            ).contiguous()  # Ensure the result is also contiguous
+            ).to("cpu").contiguous()  # Ensure the result is also contiguous
             
             if weight_name in ["weight_k", "weight_v", "bias_k", "bias_v"]:
                 full_weight = (

--- a/optimum/neuron/distributed/checkpointing.py
+++ b/optimum/neuron/distributed/checkpointing.py
@@ -35,12 +35,8 @@ from .utils import MODEL_PARALLEL_SHARDS_DIR_NAME, ParameterMetadata, compute_qu
 
 
 if is_peft_available():
-    from peft.utils.constants import (
-        SAFETENSORS_WEIGHTS_NAME as PEFT_SAFETENSORS_WEIGHTS_NAME,
-    )
-    from peft.utils.constants import (
-        WEIGHTS_NAME as PEFT_WEIGHTS_NAME,
-    )
+    from peft.utils.constants import SAFETENSORS_WEIGHTS_NAME as PEFT_SAFETENSORS_WEIGHTS_NAME
+    from peft.utils.constants import WEIGHTS_NAME as PEFT_WEIGHTS_NAME
 else:
     PEFT_SAFETENSORS_WEIGHTS_NAME = PEFT_WEIGHTS_NAME = ""
 
@@ -151,11 +147,10 @@ def consolidate_tensor_parallel_checkpoints(
             weights = [state_dict[name].contiguous() for state_dict in state_dicts]
             tp_size = len(weights)
 
-            full_weight = torch.cat(
-                weights,
-                dim=sharded_metadata.partition_dim,
-            ).to("cpu").contiguous()  # Ensure the result is also contiguous
-            
+            full_weight = (
+                torch.cat(weights, dim=sharded_metadata.partition_dim,).to("cpu").contiguous()
+            )  # Ensure the result is also contiguous
+
             if weight_name in ["weight_k", "weight_v", "bias_k", "bias_v"]:
                 full_weight = (
                     torch.chunk(full_weight, gqa_qkv_metadata["kv_size_multiplier"], dim=0)[0].detach().clone()

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -391,9 +391,7 @@ class LLamaParallelMLP(ParallelMLP):
             layer_to_fully_qualified_name = {id(module): name for name, module in model.named_modules()}
             layer_qualified_name = layer_to_fully_qualified_name[id(layer)]
             linear_layer_weight_info, linear_layer_bias_weight_info = get_linear_weight_info(
-                weight_map,
-                f"{layer_qualified_name}.{attribute_name}",
-                device=device,
+                weight_map, f"{layer_qualified_name}.{attribute_name}", device=device,
             )
 
         setattr(
@@ -670,9 +668,7 @@ class MistralParallelMLP(ParallelMLP):
             layer_to_fully_qualified_name = {id(module): name for name, module in model.named_modules()}
             layer_qualified_name = layer_to_fully_qualified_name[id(layer)]
             linear_layer_weight_info, linear_layer_bias_weight_info = get_linear_weight_info(
-                weight_map,
-                f"{layer_qualified_name}.{attribute_name}",
-                device=device,
+                weight_map, f"{layer_qualified_name}.{attribute_name}", device=device,
             )
 
         setattr(

--- a/optimum/neuron/distributed/encoder_decoder_models.py
+++ b/optimum/neuron/distributed/encoder_decoder_models.py
@@ -140,9 +140,7 @@ class T5ParallelMLP(ParallelMLP):
             if weight_map is not None:
                 layer_qualified_name = layer_to_fully_qualified_name[id(module)]
                 linear_layer_weight_info, linear_layer_bias_weight_info = get_linear_weight_info(
-                    weight_map,
-                    f"{layer_qualified_name}.{attribute_name}",
-                    device=device,
+                    weight_map, f"{layer_qualified_name}.{attribute_name}", device=device,
                 )
 
             setattr(

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -512,11 +512,7 @@ def embedding_to_parallel_embedding(
     with torch.no_grad():
         if embedding_weight_info is not None:
             weight_data = load_tensor_for_weight(
-                embedding_weight_info,
-                tensor_slices=(
-                    (tp_rank * row_size, (tp_rank + 1) * row_size),
-                    None,
-                ),
+                embedding_weight_info, tensor_slices=((tp_rank * row_size, (tp_rank + 1) * row_size), None,),
             )
             parallel_embedding_layer.weight.copy_(weight_data)
             mark_parameter_init_status_during_parallelization(parallel_embedding_layer.weight, True)
@@ -576,10 +572,7 @@ def get_linear_weight_info(
     linear_layer_bias_filename = weight_map.get(linear_layer_bias_qualified_name, None)
     if linear_layer_bias_filename is not None:
         linear_layer_bias_weight_info = WeightInformation(
-            linear_layer_bias_filename,
-            linear_layer_bias_qualified_name,
-            weight_map=weight_map,
-            device=device,
+            linear_layer_bias_filename, linear_layer_bias_qualified_name, weight_map=weight_map, device=device,
         )
     else:
         linear_layer_bias_weight_info = None
@@ -837,9 +830,7 @@ def maybe_load_weights_to_gqa_qkv_column_parallel_linear(
         elif try_from_original_layer:
             orig_layer_name, _ = orig_name.rsplit(".", maxsplit=1)
             maybe_load_linear_weight_to_gqa_qkv_column_parallel_linear(
-                layer,
-                weight_name,
-                linear_layer=model.get_submodule(orig_layer_name),
+                layer, weight_name, linear_layer=model.get_submodule(orig_layer_name),
             )
 
 
@@ -920,10 +911,7 @@ def maybe_load_linear_weight_to_parallel_linear(
                 if linear_layer_weight_info is not None:
                     weight_data = load_tensor_for_weight(
                         linear_layer_weight_info,
-                        tensor_slices=(
-                            None,
-                            (tp_rank * col_size, (tp_rank + 1) * col_size),
-                        ),
+                        tensor_slices=(None, (tp_rank * col_size, (tp_rank + 1) * col_size),),
                     )
                     parallel_linear_layer.weight.copy_(weight_data)
                     mark_parameter_init_status_during_parallelization(parallel_linear_layer.weight, True)
@@ -952,10 +940,7 @@ def maybe_load_linear_weight_to_parallel_linear(
                 if linear_layer_weight_info is not None:
                     weight_data = load_tensor_for_weight(
                         linear_layer_weight_info,
-                        tensor_slices=(
-                            (tp_rank * row_size, (tp_rank + 1) * row_size),
-                            None,
-                        ),
+                        tensor_slices=((tp_rank * row_size, (tp_rank + 1) * row_size), None,),
                     )
                     parallel_linear_layer.weight.copy_(weight_data)
                     mark_parameter_init_status_during_parallelization(parallel_linear_layer.weight, True)
@@ -974,15 +959,9 @@ def maybe_load_linear_weight_to_parallel_linear(
                         if parallel_linear_layer.gather_output:
                             tensor_slices = (None,)
                         else:
-                            tensor_slices = (
-                                (
-                                    tp_rank * row_size,
-                                    (tp_rank + 1) * row_size,
-                                ),
-                            )
+                            tensor_slices = ((tp_rank * row_size, (tp_rank + 1) * row_size,),)
                         bias_weight_data = load_tensor_for_weight(
-                            linear_layer_bias_weight_info,
-                            tensor_slices=tensor_slices,
+                            linear_layer_bias_weight_info, tensor_slices=tensor_slices,
                         )
                         parallel_linear_layer.bias.copy_(bias_weight_data)
                         mark_parameter_init_status_during_parallelization(parallel_linear_layer.bias, True)
@@ -1388,7 +1367,6 @@ def parameter_can_be_initialized(model: torch.nn.Module, parent_module: torch.nn
 
 
 def create_wrapper_for_resize_token_embedding(orig_resize_token_embeddings):
-
     @functools.wraps(orig_resize_token_embeddings)
     def wrapper(
         self, new_num_tokens: Optional[int] = None, pad_to_multiple_of: Optional[int] = None
@@ -1401,9 +1379,7 @@ def create_wrapper_for_resize_token_embedding(orig_resize_token_embeddings):
             if embeddings_qualified_name in self._weight_map:
                 filename = self._weight_map[embeddings_qualified_name]
                 embeddings_weight_info = WeightInformation(
-                    filename=filename,
-                    qualified_name=embeddings_qualified_name,
-                    weight_map=self._weight_map,
+                    filename=filename, qualified_name=embeddings_qualified_name, weight_map=self._weight_map,
                 )
                 setattr(embeddings, "weight", torch.nn.Parameter(load_tensor_for_weight(embeddings_weight_info)))
                 self._weight_map.pop(embeddings_qualified_name)
@@ -1597,10 +1573,7 @@ def from_pretrained_for_mp(
 
     if _adapter_model_path is not None:
         model.load_adapter(
-            _adapter_model_path,
-            adapter_name=adapter_name,
-            token=token,
-            adapter_kwargs=adapter_kwargs,
+            _adapter_model_path, adapter_name=adapter_name, token=token, adapter_kwargs=adapter_kwargs,
         )
 
     model._weight_map = weight_map
@@ -1711,10 +1684,7 @@ def get_parameters_tp_metadata(named_parameters: Dict[str, "torch.nn.Parameter"]
     tp_metadata = {}
     for name, param in named_parameters.items():
         if getattr(param, "tensor_model_parallel", False):
-            param_metadata = ParameterMetadata(
-                "sharded",
-                partition_dim=param.partition_dim,
-            )
+            param_metadata = ParameterMetadata("sharded", partition_dim=param.partition_dim,)
         else:
             param_metadata = ParameterMetadata("tied")
         tp_metadata[name] = param_metadata

--- a/optimum/neuron/generation/utils.py
+++ b/optimum/neuron/generation/utils.py
@@ -34,9 +34,7 @@ if is_torch_xla_available():
 from transformers import GenerationMixin
 from transformers.generation.beam_search import BeamScorer, BeamSearchScorer
 from transformers.generation.configuration_utils import GenerationConfig
-from transformers.generation.logits_process import (
-    LogitsProcessorList,
-)
+from transformers.generation.logits_process import LogitsProcessorList
 from transformers.generation.stopping_criteria import (
     MaxLengthCriteria,
     MaxTimeCriteria,
@@ -210,9 +208,7 @@ def _get_fwd_for_general_sampling(
             and outputs["logits"].shape[-1] != vocab_size
         ):
             outputs["logits"] = xm.all_gather(
-                outputs["logits"],
-                dim=-1,
-                groups=parallel_state.get_tensor_model_parallel_group(as_list=True),
+                outputs["logits"], dim=-1, groups=parallel_state.get_tensor_model_parallel_group(as_list=True),
             )
         xm.mark_step()
 
@@ -238,10 +234,7 @@ class GeneralNeuronGenerationMixin(GenerationMixin):
 
     @torch.no_grad()
     def generate(
-        self,
-        inputs: Optional[torch.Tensor] = None,
-        generation_config: Optional[GenerationConfig] = None,
-        **kwargs,
+        self, inputs: Optional[torch.Tensor] = None, generation_config: Optional[GenerationConfig] = None, **kwargs,
     ):
         # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
         self._validate_model_class()
@@ -296,11 +289,7 @@ class GeneralNeuronGenerationMixin(GenerationMixin):
         original_forward = copy.deepcopy(self.forward)
         try:
             general_forward = _get_fwd_for_general_sampling(
-                self.forward,
-                generation_config,
-                self.config.is_encoder_decoder,
-                self.config.vocab_size,
-                self.device,
+                self.forward, generation_config, self.config.is_encoder_decoder, self.config.vocab_size, self.device,
             )
             self.forward = general_forward
             if generation_config.use_cache:
@@ -357,11 +346,7 @@ class NeuronGenerationMixin(GenerationMixin):
 
     @staticmethod
     def _initialize_attention(
-        model_kwargs,
-        num_padding_values,
-        batch_size,
-        device,
-        is_encoder_decoder,
+        model_kwargs, num_padding_values, batch_size, device, is_encoder_decoder,
     ):
         """Initializes the appropriate attention mask -- encoder-decoder models use `decoder_attention_mask`"""
         if is_encoder_decoder:
@@ -763,9 +748,7 @@ class NeuronGenerationMixin(GenerationMixin):
             [
                 input_ids,
                 (
-                    torch.ones(
-                        (batch_size, (generation_config.max_length - input_ids_seq_length)),
-                    )
+                    torch.ones((batch_size, (generation_config.max_length - input_ids_seq_length)),)
                     .long()
                     .to(input_ids.device)
                 )

--- a/optimum/neuron/modeling.py
+++ b/optimum/neuron/modeling.py
@@ -36,9 +36,7 @@ from transformers import (
     AutoModelForTokenClassification,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
-from transformers.generation import (
-    GenerationMixin,
-)
+from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutput,
@@ -246,9 +244,9 @@ class NeuronModelForSentenceTransformers(NeuronTracedModel):
         neuron_inputs = {"input_ids": input_ids}
         if pixel_values is not None:
             neuron_inputs["pixel_values"] = pixel_values
-        neuron_inputs["attention_mask"] = (
-            attention_mask  # The input order for clip is: input_ids, pixel_values, attention_mask.
-        )
+        neuron_inputs[
+            "attention_mask"
+        ] = attention_mask  # The input order for clip is: input_ids, pixel_values, attention_mask.
 
         with self.neuron_padding_manager(neuron_inputs) as inputs:
             outputs = self.model(*inputs)
@@ -700,9 +698,7 @@ class NeuronModelForImageClassification(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        pixel_values: torch.Tensor,
-        **kwargs,
+        self, pixel_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"pixel_values": pixel_values}
 
@@ -786,9 +782,7 @@ class NeuronModelForSemanticSegmentation(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        pixel_values: torch.Tensor,
-        **kwargs,
+        self, pixel_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"pixel_values": pixel_values}
 
@@ -873,9 +867,7 @@ class NeuronModelForObjectDetection(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        pixel_values: torch.Tensor,
-        **kwargs,
+        self, pixel_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"pixel_values": pixel_values}
 
@@ -957,9 +949,7 @@ class NeuronModelForAudioClassification(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        input_values: torch.Tensor,
-        **kwargs,
+        self, input_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"input_values": input_values}
 
@@ -1023,9 +1013,7 @@ class NeuronModelForAudioFrameClassification(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        input_values: torch.Tensor,
-        **kwargs,
+        self, input_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"input_values": input_values}
 
@@ -1103,9 +1091,7 @@ class NeuronModelForCTC(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        input_values: torch.Tensor,
-        **kwargs,
+        self, input_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"input_values": input_values}
 
@@ -1176,9 +1162,7 @@ class NeuronModelForXVector(NeuronTracedModel):
         )
     )
     def forward(
-        self,
-        input_values: torch.Tensor,
-        **kwargs,
+        self, input_values: torch.Tensor, **kwargs,
     ):
         neuron_inputs = {"input_values": input_values}
 
@@ -1264,9 +1248,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
     @add_start_docstrings_to_model_forward(
         NEURON_CAUSALLM_MODEL_FORWARD_DOCSTRING
         + TEXT_GENERATION_EXAMPLE.format(
-            processor_class="AutoTokenizer",
-            model_class="NeuronModelForCausalLM",
-            checkpoint="gpt2",
+            processor_class="AutoTokenizer", model_class="NeuronModelForCausalLM", checkpoint="gpt2",
         )
     )
     def forward(
@@ -1285,10 +1267,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
         return (out_logits,)
 
     def get_start_ids(
-        self,
-        input_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
-        seq_ids: Optional[torch.Tensor] = None,
+        self, input_ids: torch.Tensor, attention_mask: torch.Tensor, seq_ids: Optional[torch.Tensor] = None,
     ):
         # The start_ids parameter has different meanings:
         # - for continuous (unpadded) batching it corresponds to the sequence id,
@@ -1342,10 +1321,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
         }
 
     def prepare_inputs_for_decode(
-        self,
-        input_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
-        seq_ids: Optional[List[int]] = None,
+        self, input_ids: torch.Tensor, attention_mask: torch.Tensor, seq_ids: Optional[List[int]] = None,
     ) -> Dict[str, torch.Tensor]:
         start_ids = self.get_start_ids(input_ids, attention_mask, seq_ids=seq_ids)
         cache_ids = self.get_cache_ids(attention_mask, prefill=False)
@@ -1444,11 +1420,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
             padded_attention_mask = torch.cat([padded_attention_mask, padding])
 
         output_ids = self.generate_tokens(
-            padded_input_ids,
-            selector,
-            batch_size,
-            padded_attention_mask,
-            **model_kwargs,
+            padded_input_ids, selector, batch_size, padded_attention_mask, **model_kwargs,
         )
         return output_ids[:batch_size, :]
 
@@ -1485,10 +1457,7 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
 
         # Prefill and obtain the first token
         model_inputs = self.prepare_inputs_for_prefill(input_ids, attention_mask)
-        outputs = self(
-            **model_inputs,
-            return_dict=True,
-        )
+        outputs = self(**model_inputs, return_dict=True,)
 
         # auto-regressive generation
         while True:
@@ -1510,9 +1479,6 @@ class NeuronModelForCausalLM(NeuronDecoderModel, GenerationMixin):
 
             # forward pass to get next token
             model_inputs = self.prepare_inputs_for_decode(input_ids, attention_mask)
-            outputs = self(
-                **model_inputs,
-                return_dict=True,
-            )
+            outputs = self(**model_inputs, return_dict=True,)
 
         return input_ids

--- a/optimum/neuron/modeling_base.py
+++ b/optimum/neuron/modeling_base.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
 
 class NeuronModel(OptimizedModel):
-
     def __init__(self, model: "PreTrainedModel", config: "PretrainedConfig"):
         super().__init__(model, config)
         if hasattr(model, "device"):

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -367,10 +367,7 @@ class NeuronDecoderModel(NeuronModel):
         else:
             # Create the local transformers model checkpoint
             checkpoint_dir = cls._create_checkpoint(
-                model_id,
-                task=new_config.neuron["task"],
-                revision=revision,
-                **kwargs,
+                model_id, task=new_config.neuron["task"], revision=revision, **kwargs,
             )
 
         # Try to reload the generation config (if any)
@@ -422,11 +419,7 @@ class NeuronDecoderModel(NeuronModel):
                 raise ValueError("Unable to fetch the neuron model weights files.")
             checkpoint_revision = neuron_config["checkpoint_revision"]
             checkpoint_dir = cls._create_checkpoint(
-                checkpoint_id,
-                task=task,
-                revision=checkpoint_revision,
-                token=token,
-                **kwargs,
+                checkpoint_id, task=task, revision=checkpoint_revision, token=token, **kwargs,
             )
         assert os.path.isdir(compiled_dir)
 
@@ -473,10 +466,7 @@ class NeuronDecoderModel(NeuronModel):
         api = HfApi(endpoint=endpoint)
 
         api.create_repo(
-            token=token,
-            repo_id=repository_id,
-            exist_ok=True,
-            private=private,
+            token=token, repo_id=repository_id, exist_ok=True, private=private,
         )
         ignore_patterns = []
         neuron_config = getattr(self.config, "neuron")

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -362,9 +362,7 @@ class NeuronStableDiffusionPipelineBase(NeuronTracedModel):
                             submodel_path, to_neuron=False
                         )  # No need to load to neuron manually when dp
                         submodel = torch_neuronx.DataParallel(
-                            submodel,
-                            [0, 1],
-                            set_dynamic_batching=dynamic_batch_size,
+                            submodel, [0, 1], set_dynamic_batching=dynamic_batch_size,
                         )
                         submodels_list.append(submodel)
                 if submodels_list:
@@ -384,11 +382,7 @@ class NeuronStableDiffusionPipelineBase(NeuronTracedModel):
             unet = NeuronTracedModel.load_model(
                 unet_path, to_neuron=False
             )  # No need to load to neuron manually when dp
-            submodels["unet"] = torch_neuronx.DataParallel(
-                unet,
-                [0, 1],
-                set_dynamic_batching=dynamic_batch_size,
-            )
+            submodels["unet"] = torch_neuronx.DataParallel(unet, [0, 1], set_dynamic_batching=dynamic_batch_size,)
             # load controlnets
             if controlnet_paths:
                 controlnets = []
@@ -944,10 +938,7 @@ class NeuronStableDiffusionPipelineBase(NeuronTracedModel):
             )
 
         return cls._from_pretrained(
-            model_id=save_dir_path,
-            config=config,
-            model_save_dir=save_dir,
-            data_parallel_mode=data_parallel_mode,
+            model_id=save_dir_path, config=config, model_save_dir=save_dir, data_parallel_mode=data_parallel_mode,
         )
 
     @classmethod
@@ -1092,10 +1083,7 @@ class NeuronModelVaeDecoder(_NeuronDiffusionModelPart):
         super().__init__(model, parent_model, config, neuron_config, DIFFUSION_MODEL_VAE_DECODER_NAME)
 
     def forward(
-        self,
-        latent_sample: torch.Tensor,
-        image: Optional[torch.Tensor] = None,
-        mask: Optional[torch.Tensor] = None,
+        self, latent_sample: torch.Tensor, image: Optional[torch.Tensor] = None, mask: Optional[torch.Tensor] = None,
     ):
         inputs = (latent_sample,)
         if image is not None:
@@ -1331,7 +1319,6 @@ class NeuronStableDiffusionXLControlNetPipeline(
 if is_neuronx_available():
     # TO REMOVE: This class will be included directly in the DDP API of Neuron SDK 2.20
     class WeightSeparatedDataParallel(torch_neuronx.DataParallel):
-
         def _load_modules(self, module):
             try:
                 self.device_ids.sort()
@@ -1353,6 +1340,7 @@ if is_neuronx_available():
                 )
             self.num_workers = 2 * len(loaded_modules)
             return loaded_modules
+
 
 else:
 

--- a/optimum/neuron/modeling_seq2seq.py
+++ b/optimum/neuron/modeling_seq2seq.py
@@ -82,18 +82,8 @@ class NeuronModelForConditionalGeneration(NeuronTracedModel, ABC):
         )  # only for the encoder
         self._attributes_init(model_save_dir, preprocessors, **kwargs)
         self.model_and_config_save_paths = model_and_config_save_paths if model_and_config_save_paths else None
-        self.encoder = NeuronEncoder(
-            encoder,
-            self,
-            self.configs[ENCODER_NAME],
-            self.neuron_configs[ENCODER_NAME],
-        )
-        self.decoder = NeuronDecoder(
-            decoder,
-            self,
-            self.configs[DECODER_NAME],
-            self.neuron_configs[DECODER_NAME],
-        )
+        self.encoder = NeuronEncoder(encoder, self, self.configs[ENCODER_NAME], self.neuron_configs[ENCODER_NAME],)
+        self.decoder = NeuronDecoder(decoder, self, self.configs[DECODER_NAME], self.neuron_configs[DECODER_NAME],)
         self.dynamic_batch_size = all(
             neuron_config._config.neuron["dynamic_batch_size"] for neuron_config in self.neuron_configs.values()
         )
@@ -317,19 +307,14 @@ class NeuronModelForConditionalGeneration(NeuronTracedModel, ABC):
             **kwargs_shapes,
         )
 
-        return cls._from_pretrained(
-            model_id=save_dir_path,
-            config=config,
-            model_save_dir=save_dir,
-        )
+        return cls._from_pretrained(model_id=save_dir_path, config=config, model_save_dir=save_dir,)
 
     def _save_config(self, save_directory):
         save_directory = Path(save_directory)
         self.configs[ENCODER_NAME].save_pretrained(save_directory / ENCODER_NAME)
         self.configs[DECODER_NAME].save_pretrained(save_directory / DECODER_NAME)
         combined_config = self._combine_encoder_decoder_config(
-            encoder_config=self.configs[ENCODER_NAME],
-            decoder_config=self.configs[DECODER_NAME],
+            encoder_config=self.configs[ENCODER_NAME], decoder_config=self.configs[DECODER_NAME],
         )
         combined_config.save_pretrained(save_directory)
 
@@ -495,12 +480,7 @@ class NeuronModelForSeq2SeqLM(NeuronModelForConditionalGeneration, NeuronGenerat
 
     # Override to cut the input_ids to just last token
     def prepare_inputs_for_generation(
-        self,
-        input_ids,
-        attention_mask=None,
-        decoder_attention_mask=None,
-        encoder_outputs=None,
-        **kwargs,
+        self, input_ids, attention_mask=None, decoder_attention_mask=None, encoder_outputs=None, **kwargs,
     ):
         # cut decoder_input_ids as past is cached
         input_ids = input_ids[:, -1:]

--- a/optimum/neuron/modeling_traced.py
+++ b/optimum/neuron/modeling_traced.py
@@ -376,10 +376,7 @@ class NeuronTracedModel(NeuronModel):
         api = HfApi(endpoint=endpoint)
 
         api.create_repo(
-            token=token,
-            repo_id=repository_id,
-            exist_ok=True,
-            private=private,
+            token=token, repo_id=repository_id, exist_ok=True, private=private,
         )
         for path, subdirs, files in os.walk(save_directory):
             for name in files:
@@ -450,10 +447,7 @@ class NeuronTracedModel(NeuronModel):
         model_type = neuron_config.get("model_type", None) or config.model_type
         model_type = model_type.replace("_", "-")
         neuron_config_constructor = TasksManager.get_exporter_config_constructor(
-            model_type=model_type,
-            exporter="neuron",
-            task=task,
-            library_name=cls.library_name,
+            model_type=model_type, exporter="neuron", task=task, library_name=cls.library_name,
         )
 
         return neuron_config_constructor(

--- a/optimum/neuron/pipelines/__init__.py
+++ b/optimum/neuron/pipelines/__init__.py
@@ -47,15 +47,8 @@ if TYPE_CHECKING:
         NeuronStableDiffusionXLInpaintPipelineMixin,
         NeuronStableDiffusionXLPipelineMixin,
     )
-    from .transformers import (
-        pipeline,
-    )
+    from .transformers import pipeline
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(
-        __name__,
-        globals()["__file__"],
-        _import_structure,
-        module_spec=__spec__,
-    )
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__,)

--- a/optimum/neuron/pipelines/diffusers/pipeline_latent_consistency_text2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_latent_consistency_text2img.py
@@ -229,10 +229,7 @@ class NeuronLatentConsistencyPipelineMixin(StableDiffusionPipelineMixin, LatentC
 
                 # model prediction (v-prediction, eps, x)
                 model_pred = self.unet(
-                    sample=latents,
-                    timestep=t,
-                    encoder_hidden_states=prompt_embeds,
-                    timestep_cond=w_embedding,
+                    sample=latents, timestep=t, encoder_hidden_states=prompt_embeds, timestep_cond=w_embedding,
                 )[0]
 
                 # compute the previous noisy sample x_t -> x_t-1

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion.py
@@ -210,11 +210,7 @@ class NeuronStableDiffusionPipelineMixin(StableDiffusionPipelineMixin, StableDif
 
                 # predict the noise residual
                 # [modified for neuron] Remove not traced inputs: cross_attention_kwargs, return_dict
-                noise_pred = self.unet(
-                    latent_model_input,
-                    t,
-                    encoder_hidden_states=prompt_embeds,
-                )[0]
+                noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=prompt_embeds,)[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_img2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_img2img.py
@@ -260,11 +260,7 @@ class NeuronStableDiffusionImg2ImgPipelineMixin(StableDiffusionPipelineMixin, St
 
                 # predict the noise residual
                 # [modified for neuron] Remove not traced inputs: cross_attention_kwargs, return_dict
-                noise_pred = self.unet(
-                    latent_model_input,
-                    t,
-                    encoder_hidden_states=prompt_embeds,
-                )[0]
+                noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=prompt_embeds,)[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_inpaint.py
@@ -339,11 +339,7 @@ class NeuronStableDiffusionInpaintPipelineMixin(StableDiffusionPipelineMixin, St
 
                 # predict the noise residual
                 # [modified for neuron] Remove not traced inputs: cross_attention_kwargs, return_dict
-                noise_pred = self.unet(
-                    latent_model_input,
-                    t,
-                    encoder_hidden_states=prompt_embeds,
-                )[0]
+                noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=prompt_embeds,)[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_instruct_pix2pix.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_instruct_pix2pix.py
@@ -152,12 +152,7 @@ class NeuronStableDiffusionInstructPix2PixPipelineMixin(
 
         # 0. Check inputs
         self.check_inputs(
-            prompt,
-            None,
-            negative_prompt,
-            prompt_embeds,
-            negative_prompt_embeds,
-            callback_on_step_end_tensor_inputs,
+            prompt, None, negative_prompt, prompt_embeds, negative_prompt_embeds, callback_on_step_end_tensor_inputs,
         )
         self._guidance_scale = guidance_scale
         self._image_guidance_scale = image_guidance_scale
@@ -196,11 +191,7 @@ class NeuronStableDiffusionInstructPix2PixPipelineMixin(
 
         # 5. Prepare Image latents
         image_latents = self.prepare_image_latents(
-            image,
-            batch_size,
-            num_images_per_prompt,
-            self.do_classifier_free_guidance,
-            generator,
+            image, batch_size, num_images_per_prompt, self.do_classifier_free_guidance, generator,
         )
 
         height, width = image_latents.shape[-2:]
@@ -247,11 +238,7 @@ class NeuronStableDiffusionInstructPix2PixPipelineMixin(
                 scaled_latent_model_input = torch.cat([scaled_latent_model_input, image_latents], dim=1)
 
                 # predict the noise residual
-                noise_pred = self.unet(
-                    scaled_latent_model_input,
-                    t,
-                    encoder_hidden_states=prompt_embeds,
-                )[0]
+                noise_pred = self.unet(scaled_latent_model_input, t, encoder_hidden_states=prompt_embeds,)[0]
 
                 # perform guidance
                 if self.do_classifier_free_guidance:
@@ -445,11 +432,7 @@ class NeuronStableDiffusionInstructPix2PixPipelineMixin(
 
             max_length = prompt_embeds.shape[1]
             uncond_input = self.tokenizer(
-                uncond_tokens,
-                padding="max_length",
-                max_length=max_length,
-                truncation=True,
-                return_tensors="pt",
+                uncond_tokens, padding="max_length", max_length=max_length, truncation=True, return_tensors="pt",
             )
 
             negative_prompt_embeds = self.text_encoder(uncond_input.input_ids)

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl.py
@@ -301,10 +301,7 @@ class NeuronStableDiffusionXLPipelineMixin(StableDiffusionXLPipelineMixin, Stabl
         add_text_embeds = pooled_prompt_embeds
 
         add_time_ids = self._get_add_time_ids(
-            original_size,
-            crops_coords_top_left,
-            target_size,
-            dtype=prompt_embeds.dtype,
+            original_size, crops_coords_top_left, target_size, dtype=prompt_embeds.dtype,
         )
         if negative_original_size is not None and negative_target_size is not None:
             negative_add_time_ids = self._get_add_time_ids(

--- a/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
@@ -389,13 +389,7 @@ class NeuronStableDiffusionXLImg2ImgPipelineMixin(StableDiffusionXLPipelineMixin
 
         # 6. Prepare latent variables
         latents = self.prepare_latents(
-            image,
-            latent_timestep,
-            batch_size,
-            num_images_per_prompt,
-            prompt_embeds.dtype,
-            generator,
-            add_noise,
+            image, latent_timestep, batch_size, num_images_per_prompt, prompt_embeds.dtype, generator, add_noise,
         )
 
         # 7. Prepare extra step kwargs.

--- a/optimum/neuron/pipelines/diffusers/pipeline_utils.py
+++ b/optimum/neuron/pipelines/diffusers/pipeline_utils.py
@@ -177,11 +177,7 @@ class StableDiffusionPipelineMixin(DiffusionBasePipelineMixin):
 
             max_length = prompt_embeds.shape[1]
             uncond_input = self.tokenizer(
-                uncond_tokens,
-                padding="max_length",
-                max_length=max_length,
-                truncation=True,
-                return_tensors="pt",
+                uncond_tokens, padding="max_length", max_length=max_length, truncation=True, return_tensors="pt",
             )
 
             negative_prompt_embeds = self.text_encoder(uncond_input.input_ids)
@@ -372,11 +368,7 @@ class StableDiffusionXLPipelineMixin(DiffusionBasePipelineMixin):
 
                 max_length = prompt_embeds.shape[1]
                 uncond_input = tokenizer(
-                    negative_prompt,
-                    padding="max_length",
-                    max_length=max_length,
-                    truncation=True,
-                    return_tensors="pt",
+                    negative_prompt, padding="max_length", max_length=max_length, truncation=True, return_tensors="pt",
                 )
                 negative_prompt_embeds = text_encoder(input_ids=uncond_input.input_ids)
                 # We are only ALWAYS interested in the pooled output of the final text encoder

--- a/optimum/neuron/pipelines/transformers/__init__.py
+++ b/optimum/neuron/pipelines/transformers/__init__.py
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import (
-    pipeline,
-)
+from .base import pipeline

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -186,8 +186,7 @@ class _TrainerForNeuron:
         # We need to change which process can be seen as "world process zero" to make sure the proper metrics
         # (eg.g loss) are logged and sent to the callbacks (for instance WandbCallback).
         self.state = TrainerState(
-            is_local_process_zero=self.is_local_process_zero(),
-            is_world_process_zero=is_main_worker_for_metrics(),
+            is_local_process_zero=self.is_local_process_zero(), is_world_process_zero=is_main_worker_for_metrics(),
         )
 
         if self.args.local_rank <= 0:
@@ -406,8 +405,7 @@ class _TrainerForNeuron:
         arguments, depending on the situation.
         """
         autocast_handler = AutocastKwargs(
-            enabled=self.accelerator.autocast_handler.enabled,
-            cache_enabled=cache_enabled,
+            enabled=self.accelerator.autocast_handler.enabled, cache_enabled=cache_enabled,
         )
         return self.accelerator.autocast(autocast_handler=autocast_handler)
 
@@ -1078,18 +1076,13 @@ class _TrainerForNeuron:
                         elif self.use_apex:
                             # Revert to normal clipping otherwise, handling Apex or full precision
                             torch.nn.utils.clip_grad_norm_(
-                                amp.master_params(self.optimizer),
-                                args.max_grad_norm,
+                                amp.master_params(self.optimizer), args.max_grad_norm,
                             )
                             _grad_norm = torch.nn.utils.clip_grad_norm_(
-                                amp.master_params(self.optimizer),
-                                args.max_grad_norm,
+                                amp.master_params(self.optimizer), args.max_grad_norm,
                             )
                         else:
-                            _grad_norm = self.accelerator.clip_grad_norm_(
-                                model.parameters(),
-                                args.max_grad_norm,
-                            )
+                            _grad_norm = self.accelerator.clip_grad_norm_(model.parameters(), args.max_grad_norm,)
                         grad_norm = _grad_norm
 
                     # Optimizer step

--- a/optimum/neuron/training_args.py
+++ b/optimum/neuron/training_args.py
@@ -52,11 +52,7 @@ class NeuronTrainingArgumentsMixin:
         default=False, metadata={"help": "Whether to skip pushing Neuron artifacts to hub cache"}
     )
     half_precision_backend: str = field(
-        default="xla",
-        metadata={
-            "help": "The backend to be used for half precision.",
-            "choices": ["xla", "amp"],
-        },
+        default="xla", metadata={"help": "The backend to be used for half precision.", "choices": ["xla", "amp"],},
     )
     zero_1: bool = field(default=False, metadata={"help": "Whether to use  ZeRO Stage 1 Optimization."})
     tensor_parallel_size: int = field(
@@ -73,8 +69,7 @@ class NeuronTrainingArgumentsMixin:
         },
     )
     disable_sequence_parallel: bool = field(
-        default=False,
-        metadata={"help": "Whether or not to disable sequence parallelism."},
+        default=False, metadata={"help": "Whether or not to disable sequence parallelism."},
     )
     neuron_cc_optlevel: Optional[int] = field(
         default=None,
@@ -84,12 +79,10 @@ class NeuronTrainingArgumentsMixin:
         },
     )
     pipeline_parallel_size: int = field(
-        default=1,
-        metadata={"help": "The number of pipeline parallel replicas."},
+        default=1, metadata={"help": "The number of pipeline parallel replicas."},
     )
     pipeline_parallel_num_microbatches: int = field(
-        default=-1,
-        metadata={"help": "The number of microbatches used for pipeline execution."},
+        default=-1, metadata={"help": "The number of microbatches used for pipeline execution."},
     )
     kv_size_multiplier: Optional[int] = field(
         default=None,

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -57,10 +57,7 @@ _import_structure = {
         "replace_weights",
     ],
     "model_utils": ["get_tied_parameters_dict", "tie_parameters"],
-    "optimization_utils": [
-        "get_attention_scores_sd",
-        "get_attention_scores_sdxl",
-    ],
+    "optimization_utils": ["get_attention_scores_sd", "get_attention_scores_sdxl",],
     "patching": [
         "DynamicPatch",
         "ModelPatcher",
@@ -70,10 +67,7 @@ _import_structure = {
         "replace_class_in_inheritance_hierarchy",
     ],
     "peft_utils": ["NeuronPeftModel", "get_peft_model"],
-    "training_utils": [
-        "is_model_officially_supported",
-        "patch_transformers_for_neuron_sdk",
-    ],
+    "training_utils": ["is_model_officially_supported", "patch_transformers_for_neuron_sdk",],
     "trl_utils": ["NeuronSFTConfig"],
 }
 
@@ -137,9 +131,4 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(
-        __name__,
-        globals()["__file__"],
-        _import_structure,
-        module_spec=__spec__,
-    )
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__,)

--- a/optimum/neuron/utils/argument_utils.py
+++ b/optimum/neuron/utils/argument_utils.py
@@ -93,9 +93,7 @@ def validate_arg(
 
 
 def convert_neuronx_compiler_args_to_neuron(
-    auto_cast: Optional[str],
-    auto_cast_type: str,
-    disable_fast_relayout: bool,
+    auto_cast: Optional[str], auto_cast_type: str, disable_fast_relayout: bool,
 ):
     """
     Builds `compiler_args` for neuron compiler.

--- a/optimum/neuron/utils/hub_cache_utils.py
+++ b/optimum/neuron/utils/hub_cache_utils.py
@@ -242,8 +242,7 @@ class CompileCacheHfProxy(CompileCache):
 
 
 def create_hub_compile_cache_proxy(
-    cache_url: Optional[CacheUrl] = None,
-    cache_repo_id: Optional[str] = None,
+    cache_url: Optional[CacheUrl] = None, cache_repo_id: Optional[str] = None,
 ):
     if cache_url is None:
         cache_url = CacheUrl.get_cache_url()

--- a/optimum/neuron/utils/input_generators.py
+++ b/optimum/neuron/utils/input_generators.py
@@ -38,11 +38,7 @@ class DummyBeamValuesGenerator(DummyInputGenerator):
     )
 
     def __init__(
-        self,
-        task: str,
-        normalized_config: NormalizedTextConfig,
-        num_beams: int = 1,
-        **kwargs,
+        self, task: str, normalized_config: NormalizedTextConfig, num_beams: int = 1, **kwargs,
     ):
         self.task = task
         self.num_beams = num_beams
@@ -58,11 +54,7 @@ class DummyMaskedPosGenerator(DummyInputGenerator):
     SUPPORTED_INPUT_NAMES = ("masked_pos", "bool_masked_pos")
 
     def __init__(
-        self,
-        task: str,
-        normalized_config: NormalizedVisionConfig,
-        batch_size: int,
-        **kwargs,
+        self, task: str, normalized_config: NormalizedVisionConfig, batch_size: int, **kwargs,
     ):
         self.task = task
         self.image_size = getattr(normalized_config, "image_size", None)
@@ -160,8 +152,8 @@ class DummyControNetInputGenerator(DummyInputGenerator):
             shape = (
                 self.batch_size,
                 out_channels,
-                self.height // 2**num_cross_attn_blocks,
-                self.width // 2**num_cross_attn_blocks,
+                self.height // 2 ** num_cross_attn_blocks,
+                self.width // 2 ** num_cross_attn_blocks,
             )
             return self.random_float_tensor(shape, framework=framework, dtype=float_dtype)
 

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -432,9 +432,7 @@ def download_checkpoints_in_cache(
                 if resolved_archive_file is None and filename == _add_variant(WEIGHTS_NAME, variant):
                     # Maybe the checkpoint is sharded, we try to grab the index name in this case.
                     resolved_archive_file = distributed_friendly_cached_file(
-                        pretrained_model_name_or_path,
-                        _add_variant(WEIGHTS_INDEX_NAME, variant),
-                        **cached_file_kwargs,
+                        pretrained_model_name_or_path, _add_variant(WEIGHTS_INDEX_NAME, variant), **cached_file_kwargs,
                     )
                     if resolved_archive_file is not None:
                         is_sharded = True
@@ -667,9 +665,7 @@ class DiffusersPretrainedConfig(PretrainedConfig):
         return output
 
 
-def get_stable_diffusion_configs(
-    models_for_export: Dict[str, Union["PreTrainedModel", "ModelMixin"]],
-):
+def get_stable_diffusion_configs(models_for_export: Dict[str, Union["PreTrainedModel", "ModelMixin"]],):
     subfolders = ["text_encoder", "text_encoder_2", "unet", "vae"]
     configs = {}
     for name in subfolders:

--- a/optimum/neuron/utils/peft_utils.py
+++ b/optimum/neuron/utils/peft_utils.py
@@ -38,9 +38,7 @@ if is_peft_available():
         id_tensor_storage,
         set_peft_model_state_dict,
     )
-    from peft.utils import (
-        get_peft_model_state_dict as orig_get_peft_model_state_dict,
-    )
+    from peft.utils import get_peft_model_state_dict as orig_get_peft_model_state_dict
 
 else:
 
@@ -180,10 +178,7 @@ class NeuronPeftModel(PeftModel):
 
                 dummy_mod = DummyModule()
                 neuronx_distributed.trainer.save_checkpoint(
-                    output_dir,
-                    tag="adapter_shards",
-                    model=dummy_mod,
-                    async_save=async_save,
+                    output_dir, tag="adapter_shards", model=dummy_mod, async_save=async_save,
                 )
 
                 # Importing here to avoid circular imports.
@@ -237,9 +232,7 @@ class NeuronPeftModel(PeftModel):
                         peft_config, convert_pissa_to_lora, output_state_dict, kwargs
                     )
                 safe_save_file(
-                    output_state_dict,
-                    os.path.join(output_dir, SAFETENSORS_WEIGHTS_NAME),
-                    metadata={"format": "pt"},
+                    output_state_dict, os.path.join(output_dir, SAFETENSORS_WEIGHTS_NAME), metadata={"format": "pt"},
                 )
             elif is_main_process:
                 output_state_dict = move_all_tensor_to_cpu(output_state_dict, convert=should_write_data)
@@ -261,9 +254,7 @@ class NeuronPeftModel(PeftModel):
 
             if peft_config.task_type is None:
                 # deal with auto mapping
-                base_model_class = self._get_base_model_class(
-                    is_prompt_tuning=peft_config.is_prompt_learning,
-                )
+                base_model_class = self._get_base_model_class(is_prompt_tuning=peft_config.is_prompt_learning,)
                 parent_library = base_model_class.__module__
 
                 auto_mapping_dict = {

--- a/optimum/neuron/utils/runner.py
+++ b/optimum/neuron/utils/runner.py
@@ -159,24 +159,14 @@ class ExampleRunner:
             "dataset_name": "wikitext",
             "dataset_config_name": "wikitext-2-raw-v1",
             "set_max_length": True,
-            "extra_command_line_arguments": [
-                "--pad_to_max_length",
-            ],
+            "extra_command_line_arguments": ["--pad_to_max_length",],
         },
-        "causal-lm": {
-            "dataset_name": "wikitext",
-            "dataset_config_name": "wikitext-2-raw-v1",
-        },
-        "text-classification": {
-            "task_name": "sst2",
-        },
+        "causal-lm": {"dataset_name": "wikitext", "dataset_config_name": "wikitext-2-raw-v1",},
+        "text-classification": {"task_name": "sst2",},
         "token-classification": {
             "dataset_name": "bnsapa/cybersecurity-ner",
             "set_max_length": True,
-            "extra_command_line_arguments": [
-                "--pad_to_max_length",
-                "--ignore_mismatched_sizes",
-            ],
+            "extra_command_line_arguments": ["--pad_to_max_length", "--ignore_mismatched_sizes",],
         },
         "multiple-choice": {
             "set_max_length": True,
@@ -189,9 +179,7 @@ class ExampleRunner:
             "dataset_name": "squad",
             # It is already the case, but just to make sure if it ever changes.
             "set_max_length": True,
-            "extra_command_line_arguments": [
-                "--pad_to_max_length",
-            ],
+            "extra_command_line_arguments": ["--pad_to_max_length",],
         },
         "summarization": {
             "dataset_name": "cnn_dailymail",
@@ -219,10 +207,7 @@ class ExampleRunner:
         },
         "image-classification": {
             "dataset_name": "mnist",
-            "extra_command_line_arguments": [
-                "--remove_unused_columns false",
-                "--ignore_mismatched_sizes",
-            ],
+            "extra_command_line_arguments": ["--remove_unused_columns false", "--ignore_mismatched_sizes",],
         },
     }
 

--- a/optimum/neuron/utils/training_utils.py
+++ b/optimum/neuron/utils/training_utils.py
@@ -58,8 +58,7 @@ if TYPE_CHECKING:
 
 
 def _generate_supported_model_class_names(
-    model_type: str,
-    supported_tasks: Optional[Union[str, List[str]]] = None,
+    model_type: str, supported_tasks: Optional[Union[str, List[str]]] = None,
 ) -> List[str]:
     task_mapping = {
         "default": MODEL_MAPPING_NAMES,

--- a/tests/decoder/test_decoder_export.py
+++ b/tests/decoder/test_decoder_export.py
@@ -55,11 +55,7 @@ def check_neuron_model(neuron_model, batch_size=None, sequence_length=None, num_
 
 @pytest.mark.parametrize(
     "batch_size, sequence_length, num_cores, auto_cast_type",
-    [
-        [1, 100, 2, "fp32"],
-        [1, 100, 2, "fp16"],
-        [2, 100, 2, "fp16"],
-    ],
+    [[1, 100, 2, "fp32"], [1, 100, 2, "fp16"], [2, 100, 2, "fp16"],],
 )
 @is_inferentia_test
 @requires_neuronx

--- a/tests/distributed/test_common.py
+++ b/tests/distributed/test_common.py
@@ -108,9 +108,7 @@ def move_params_to_cpu(parameters):
 class TestCommonDistributed(DistributedTest):
     # TODO: enable dp=4,tp=pp=2 when working on the multi-node training PR.
     @pytest.fixture(
-        scope="class",
-        params=[[2, 1, 1], [2, 2, 1], [2, 1, 2]],
-        ids=["dp=2", "tp=2", "pp=2"],
+        scope="class", params=[[2, 1, 1], [2, 2, 1], [2, 1, 2]], ids=["dp=2", "tp=2", "pp=2"],
     )
     def parallel_sizes(self, request):
         return request.param
@@ -443,20 +441,9 @@ class TestCommonDistributed(DistributedTest):
         ],
     )
     def test_consolidate_model_parallel_checkpoints(
-        self,
-        tmpdir,
-        world_size,
-        tp_size,
-        pp_size,
-        kv_size_multiplier,
-        model_name,
-        use_xser,
+        self, tmpdir, world_size, tp_size, pp_size, kv_size_multiplier, model_name, use_xser,
     ):
-        orig_model = get_model(
-            LlamaForCausalLM,
-            model_name,
-            use_static_seed_patcher=True,
-        )
+        orig_model = get_model(LlamaForCausalLM, model_name, use_static_seed_patcher=True,)
         orig_model_path = Path(tmpdir) / "orig_model"
         if xm.get_ordinal() == 0:
             # Saving to pytorch instead of safetensors because it fails otherwise for pickling issues with distributed tests.

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -46,9 +46,7 @@ from transformers.models.auto.modeling_auto import (
 import optimum
 from optimum.neuron.distributed.parallelizers_manager import ParallelizersManager
 from optimum.neuron.distributed.utils import compute_query_indices_for_rank, lazy_load_for_parallelism
-from optimum.neuron.utils.cache_utils import (
-    get_num_neuron_cores,
-)
+from optimum.neuron.utils.cache_utils import get_num_neuron_cores
 from optimum.neuron.utils.import_utils import (
     is_neuronx_available,
     is_neuronx_distributed_available,
@@ -91,8 +89,7 @@ CLASSES_TO_IGNORE = [
 
 
 def _generate_supported_model_classes(
-    model_type: str,
-    supported_tasks: Optional[Union[str, List[str]]] = None,
+    model_type: str, supported_tasks: Optional[Union[str, List[str]]] = None,
 ) -> List[Type["PreTrainedModel"]]:
     task_mapping = {
         # TODO: enable that when base models are supported.
@@ -137,28 +134,15 @@ MODEL_TYPES_TO_TEST = [
     # Since the update they seem to not match, that's ok since it is not needed anyways.
     # ("bert", "hf-internal-testing/tiny-random-bert", {"num_hidden_layers": "2"}),
     ("roberta", "hf-internal-testing/tiny-random-roberta", {"num_hidden_layers": "2"}),
-    (
-        "gpt_neo",
-        "hf-internal-testing/tiny-random-GPTNeoModel",
-        {
-            "num_layers": "2",
-        },
-    ),
+    ("gpt_neo", "hf-internal-testing/tiny-random-GPTNeoModel", {"num_layers": "2",},),
     # TODO: re-enable that. No super urgent, do not want it to be a blocker.
     # (
     #     "gpt_neox",
     #     "michaelbenayoun/gpt-neox-tiny-4layers-random",
     #     {"num_hidden_layers": "2"},
     # ),
-    (
-        "llama",
-        "michaelbenayoun/llama-2-tiny-4kv-heads-4layers-random",
-    ),
-    (
-        "t5",
-        "hf-internal-testing/tiny-random-T5Model",
-        {"d_ff": "36", "num_layers": "2", "num_decoder_layers": "2"},
-    ),
+    ("llama", "michaelbenayoun/llama-2-tiny-4kv-heads-4layers-random",),
+    ("t5", "hf-internal-testing/tiny-random-T5Model", {"d_ff": "36", "num_layers": "2", "num_decoder_layers": "2"},),
     ("mistral", "michaelbenayoun/mistral-tiny-4layers-8kv-heads-random"),
 ]
 
@@ -400,10 +384,7 @@ class TestModelParallelization(DistributedTest):
                 self._check_output(output_name, outputs[0], outputs[1])
 
     def test_parallel_model_matches_original_model_from_pretrained_with_parallel_embeddings_and_sequence_parallel(
-        self,
-        model_specs,
-        parallel_sizes,
-        monkeypatch,
+        self, model_specs, parallel_sizes, monkeypatch,
     ):
         _, model_class, model_name_or_path, config_overwrite = model_specs
 
@@ -418,10 +399,7 @@ class TestModelParallelization(DistributedTest):
 
     @pytest.mark.skip("Model parallelism from config is not fully supported yet.")
     def test_parallel_model_matches_original_model_from_config(
-        self,
-        model_specs,
-        parallel_sizes,
-        monkeypatch,
+        self, model_specs, parallel_sizes, monkeypatch,
     ):
         _, model_class, model_name_or_path, config_overwrite = model_specs
         monkeypatch.setattr(
@@ -549,10 +527,7 @@ class TestModelParallelization(DistributedTest):
             tokenizer = AutoTokenizer.from_pretrained(LLAMA_V2_MODEL_NAME)
             tokenizer.save_pretrained(model_name_or_path)
             model = get_model(
-                LlamaForCausalLM,
-                LLAMA_V2_MODEL_NAME,
-                from_config=True,
-                config_overwrite=config_overwrite,
+                LlamaForCausalLM, LLAMA_V2_MODEL_NAME, from_config=True, config_overwrite=config_overwrite,
             )
             model.save_pretrained(model_name_or_path)
         xm.rendezvous("Model creation done.")
@@ -596,12 +571,7 @@ class TestModelParallelization(DistributedTest):
         with static_seed_patcher:
             model.resize_token_embeddings(new_vocab_size)
 
-        accelerator = create_accelerator(
-            tp_size,
-            1,
-            parallelize_embeddings=True,
-            sequence_parallel_enabled=True,
-        )
+        accelerator = create_accelerator(tp_size, 1, parallelize_embeddings=True, sequence_parallel_enabled=True,)
         with static_seed_patcher:
             model = accelerator.prepare_model(model)
 

--- a/tests/distributed_utils.py
+++ b/tests/distributed_utils.py
@@ -102,7 +102,8 @@ class DistributedExec(ABC):
     exec_timeout: int = TEST_TIMEOUT
 
     @abstractmethod
-    def run(self): ...
+    def run(self):
+        ...
 
     def __call__(self, request=None):
         self._fixture_kwargs = self._get_fixture_kwargs(request, self.run)
@@ -217,8 +218,7 @@ class DistributedExec(ABC):
 
                 # Intializing NxD.
                 neuronx_distributed.parallel_layers.parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size=tp_size,
-                    pipeline_model_parallel_size=pp_size,
+                    tensor_model_parallel_size=tp_size, pipeline_model_parallel_size=pp_size,
                 )
         try:
             self.run(**self._fixture_kwargs)

--- a/tests/exporters/test_export.py
+++ b/tests/exporters/test_export.py
@@ -60,9 +60,7 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def _get_models_to_test(
-    export_models_dict: Dict,
-    exclude_model_types: Optional[List[str]] = None,
-    library_name: str = "transformers",
+    export_models_dict: Dict, exclude_model_types: Optional[List[str]] = None, library_name: str = "transformers",
 ):
     models_to_test = []
     for model_type, model_names_tasks in export_models_dict.items():

--- a/tests/generation/test_export.py
+++ b/tests/generation/test_export.py
@@ -21,21 +21,13 @@ from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neur
 
 
 @pytest.mark.parametrize(
-    "batch_size, sequence_length, num_beams",
-    [
-        [1, 64, 1],
-        [1, 64, 4],
-    ],
+    "batch_size, sequence_length, num_beams", [[1, 64, 1], [1, 64, 4],],
 )
 @is_inferentia_test
 @requires_neuronx
 def test_seq2seq_export(export_seq2seq_id, batch_size, sequence_length, num_beams):
     model = NeuronModelForSeq2SeqLM.from_pretrained(
-        export_seq2seq_id,
-        export=True,
-        batch_size=batch_size,
-        sequence_length=sequence_length,
-        num_beams=num_beams,
+        export_seq2seq_id, export=True, batch_size=batch_size, sequence_length=sequence_length, num_beams=num_beams,
     )
     return model
 

--- a/tests/inference/test_modeling.py
+++ b/tests/inference/test_modeling.py
@@ -266,21 +266,13 @@ class NeuronModelForFeatureExtractionIntegrationTest(NeuronModelTestMixin):
         self.assertIn("last_hidden_state", neuron_outputs_dyn)
         self.assertIsInstance(neuron_outputs_dyn.last_hidden_state, torch.Tensor)
         self.assertTrue(
-            torch.allclose(
-                neuron_outputs_dyn.last_hidden_state,
-                transformers_outputs.last_hidden_state,
-                atol=atol,
-            )
+            torch.allclose(neuron_outputs_dyn.last_hidden_state, transformers_outputs.last_hidden_state, atol=atol,)
         )
 
         if "pooler_output" in neuron_outputs_dyn:
             self.assertIsInstance(neuron_outputs_dyn.pooler_output, torch.Tensor)
             self.assertTrue(
-                torch.allclose(
-                    neuron_outputs_dyn.pooler_output,
-                    transformers_outputs.pooler_output,
-                    atol=atol,
-                )
+                torch.allclose(neuron_outputs_dyn.pooler_output, transformers_outputs.pooler_output, atol=atol,)
             )
 
         gc.collect()
@@ -321,20 +313,14 @@ class NeuronModelForFeatureExtractionIntegrationTest(NeuronModelTestMixin):
         self.assertIsInstance(neuron_outputs_non_dyn.last_hidden_state, torch.Tensor)
         self.assertTrue(
             torch.allclose(
-                neuron_outputs_non_dyn.last_hidden_state,
-                transformers_outputs.last_hidden_state,
-                atol=atol,
+                neuron_outputs_non_dyn.last_hidden_state, transformers_outputs.last_hidden_state, atol=atol,
             )
         )
 
         if "pooler_output" in neuron_outputs_non_dyn:
             self.assertIsInstance(neuron_outputs_non_dyn.pooler_output, torch.Tensor)
             self.assertTrue(
-                torch.allclose(
-                    neuron_outputs_non_dyn.pooler_output,
-                    transformers_outputs.pooler_output,
-                    atol=atol,
-                )
+                torch.allclose(neuron_outputs_non_dyn.pooler_output, transformers_outputs.pooler_output, atol=atol,)
             )
 
         gc.collect()
@@ -399,9 +385,7 @@ class NeuronModelForSentenceTransformersIntegrationTest(NeuronModelTestMixin):
         self.assertIsInstance(neuron_outputs_dyn.token_embeddings, torch.Tensor)
         self.assertTrue(
             torch.allclose(
-                neuron_outputs_dyn.token_embeddings,
-                sentence_transformers_outputs.token_embeddings,
-                atol=atol,
+                neuron_outputs_dyn.token_embeddings, sentence_transformers_outputs.token_embeddings, atol=atol,
             )
         )
 
@@ -410,9 +394,7 @@ class NeuronModelForSentenceTransformersIntegrationTest(NeuronModelTestMixin):
         self.assertIsInstance(neuron_outputs_dyn.sentence_embedding, torch.Tensor)
         self.assertTrue(
             torch.allclose(
-                neuron_outputs_dyn.sentence_embedding,
-                sentence_transformers_outputs.sentence_embedding,
-                atol=atol,
+                neuron_outputs_dyn.sentence_embedding, sentence_transformers_outputs.sentence_embedding, atol=atol,
             )
         )
 
@@ -552,13 +534,7 @@ class NeuronModelForMaskedLMIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_dyn = neuron_model_dyn(**tokens)
         self.assertIn("logits", neuron_outputs_dyn)
         self.assertIsInstance(neuron_outputs_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -596,13 +572,7 @@ class NeuronModelForMaskedLMIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_non_dyn = neuron_model_non_dyn(**tokens)
         self.assertIn("logits", neuron_outputs_non_dyn)
         self.assertIsInstance(neuron_outputs_non_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_non_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_non_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -737,17 +707,11 @@ class NeuronModelForQuestionAnsweringIntegrationTest(NeuronModelTestMixin):
         # Compare tensor outputs
         self.assertTrue(
             torch.allclose(
-                torch.Tensor(neuron_outputs_dyn.start_logits),
-                transformers_outputs.start_logits,
-                atol=atol,
+                torch.Tensor(neuron_outputs_dyn.start_logits), transformers_outputs.start_logits, atol=atol,
             )
         )
         self.assertTrue(
-            torch.allclose(
-                torch.Tensor(neuron_outputs_dyn.end_logits),
-                transformers_outputs.end_logits,
-                atol=atol,
-            )
+            torch.allclose(torch.Tensor(neuron_outputs_dyn.end_logits), transformers_outputs.end_logits, atol=atol,)
         )
 
         gc.collect()
@@ -792,16 +756,12 @@ class NeuronModelForQuestionAnsweringIntegrationTest(NeuronModelTestMixin):
         # Compare tensor outputs
         self.assertTrue(
             torch.allclose(
-                torch.Tensor(neuron_outputs_non_dyn.start_logits),
-                transformers_outputs.start_logits,
-                atol=atol,
+                torch.Tensor(neuron_outputs_non_dyn.start_logits), transformers_outputs.start_logits, atol=atol,
             )
         )
         self.assertTrue(
             torch.allclose(
-                torch.Tensor(neuron_outputs_non_dyn.end_logits),
-                transformers_outputs.end_logits,
-                atol=atol,
+                torch.Tensor(neuron_outputs_non_dyn.end_logits), transformers_outputs.end_logits, atol=atol,
             )
         )
 
@@ -937,13 +897,7 @@ class NeuronModelForSequenceClassificationIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_dyn = neuron_model_dyn(**tokens)
         self.assertIn("logits", neuron_outputs_dyn)
         self.assertIsInstance(neuron_outputs_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -983,11 +937,7 @@ class NeuronModelForSequenceClassificationIntegrationTest(NeuronModelTestMixin):
         self.assertIsInstance(neuron_outputs_non_dyn.logits, torch.Tensor)
 
         # TODO: Fix flaky, works locally but fail only for BERT in the CI
-        result_close = torch.allclose(
-            neuron_outputs_non_dyn.logits,
-            transformers_outputs.logits,
-            atol=atol,
-        )
+        result_close = torch.allclose(neuron_outputs_non_dyn.logits, transformers_outputs.logits, atol=atol,)
         if not result_close:
             warnings.warn(
                 f"Inference results between pytorch model and neuron model of {model_arch} not close enough."
@@ -1123,13 +1073,7 @@ class NeuronModelForTokenClassificationIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_dyn = neuron_model_dyn(**tokens)
         self.assertIn("logits", neuron_outputs_dyn)
         self.assertIsInstance(neuron_outputs_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -1167,13 +1111,7 @@ class NeuronModelForTokenClassificationIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_non_dyn = neuron_model_non_dyn(**tokens)
         self.assertIn("logits", neuron_outputs_non_dyn)
         self.assertIsInstance(neuron_outputs_non_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_non_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_non_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -1303,13 +1241,7 @@ class NeuronModelForMultipleChoiceIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_dyn = neuron_model_dyn(**pt_inputs)
         self.assertIn("logits", neuron_outputs_dyn)
         self.assertIsInstance(neuron_outputs_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -1356,13 +1288,7 @@ class NeuronModelForMultipleChoiceIntegrationTest(NeuronModelTestMixin):
         neuron_outputs_non_dyn = neuron_model_non_dyn(**pt_inputs)
         self.assertIn("logits", neuron_outputs_non_dyn)
         self.assertIsInstance(neuron_outputs_non_dyn.logits, torch.Tensor)
-        self.assertTrue(
-            torch.allclose(
-                neuron_outputs_non_dyn.logits,
-                transformers_outputs.logits,
-                atol=atol,
-            )
-        )
+        self.assertTrue(torch.allclose(neuron_outputs_non_dyn.logits, transformers_outputs.logits, atol=atol,))
 
         gc.collect()
 
@@ -1428,11 +1354,7 @@ class NeuronModelForImageClassificationIntegrationTest(NeuronModelTestMixin):
         neuron_outputs = neuron_model(**inputs)
         self.assertIn("logits", neuron_outputs)
         self.assertIsInstance(neuron_outputs.logits, torch.Tensor)
-        result_close = torch.allclose(
-            neuron_outputs.logits,
-            transformers_outputs.logits,
-            atol=atol,
-        )
+        result_close = torch.allclose(neuron_outputs.logits, transformers_outputs.logits, atol=atol,)
         if not result_close:
             warnings.warn(
                 f"Inference results between pytorch model and neuron model of {model_arch} not close enough."
@@ -1550,11 +1472,7 @@ class NeuronModelForSemanticSegmentationIntegrationTest(NeuronModelTestMixin):
         neuron_outputs = neuron_model(**inputs)
         self.assertIn("logits", neuron_outputs)
         self.assertIsInstance(neuron_outputs.logits, torch.Tensor)
-        result_close = torch.allclose(
-            neuron_outputs.logits,
-            transformers_outputs.logits,
-            atol=atol,
-        )
+        result_close = torch.allclose(neuron_outputs.logits, transformers_outputs.logits, atol=atol,)
         if not result_close:
             warnings.warn(
                 f"Inference results between pytorch model and neuron model of {model_arch} not close enough."
@@ -1670,11 +1588,7 @@ class NeuronModelForObjectDetectionIntegrationTest(NeuronModelTestMixin):
         self.assertIn("logits", neuron_outputs)
         self.assertIn("pred_boxes", neuron_outputs)
         self.assertIsInstance(neuron_outputs.logits, torch.Tensor)
-        result_close = torch.allclose(
-            neuron_outputs.logits,
-            transformers_outputs.logits,
-            atol=atol,
-        )
+        result_close = torch.allclose(neuron_outputs.logits, transformers_outputs.logits, atol=atol,)
         if not result_close:
             warnings.warn(
                 f"Inference results between pytorch model and neuron model of {model_arch} not close enough."

--- a/tests/inference/test_stable_diffusion_pipeline.py
+++ b/tests/inference/test_stable_diffusion_pipeline.py
@@ -71,11 +71,7 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
         input_shapes = copy.deepcopy(self.STATIC_INPUTS_SHAPES)
         input_shapes.update({"num_images_per_prompt": num_images_per_prompt})
         neuron_pipeline = self.NEURON_MODEL_CLASS.from_pretrained(
-            MODEL_NAMES[model_arch],
-            export=True,
-            dynamic_batch_size=False,
-            **input_shapes,
-            **self.COMPILER_ARGS,
+            MODEL_NAMES[model_arch], export=True, dynamic_batch_size=False, **input_shapes, **self.COMPILER_ARGS,
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.unet, NeuronModelUnet)
@@ -234,11 +230,7 @@ class NeuronStableDiffusionPipelineIntegrationTest(unittest.TestCase):
         input_shapes.update({"num_images_per_prompt": 1})
         controlnet_id = "hf-internal-testing/tiny-controlnet"
         neuron_pipeline = NeuronStableDiffusionControlNetPipeline.from_pretrained(
-            MODEL_NAMES[model_arch],
-            controlnet_ids=controlnet_id,
-            export=True,
-            **input_shapes,
-            **self.COMPILER_ARGS,
+            MODEL_NAMES[model_arch], controlnet_ids=controlnet_id, export=True, **input_shapes, **self.COMPILER_ARGS,
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.unet, NeuronModelUnet)
@@ -296,11 +288,7 @@ class NeuronStableDiffusionXLPipelineIntegrationTest(unittest.TestCase):
         input_shapes = copy.deepcopy(self.STATIC_INPUTS_SHAPES)
         input_shapes.update({"num_images_per_prompt": num_images_per_prompt})
         neuron_pipeline = self.NEURON_MODEL_CLASS.from_pretrained(
-            MODEL_NAMES[model_arch],
-            export=True,
-            dynamic_batch_size=False,
-            **input_shapes,
-            **self.COMPILER_ARGS,
+            MODEL_NAMES[model_arch], export=True, dynamic_batch_size=False, **input_shapes, **self.COMPILER_ARGS,
         )
         self.assertIsInstance(neuron_pipeline.text_encoder, NeuronModelTextEncoder)
         self.assertIsInstance(neuron_pipeline.text_encoder_2, NeuronModelTextEncoder)

--- a/tests/peft/test_peft_training.py
+++ b/tests/peft/test_peft_training.py
@@ -87,9 +87,7 @@ def test_get_peft_model():
 @is_trainium_test
 class TestPeft(DistributedTest):
     @pytest.fixture(
-        scope="class",
-        params=[[2, 1, 1], [2, 2, 1]],
-        ids=["dp=2", "tp=2"],
+        scope="class", params=[[2, 1, 1], [2, 2, 1]], ids=["dp=2", "tp=2"],
     )
     def parallel_sizes(self, request):
         return request.param
@@ -227,10 +225,7 @@ class TestPeft(DistributedTest):
         peft_config = get_peft_config(lora_on_embeddings=True, lora_on_lm_head=True)
 
         accelerator = create_accelerator(
-            tp_size,
-            pp_size,
-            parallelize_embeddings=True,
-            sequence_parallel_enabled=True,
+            tp_size, pp_size, parallelize_embeddings=True, sequence_parallel_enabled=True,
         )
 
         seed_patcher = StaticSeedPatcher(42)
@@ -243,10 +238,7 @@ class TestPeft(DistributedTest):
         orig_model = accelerator.patch_model_for_neuron(orig_model)
 
         inputs = get_model_inputs(
-            orig_model,
-            orig_model.config.name_or_path,
-            batch_size=dp_size,
-            pad_to_multiple_of=16,
+            orig_model, orig_model.config.name_or_path, batch_size=dp_size, pad_to_multiple_of=16,
         )
         xla_inputs = {k: v.to(xm.xla_device()) for k, v in inputs.items()}
 
@@ -315,10 +307,7 @@ class TestPeft(DistributedTest):
         _, model = get_tokenizer_and_tiny_llama_model()
         model = get_peft_model(model, peft_config)
         accelerator = create_accelerator(
-            tp_size,
-            pp_size,
-            parallelize_embeddings=True,
-            sequence_parallel_enabled=True,
+            tp_size, pp_size, parallelize_embeddings=True, sequence_parallel_enabled=True,
         )
         model = accelerator.prepare_model(model)
         requires_grad = {n: p.requires_grad for n, p in model.named_parameters()}

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -65,9 +65,9 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
         assert get_neuron_cache_path() is None
 
         custom_cache_dir_name = Path("_this/is_/my1/2custom/cache/dir")
-        os.environ["NEURON_CC_FLAGS"] = (
-            f"--some --parameters --here --cache_dir={custom_cache_dir_name} --other --paremeters --here"
-        )
+        os.environ[
+            "NEURON_CC_FLAGS"
+        ] = f"--some --parameters --here --cache_dir={custom_cache_dir_name} --other --paremeters --here"
 
         self.assertEqual(get_neuron_cache_path(), custom_cache_dir_name)
 
@@ -81,9 +81,9 @@ class NeuronUtilsTestCase(TrainiumTestMixin, TestCase):
         set_neuron_cache_path(new_cache_path, ignore_no_cache=True)
         self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
 
-        os.environ["NEURON_CC_FLAGS"] = (
-            "--some --parameters --here --cache_dir=original_cache_dir --other --paremeters"
-        )
+        os.environ[
+            "NEURON_CC_FLAGS"
+        ] = "--some --parameters --here --cache_dir=original_cache_dir --other --paremeters"
         set_neuron_cache_path(new_cache_path)
         self.assertEqual(get_neuron_cache_path(), Path(new_cache_path))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -97,48 +97,13 @@ COVERAGE = Coverage(os.environ.get("COVERAGE", "all"))
 RUN_TINY = string_to_bool(os.environ.get("RUN_TINY", "false"))
 
 MODELS_TO_TEST_MAPPING = {
-    "albert": (
-        "albert-base-v2",
-        TPSupport.NONE,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
-    "bart": (
-        "facebook/bart-base",
-        TPSupport.NONE,
-        Coverage.MIDDLE,
-        {"encoder_layers": 2, "decoder_layers": 2},
-    ),
-    "bert": (
-        "bert-base-uncased",
-        TPSupport.FULL,
-        Coverage.HIGH,
-        {"num_hidden_layers": 4},
-    ),
-    "camembert": (
-        "camembert-base",
-        TPSupport.NONE,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
-    "distilbert": (
-        "distilbert-base-uncased",
-        TPSupport.NONE,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
-    "electra": (
-        "google/electra-base-discriminator",
-        TPSupport.NONE,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
-    "gpt2": (
-        "gpt2",
-        TPSupport.NONE,
-        Coverage.MIDDLE,
-        {"num_hidden_layers": 4},
-    ),
+    "albert": ("albert-base-v2", TPSupport.NONE, Coverage.LOW, {"num_hidden_layers": 4},),
+    "bart": ("facebook/bart-base", TPSupport.NONE, Coverage.MIDDLE, {"encoder_layers": 2, "decoder_layers": 2},),
+    "bert": ("bert-base-uncased", TPSupport.FULL, Coverage.HIGH, {"num_hidden_layers": 4},),
+    "camembert": ("camembert-base", TPSupport.NONE, Coverage.LOW, {"num_hidden_layers": 4},),
+    "distilbert": ("distilbert-base-uncased", TPSupport.NONE, Coverage.LOW, {"num_hidden_layers": 4},),
+    "electra": ("google/electra-base-discriminator", TPSupport.NONE, Coverage.LOW, {"num_hidden_layers": 4},),
+    "gpt2": ("gpt2", TPSupport.NONE, Coverage.MIDDLE, {"num_hidden_layers": 4},),
     "gpt_neo": (
         "EleutherAI/gpt-neo-125M",
         TPSupport.PARTIAL,
@@ -151,49 +116,14 @@ MODELS_TO_TEST_MAPPING = {
         Coverage.MIDDLE,
         {"encoder_layers": 2, "decoder_layers": 2},
     ),
-    "roberta": (
-        "roberta-base",
-        TPSupport.PARTIAL,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
-    "t5": (
-        "t5-small",
-        TPSupport.FULL,
-        Coverage.HIGH,
-        {"num_hidden_layers": 2},
-    ),
-    "vit": (
-        "google/vit-base-patch16-224-in21k",
-        TPSupport.NONE,
-        Coverage.HIGH,
-        {"num_hidden_layers": 4},
-    ),
-    "xlm-roberta": (
-        "xlm-roberta-base",
-        TPSupport.NONE,
-        Coverage.LOW,
-        {"num_hidden_layers": 4},
-    ),
+    "roberta": ("roberta-base", TPSupport.PARTIAL, Coverage.LOW, {"num_hidden_layers": 4},),
+    "t5": ("t5-small", TPSupport.FULL, Coverage.HIGH, {"num_hidden_layers": 2},),
+    "vit": ("google/vit-base-patch16-224-in21k", TPSupport.NONE, Coverage.HIGH, {"num_hidden_layers": 4},),
+    "xlm-roberta": ("xlm-roberta-base", TPSupport.NONE, Coverage.LOW, {"num_hidden_layers": 4},),
     # TODO: issue with this model for now.
-    "m2m_100": (
-        "facebook/m2m100_418M",
-        TPSupport.NONE,
-        Coverage.MIDDLE,
-        {"encoder_layers": 2, "decoder_layers": 2},
-    ),
-    "llama": (
-        "NousResearch/Llama-2-7b-hf",
-        TPSupport.FULL,
-        Coverage.HIGH,
-        {"num_hidden_layers": 2},
-    ),
-    "mistral": (
-        "mistralai/Mistral-7B-v0.1",
-        TPSupport.FULL,
-        Coverage.HIGH,
-        {"num_hidden_layers": 2},
-    ),
+    "m2m_100": ("facebook/m2m100_418M", TPSupport.NONE, Coverage.MIDDLE, {"encoder_layers": 2, "decoder_layers": 2},),
+    "llama": ("NousResearch/Llama-2-7b-hf", TPSupport.FULL, Coverage.HIGH, {"num_hidden_layers": 2},),
+    "mistral": ("mistralai/Mistral-7B-v0.1", TPSupport.FULL, Coverage.HIGH, {"num_hidden_layers": 2},),
     # "wav2vec2": "facebook/wav2vec2-base",
     # Remaning: XLNet, Deberta-v2, MPNet, CLIP
 }

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -32,9 +32,7 @@ from transformers.testing_utils import is_staging_test
 from optimum.neuron import NeuronSFTConfig, NeuronSFTTrainer, NeuronTrainer, NeuronTrainingArguments
 from optimum.neuron.distributed.utils import MODEL_PARALLEL_SHARDS_DIR_NAME
 from optimum.neuron.utils import is_neuronx_distributed_available
-from optimum.neuron.utils.cache_utils import (
-    list_files_in_neuron_cache,
-)
+from optimum.neuron.utils.cache_utils import list_files_in_neuron_cache
 from optimum.neuron.utils.testing_utils import is_trainium_test
 from optimum.neuron.utils.training_utils import get_model_param_count
 
@@ -75,9 +73,7 @@ class TestNeuronTrainingUtils(DistributedTest):
         target_num_parameters = sum(p.numel() for p in model.parameters())
 
         args = NeuronTrainingArguments(
-            tensor_parallel_size=tp_size,
-            pipeline_parallel_size=pp_size,
-            output_dir=output_dir.as_posix(),
+            tensor_parallel_size=tp_size, pipeline_parallel_size=pp_size, output_dir=output_dir.as_posix(),
         )
         trainer = NeuronTrainer(args=args, model=model)
         prepared_model = trainer.accelerator.prepare_model(model)
@@ -93,10 +89,7 @@ class TestNeuronTrainer(DistributedTest):
         # TODO: enable dp + tp + pp, currently produces communication error between replicas.
         # TODO: Fix pp as well.
         params=[[2, 1, 1], [2, 2, 1]],  # , [2, 1, 2]],  # [8, 2, 2]],
-        ids=[
-            "dp=2",
-            "tp=2",
-        ],  # "pp=2"],  # , "dp=4,tp=pp=2"],
+        ids=["dp=2", "tp=2",],  # "pp=2"],  # , "dp=4,tp=pp=2"],
     )
     def parallel_sizes(self, request):
         return request.param
@@ -402,9 +395,7 @@ class TestNeuronTrainer(DistributedTest):
 @is_trainium_test
 class TestNeuronSFTTrainer(DistributedTest):
     @pytest.fixture(
-        scope="class",
-        params=[[2, 1, 1], [2, 2, 1]],
-        ids=["dp=2", "tp=2"],
+        scope="class", params=[[2, 1, 1], [2, 2, 1]], ids=["dp=2", "tp=2"],
     )
     def parallel_sizes(self, request):
         return request.param
@@ -440,20 +431,11 @@ class TestNeuronSFTTrainer(DistributedTest):
             logging_steps=1,
         )
         args = args.to_dict()
-        sft_config = NeuronSFTConfig(
-            max_seq_length=512,
-            packing=packing,
-            dataset_num_proc=1,
-            **args,
-        )
+        sft_config = NeuronSFTConfig(max_seq_length=512, packing=packing, dataset_num_proc=1, **args,)
 
         # Create Trainer instance
         trainer = NeuronSFTTrainer(
-            model=model,
-            tokenizer=tokenizer,
-            train_dataset=dataset,
-            formatting_func=format_dolly,
-            args=sft_config,
+            model=model, tokenizer=tokenizer, train_dataset=dataset, formatting_func=format_dolly, args=sft_config,
         )
 
         trainer.train()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -79,7 +79,6 @@ def get_random_string(length) -> str:
 
 
 def create_dummy_dataset(input_specs: Dict[str, Tuple[Tuple[int, ...], torch.dtype]], num_examples: int) -> Dataset:
-
     def gen():
         for _ in range(num_examples):
             yield {name: torch.rand(shape) for name, shape in input_specs.items()}
@@ -143,11 +142,7 @@ def create_dummy_causal_lm_dataset(
                 input_ids = generate_input_ids(vocab_size, 1, sequence_length)
                 attention_mask = generate_attention_mask(1, sequence_length, random=random_attention_mask)
                 examples.append(
-                    {
-                        "input_ids": input_ids,
-                        "attention_mask": attention_mask,
-                        "labels": input_ids,
-                    }
+                    {"input_ids": input_ids, "attention_mask": attention_mask, "labels": input_ids,}
                 )
             for i in range(num_examples):
                 yield examples[i % max_number_of_unique_examples]
@@ -391,9 +386,7 @@ def get_model_inputs(
                 else:
                     pad_value = 1
                 tensor = torch.nn.functional.pad(
-                    tensor,
-                    pad=(0, pad_to_multiple_of - tensor.shape[1] % pad_to_multiple_of),
-                    value=pad_value,
+                    tensor, pad=(0, pad_to_multiple_of - tensor.shape[1] % pad_to_multiple_of), value=pad_value,
                 )
                 inputs[name] = tensor
     return inputs
@@ -507,9 +500,7 @@ class StagingTestMixin:
         operations = [CommitOperationDelete(path_in_repo=filename) for filename in filenames]
         try:
             api.create_commit(
-                repo_id=repo_id,
-                operations=operations,
-                commit_message="Cleanup the repo",
+                repo_id=repo_id, operations=operations, commit_message="Cleanup the repo",
             )
         except RepositoryNotFoundError:
             pass

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -217,9 +217,7 @@ class Slot:
         """Mark the slot as ready for generation."""
         self._state = Slot.State.READY
 
-    def _decode_next_tokens(
-        self,
-    ) -> str:
+    def _decode_next_tokens(self,) -> str:
         """Hack to hopefully support generate_stream for the maximum number of tokenizers"""
         # We need to include the tokens that produced the last text to defeat cleanup algorithms in the decode
         # which decide to add a space or not depending on the surrounding ids.
@@ -231,8 +229,7 @@ class Slot:
 
         # Compare the generated text with the one using only the tokens producing the last one
         last_text = self._tokenizer.decode(
-            self._tokens[self._next_text_token_start : self._next_text_token_end],
-            skip_special_tokens=False,
+            self._tokens[self._next_text_token_start : self._next_text_token_end], skip_special_tokens=False,
         )
         if len(new_text) == len(last_text):
             # Nothing new was actually generated
@@ -312,9 +309,7 @@ class NeuronGenerator(Generator):
     """A Generator for Neuron models."""
 
     def __init__(
-        self,
-        model: NeuronModelForCausalLM,
-        tokenizer: PreTrainedTokenizerBase,
+        self, model: NeuronModelForCausalLM, tokenizer: PreTrainedTokenizerBase,
     ):
         self.model = model
         self.rebuild_cache_on_prefill = not self.model.continuous_batching
@@ -331,11 +326,7 @@ class NeuronGenerator(Generator):
     def info(self) -> InfoResponse:
         """Returns the expected InfoResponse."""
         dtype = getattr(self.model.config, "torch_dtype", "float32")
-        return InfoResponse(
-            requires_padding=True,
-            dtype=str(dtype),
-            device_type="xla",
-        )
+        return InfoResponse(requires_padding=True, dtype=str(dtype), device_type="xla",)
 
     def warmup(self, batch: Batch) -> int:
         """Verify if the hardware can support the target load.

--- a/text-generation-inference/server/text_generation_server/interceptor.py
+++ b/text-generation-inference/server/text_generation_server/interceptor.py
@@ -9,11 +9,7 @@ from loguru import logger
 
 class ExceptionInterceptor(AsyncServerInterceptor):
     async def intercept(
-        self,
-        method: Callable,
-        request_or_iterator: Any,
-        context: grpc.ServicerContext,
-        method_name: str,
+        self, method: Callable, request_or_iterator: Any, context: grpc.ServicerContext, method_name: str,
     ) -> Any:
         try:
             response = method(request_or_iterator, context)

--- a/text-generation-inference/server/text_generation_server/model.py
+++ b/text-generation-inference/server/text_generation_server/model.py
@@ -55,16 +55,13 @@ def log_cache_size():
     path = HF_HUB_CACHE
     if os.path.exists(path):
         usage = shutil.disk_usage(path)
-        gb = 2**30
+        gb = 2 ** 30
         logger.info(f"Cache disk [{path}]: total = {usage.total/gb:.2f} G, free = {usage.free/gb:.2f} G")
     else:
         raise ValueError(f"The cache directory ({path}) does not exist.")
 
 
-def fetch_model(
-    model_id: str,
-    revision: Optional[str] = None,
-) -> str:
+def fetch_model(model_id: str, revision: Optional[str] = None,) -> str:
     """Fetch a neuron model.
 
     Args:

--- a/text-generation-inference/server/text_generation_server/server.py
+++ b/text-generation-inference/server/text_generation_server/server.py
@@ -50,9 +50,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
 
 def serve(
-    model_id: str,
-    revision: str,
-    uds_path: Path,
+    model_id: str, revision: str, uds_path: Path,
 ):
     async def serve_inner(model_id: str, revision: str):
         unix_socket_template = "unix://{}-{}"

--- a/text-generation-inference/tests/fixtures/service.py
+++ b/text-generation-inference/tests/fixtures/service.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__file__)
 
 
 class TestClient(AsyncInferenceClient):
-
     def __init__(self, service_name: str, base_url: str):
         super().__init__(model=base_url)
         self.service_name = service_name
@@ -104,9 +103,7 @@ def launcher(event_loop):
 
     @contextlib.contextmanager
     def docker_launcher(
-        service_name: str,
-        model_name_or_path: str,
-        trust_remote_code: bool = False,
+        service_name: str, model_name_or_path: str, trust_remote_code: bool = False,
     ):
         port = random.randint(8000, 10_000)
 
@@ -137,9 +134,7 @@ def launcher(event_loop):
 
             docker_tag = f"{container_name}-img"
             logger.info(
-                "Building image on the flight derivated from %s, tagged with %s",
-                DOCKER_IMAGE,
-                docker_tag,
+                "Building image on the flight derivated from %s, tagged with %s", DOCKER_IMAGE, docker_tag,
             )
             with tempfile.TemporaryDirectory() as context_dir:
                 # Copy model directory to build context

--- a/text-generation-inference/tests/integration/test_generate.py
+++ b/text-generation-inference/tests/integration/test_generate.py
@@ -69,12 +69,7 @@ async def test_model_single_request(tgi_service):
 @pytest.mark.asyncio
 async def test_model_multiple_requests(tgi_service, generate_load):
     num_requests = 4
-    responses = await generate_load(
-        tgi_service.client,
-        "What is Deep Learning?",
-        max_new_tokens=17,
-        n=num_requests,
-    )
+    responses = await generate_load(tgi_service.client, "What is Deep Learning?", max_new_tokens=17, n=num_requests,)
 
     assert len(responses) == 4
     expectations = {

--- a/text-generation-inference/tests/integration/test_implicit_env.py
+++ b/text-generation-inference/tests/integration/test_implicit_env.py
@@ -42,15 +42,10 @@ async def test_model_single_request(tgi_service):
     # Just verify that the generation works, and nothing is raised, with several set of params
 
     # No params
-    await tgi_service.client.text_generation(
-        "What is Deep Learning?",
-    )
+    await tgi_service.client.text_generation("What is Deep Learning?",)
 
     response = await tgi_service.client.text_generation(
-        "How to cook beans ?",
-        max_new_tokens=17,
-        details=True,
-        decoder_input_details=True,
+        "How to cook beans ?", max_new_tokens=17, details=True, decoder_input_details=True,
     )
     assert response.details.generated_tokens == 17
 

--- a/text-generation-inference/tests/server/test_prefill.py
+++ b/text-generation-inference/tests/server/test_prefill.py
@@ -49,9 +49,7 @@ def test_prefill_truncate(neuron_model_config):
     generator = NeuronGenerator.from_pretrained(neuron_model_path)
     batch_size = generator.model.batch_size
     # We apply truncation to all requests but the first one
-    truncate = [
-        None,
-    ] + [i * 3 for i in range(1, batch_size)]
+    truncate = [None,] + [i * 3 for i in range(1, batch_size)]
     input_text = (
         "Two gin-scented tears trickled down the sides of his nose."
         " But it was all right, everything was all right, the struggle was finished."

--- a/tools/auto_fill_neuron_cache.py
+++ b/tools/auto_fill_neuron_cache.py
@@ -117,18 +117,12 @@ ARCHITECTURES_TO_COMMON_PRETRAINED_WEIGHTS = {
         },
     },
     "gpt2": {
-        "gpt2": {
-            "default": {"batch_size": 16, "sequence_length": 128},
-        },
+        "gpt2": {"default": {"batch_size": 16, "sequence_length": 128},},
         # "gpt2-large": {
         #     "default": {"batch_size": 16, "sequence_length": 128},
         # },
     },
-    "gpt-neo": {
-        "EleutherAI/gpt-neo-125M": {
-            "default": {"batch_size": 16, "sequence_length": 128},
-        },
-    },
+    "gpt-neo": {"EleutherAI/gpt-neo-125M": {"default": {"batch_size": 16, "sequence_length": 128},},},
     "marian": {
         "Helsinki-NLP/opus-mt-en-es": {
             "translation": {"batch_size": 4, "source_sequence_length": 512, "target_sequence_length": 512},

--- a/tools/list_top_models.py
+++ b/tools/list_top_models.py
@@ -5,7 +5,6 @@ from huggingface_hub import HfApi
 
 
 class ModelStats(HfApi):
-
     class Sort:
         DOWNLOADS = "downloads"
         TRENDING = "trendingScore"


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in the `consolidate_tensor_parallel_checkpoints` function where non-contiguous tensors caused a `ValueError` when saving consolidated model checkpoints, particularly with the Safetensors format. The fix ensures that tensors are made contiguous before and after concatenation, resolving memory layout issues during saving.

### Error Example:

When running the following command:

```python
consolidate_model_parallel_checkpoints_to_unified_checkpoint(
    Path("./model_sharded/model/shards"), 
    "./consolidated", 
    "safetensors"
)
```

The following error occurs:

`ValueError: You are trying to save a non contiguous tensor: model.layers.0.self_attn.o_proj.weight which is not allowed.`

This PR solves the issue by applying the `.contiguous()` method to tensors at key points in the consolidation process, ensuring the consolidated model can be saved without errors.

# Motivation and Context:

When consolidating distributed model checkpoints (e.g., from model shards), tensors may not be contiguous in memory. Safetensors, which is a memory-efficient way to store models, does not allow saving non-contiguous tensors. This PR modifies the `consolidate_tensor_parallel_checkpoints` function to apply `.contiguous()` to tensors to ensure that the checkpoints can be properly consolidated and saved.

This change impacts the overall consolidation pipeline, as `consolidate_model_parallel_checkpoints_to_unified_checkpoint` depends on the lower-level functions to process tensors correctly.