### PR TITLE
chore(ci): fix trufflehog secrets check failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,20 +10,9 @@ jobs:
   secrets:
     runs-on: ubuntu-latest
     steps:
-      - shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_ENV
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          fi
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{env.branch}}
-          fetch-depth: ${{env.depth}}
-      - name: Scan for secrets
+          fetch-depth: 0
+      - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
There are failures with CI secrets' checks. This tries to fix it in the same was that was done on optimum-tpu in https://github.com/huggingface/optimum-tpu/pull/79

(and it worked).
