### PR TITLE
fix(peft): adapt to latest internal API

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ["3.9"]
         os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.10"]
         os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}

--- a/optimum/neuron/accelerate/accelerator.py
+++ b/optimum/neuron/accelerate/accelerator.py
@@ -33,7 +33,6 @@ from accelerate.utils.operations import gather_object, recursively_apply
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from transformers import PreTrainedModel
-from transformers.utils import is_peft_available
 
 from ...utils import logging
 from ..distributed import Parallelizer, ParallelizersManager
@@ -47,6 +46,7 @@ from ..utils import (
     patch_within_function,
     replace_class_in_inheritance_hierarchy,
 )
+from ..utils.import_utils import is_peft_available
 from ..utils.misc import args_and_kwargs_to_kwargs_only, is_main_worker
 from ..utils.model_utils import get_tied_parameters_dict, tie_parameters
 from ..utils.require_utils import requires_neuronx_distributed, requires_torch_xla

--- a/optimum/neuron/distributed/checkpointing.py
+++ b/optimum/neuron/distributed/checkpointing.py
@@ -26,9 +26,9 @@ from transformers.utils import (
     SAFE_WEIGHTS_NAME,
     WEIGHTS_INDEX_NAME,
     WEIGHTS_NAME,
-    is_peft_available,
 )
 
+from ..utils.import_utils import is_peft_available
 from ..utils.peft_utils import ADAPTER_MODEL_PARALLEL_SHARDS_DIR_NAME
 from ..utils.require_utils import requires_neuronx_distributed, requires_safetensors, requires_torch_xla
 from .utils import MODEL_PARALLEL_SHARDS_DIR_NAME, ParameterMetadata, compute_query_indices_for_rank

--- a/optimum/neuron/distributed/parallel_layers.py
+++ b/optimum/neuron/distributed/parallel_layers.py
@@ -23,10 +23,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, 
 
 import torch
 from torch.nn.modules.loss import _WeightedLoss
-from transformers.utils import is_peft_available
 
 from ...utils import NormalizedConfigManager, logging
 from ..utils import patch_everywhere, patch_within_function
+from ..utils.import_utils import is_peft_available
 from ..utils.misc import is_main_worker
 from ..utils.require_utils import requires_neuronx_distributed
 from .utils import (

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -1078,6 +1078,7 @@ def _peft_tuner_linear_to_parallel_linear(
                 config.init_lora_weights,
                 config.use_rslora,
                 config.use_dora,
+                config.lora_bias,
             )
             if axis == "row":
                 layer_to_parallelize = parent.lora_A[adapter_name]

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -412,6 +412,7 @@ def _peft_tuner_embedding_to_parallel_embedding(
                     config.init_lora_weights,
                     config.use_rslora,
                     config.use_dora,
+                    config.lora_bias,
                 )
                 mark_parameter_init_status_during_parallelization(parent.lora_embedding_A[adapter_name], True)
                 mark_parameter_init_status_during_parallelization(parent.lora_embedding_B[adapter_name], True)

--- a/optimum/neuron/distributed/utils.py
+++ b/optimum/neuron/distributed/utils.py
@@ -27,12 +27,11 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Set, 
 
 import torch
 from transformers import PretrainedConfig
-from transformers.utils import is_peft_available
 from transformers.utils.fx import HFTracer
 
 from ...utils import logging
 from ..utils import DynamicPatch, Patcher
-from ..utils.import_utils import is_neuronx_distributed_available
+from ..utils.import_utils import is_neuronx_distributed_available, is_peft_available
 from ..utils.misc import download_checkpoints_in_cache, is_precompilation
 from ..utils.peft_utils import NeuronPeftModel
 from ..utils.require_utils import requires_neuronx_distributed, requires_peft, requires_safetensors, requires_torch_xla

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -80,7 +80,6 @@ from transformers.utils import (
     WEIGHTS_NAME,
     is_accelerate_available,
     is_apex_available,
-    is_peft_available,
     is_sagemaker_mp_enabled,
 )
 
@@ -102,6 +101,7 @@ from .utils.cache_utils import (
     has_write_access_to_repo,
 )
 from .utils.hub_cache_utils import ModelCacheEntry, hub_neuronx_cache, patch_neuron_cc_wrapper, synchronize_hub_cache
+from .utils.import_utils import is_peft_available
 from .utils.misc import is_main_worker, is_precompilation
 from .utils.peft_utils import NeuronPeftModel, get_peft_model
 from .utils.require_utils import requires_neuronx_distributed, requires_torch_neuronx

--- a/optimum/neuron/utils/import_utils.py
+++ b/optimum/neuron/utils/import_utils.py
@@ -21,6 +21,7 @@ from packaging import version
 
 
 MIN_ACCELERATE_VERSION = "0.20.1"
+MIN_PEFT_VERSION = "0.14.0"
 
 
 def is_neuron_available() -> bool:
@@ -80,3 +81,16 @@ def is_trl_available(required_version: Optional[str] = None) -> bool:
 
         raise RuntimeError(f"Only `trl=={required_version}` is supported, but {trl.__version__} is installed.")
     return False
+
+
+def is_peft_available(min_version: Optional[str] = MIN_PEFT_VERSION) -> bool:
+    _peft_available = importlib.util.find_spec("peft") is not None
+    if min_version is not None:
+        if _peft_available:
+            import peft
+
+            _peft_version = peft.__version__
+            return version.parse(_peft_version) >= version.parse(min_version)
+        else:
+            return False
+    return _peft_available

--- a/optimum/neuron/utils/peft_utils.py
+++ b/optimum/neuron/utils/peft_utils.py
@@ -22,8 +22,8 @@ from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
 import torch
-from transformers.utils import is_peft_available
 
+from .import_utils import is_peft_available
 from .patching import Patcher, replace_class_in_inheritance_hierarchy
 from .require_utils import requires_neuronx_distributed, requires_safetensors
 from .training_utils import _get_model_param_count

--- a/optimum/neuron/utils/require_utils.py
+++ b/optimum/neuron/utils/require_utils.py
@@ -17,10 +17,11 @@
 import functools
 from typing import Any, Callable, Dict
 
-from transformers.utils import is_peft_available, is_safetensors_available
+from transformers.utils import is_safetensors_available
 
 from .import_utils import (
     is_neuronx_distributed_available,
+    is_peft_available,
     is_torch_neuronx_available,
     is_torch_xla_available,
     is_transformers_neuronx_available,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ TESTS_REQUIRE = [
     "diffusers>=0.28.0, <=0.30.3",
     "safetensors",
     "sentence-transformers >= 2.2.0",
-    "peft",
+    "peft>=0.14.0",
     "trl==0.11.4",
     "compel",
     "rjieba",
@@ -72,7 +72,7 @@ EXTRAS_REQUIRE = {
         "neuronx_distributed==0.9.0",
         "libneuronxla==2.0.5347.0",
     ],
-    "diffusers": ["diffusers>=0.28.0, <=0.30.3", "peft"],
+    "diffusers": ["diffusers>=0.28.0, <=0.30.3", "peft>=0.14.0"],
     "sentence-transformers": ["sentence-transformers >= 2.2.0"],
 }
 


### PR DESCRIPTION
# What does this PR do?

There has been an evolution in the PEFT internal API that is used by `optimum-neuron` when subclassing the PEFT Trainer.

This pull-request:
- adapts to the new internal API,
- sets a minimum PEFT version in `optimum-neuron` prerequisites,
- modifies internal checks for PEFT to verify that the version is at least 0.14.0.