### PR TITLE
Cache Qwen 2.5 models

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -22,9 +22,11 @@ jobs:
         config: [
           gpt2,
           llama,
+          qwen2.5,
           llama3.1-70b,
           llama3-70b,
           llama2-70b,
+          qwen2.5-large,
           mistral,
           llama-variants,
           mistral-variants,

--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -24,8 +24,6 @@ jobs:
           llama,
           qwen2.5,
           llama3.1-70b,
-          llama3-70b,
-          llama2-70b,
           qwen2.5-large,
           mistral,
           llama-variants,


### PR DESCRIPTION
# What does this PR do?

This adds the Qwen 2.5 models to the list of models to be cached by the nightly workflow.