### PR TITLE
Fix emb model export and load with trfrs

### DIFF
--- a/optimum/neuron/modeling_traced.py
+++ b/optimum/neuron/modeling_traced.py
@@ -363,6 +363,7 @@ class NeuronTracedModel(NeuronModel):
                 local_files_only=local_files_only,
                 token=token,
                 do_validation=False,
+                library_name=cls.library_name,
                 **kwargs_shapes,
             )
             config = AutoConfig.from_pretrained(save_dir_path)

--- a/tests/inference/test_modeling.py
+++ b/tests/inference/test_modeling.py
@@ -109,7 +109,6 @@ class NeuronModelIntegrationTest(NeuronModelIntegrationTestMixin):
             self.TINY_SUBFOLDER_MODEL_ID,
             subfolder="my_subfolder",
             export=True,
-            library_name="transformers",
             **self.STATIC_INPUTS_SHAPES,
         )
         self.assertIsInstance(model.model, torch.jit._script.ScriptModule)


### PR DESCRIPTION
# What does this PR do?

Fixes #744 

With the PR, we should be once again able to export embedding model via transformers library or sentence transformer library depending on the class called:

* With Transformers

```python
import torch
from optimum.neuron import NeuronModelForFeatureExtraction
from transformers import AutoConfig, AutoTokenizer

compiler_args = {"auto_cast": "matmul", "auto_cast_type": "fp16"}
input_shapes = {"batch_size": 4, "sequence_length": 512}
model = NeuronModelForFeatureExtraction.from_pretrained(
    model_id="TaylorAI/bge-micro-v2", # BERT SMALL
    export=True,
    disable_neuron_cache=True,
    **compiler_args,
    **input_shapes,
)
```

* With Sentence Transformers

```python
import torch
from optimum.neuron import NeuronModelForSentenceTransformers
from transformers import AutoConfig, AutoTokenizer

compiler_args = {"auto_cast": "matmul", "auto_cast_type": "fp16"}
input_shapes = {"batch_size": 4, "sequence_length": 512}
model = NeuronModelForSentenceTransformers.from_pretrained(
    model_id="TaylorAI/bge-micro-v2", # BERT SMALL
    export=True,
    disable_neuron_cache=True,
    **compiler_args,
    **input_shapes,
)
```
