### PR TITLE
Added num_cores argument to neuron

### DIFF
--- a/optimum/commands/export/neuron.py
+++ b/optimum/commands/export/neuron.py
@@ -60,6 +60,12 @@ def parse_args_neuron(parser: "ArgumentParser"):
         default=None,
         help="If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol for the model will be used.",
     )
+    optional_group.add_argument(
+        "--num_cores",
+        type=int,
+        default=1,
+        help="Number of neuron cores used when instantiating the model. Each neuron core has 16 Gb of memory, which means that bigger models need to be split on multiple cores.",
+    )
     optional_group.add_argument("--cache_dir", type=str, default=None, help="Path indicating where to store cache.")
     optional_group.add_argument(
         "--disable_neuron_cache",


### PR DESCRIPTION
# What does this PR do?

Added num_cores argument to optimum-cli export neuron

Fixes # (issue)

Was getting AttributeError: 'Namespace' object has no attribute 'num_cores' on optimum-cli export neuron


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
