### PR TITLE
Bump transformers version to 4.48.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ To install the latest release of this package:
 * For AWS Trainium (trn1) or AWS inferentia2 (inf2)
 
 ```bash
-pip install --upgrade-strategy eager optimum[neuronx]
+pip install --upgrade-strategy eager optimum-neuron[neuronx]
 ```
 
 * For AWS inferentia (inf1)
 
 ```bash
-pip install --upgrade-strategy eager optimum[neuron]
+pip install --upgrade-strategy eager optimum-neuron[neuron]
 ```
 
 Optimum Neuron is a fast-moving project, and you may want to install it from source:

--- a/docs/source/guides/export_model.mdx
+++ b/docs/source/guides/export_model.mdx
@@ -65,13 +65,13 @@ To export a 🤗 Transformers model to Neuron, you'll first need to install some
 **For Inf2**
 
 ```bash
-pip install optimum[neuronx]
+pip install optimum-neuron[neuronx]
 ```
 
 **For Inf1**
 
 ```bash
-pip install optimum[neuron]
+pip install optimum-neuron[neuron]
 ```
 
 The Optimum Neuron export can be used through Optimum command-line:

--- a/docs/source/inference_tutorials/stable_diffusion.mdx
+++ b/docs/source/inference_tutorials/stable_diffusion.mdx
@@ -25,7 +25,7 @@ limitations under the License.
 To get started, make sure you have [configured your inf2 / trn1 instance](../installation), and installed optimum:
 
 ```bash
-pip install "optimum[neuronx, diffusers]"
+pip install optimum-neuron[neuronx] diffusers
 ```
 
 ### Compile Stable Diffusion
@@ -585,7 +585,7 @@ pipe.save_pretrained("sd_neuron_controlnet")
 
 ### Text-to-Image
 
-For text-to-image, we can specify an additional conditioning input. 
+For text-to-image, we can specify an additional conditioning input.
 
 Here is an example with a canny image, a white outline of an image on a black background. The ControlNet will use the canny image as a control to guide the model to generate an image with the same outline.
 

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -29,11 +29,11 @@ python -m pip config set global.extra-index-url https://pip.repos.neuron.amazona
 ## Installing `optimum-neuron` for AWS Trainium (`trn1`) or AWS inferentia2 (`inf2`)
 
 ```bash
-python -m pip install --upgrade-strategy eager optimum[neuronx]
+python -m pip install --upgrade-strategy eager optimum-neuron[neuronx]
 ```
 
 ## Installing `optimum-neuron` for AWS inferentia (`inf1`)
 
 ```bash
-python -m pip install --upgrade-strategy eager optimum[neuron]
+python -m pip install --upgrade-strategy eager optimum-neuron[neuron]
 ```

--- a/infrastructure/ami/hcl2-files/build.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/build.pkr.hcl
@@ -14,7 +14,7 @@ build {
     ]
   }
   provisioner "shell" {
-    inline = ["echo 'source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate' | sudo tee -a /home/ubuntu/.bashrc"]
+    inline = ["echo 'source /opt/aws_neuronx_venv_pytorch/bin/activate' | sudo tee -a /home/ubuntu/.bashrc"]
   }
   provisioner "file" {
     source      = "scripts/welcome-msg.sh"

--- a/infrastructure/ami/hcl2-files/variables.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/variables.pkr.hcl
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "source_ami" {
-  default     = "ami-0980ce83654efe544"
+  default     = "ami-034a7ef9c22c72085"
   description = "Base Image"
   type        = string
   /*

--- a/infrastructure/ami/scripts/install-huggingface-libraries.sh
+++ b/infrastructure/ami/scripts/install-huggingface-libraries.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Activate the neuron virtual environment
-source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate
+source /opt/aws_neuronx_venv_pytorch/bin/activate
 
 echo "Step: install-hugging-face-libraries"
 
@@ -15,12 +15,12 @@ pip install --upgrade --no-cache-dir \
     "markupsafe==2.1.1" \
     "jinja2==3.1.2" \
     "attrs==23.1.0" \
-    "hf_transfer>=0.1.4" 
+    "hf_transfer>=0.1.4"
 
 # Temporary fix for the issue: https://github.com/huggingface/optimum-neuron/issues/142
 pip install -U optimum
 echo 'export PATH="${HOME}/.local/bin:$PATH"' >> "${HOME}/.bashrc"
-# Add HF_TRANSFER by default 
+# Add HF_TRANSFER by default
 echo 'export HF_HUB_ENABLE_HF_TRANSFER=1' >> "${HOME}/.bashrc"
 
 echo "Step: install-and-copy-optimum-neuron-examples"

--- a/infrastructure/ami/scripts/validate-neuron.sh
+++ b/infrastructure/ami/scripts/validate-neuron.sh
@@ -3,7 +3,7 @@ echo "Step: validate-neuron-devices"
 neuron-ls
 
 # Activate the neuron virtual environment
-source /opt/aws_neuronx_venv_pytorch_2_1/bin/activate
+source /opt/aws_neuronx_venv_pytorch/bin/activate
 
 python -c 'import torch'
 python -c 'import torch_neuronx'

--- a/notebooks/stable-diffusion/stable-diffusion-txt2img.ipynb
+++ b/notebooks/stable-diffusion/stable-diffusion-txt2img.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"optimum[neuronx, diffusers]\" matplotlib"
+    "!pip install \"optimum-neuron[neuronx]\" diffusers matplotlib"
    ]
   },
   {

--- a/notebooks/stable-diffusion/stable-diffusion-xl-txt2img.ipynb
+++ b/notebooks/stable-diffusion/stable-diffusion-xl-txt2img.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"optimum[neuronx, diffusers]\" matplotlib"
+    "!pip install \"optimum-neuron[neuronx]\" diffusers matplotlib"
    ]
   },
   {

--- a/optimum/exporters/neuron/base.py
+++ b/optimum/exporters/neuron/base.py
@@ -458,7 +458,7 @@ class NeuronDecoderConfig(NeuronConfig):
     def __init__(self, task: str):
         if not is_transformers_neuronx_available():
             raise ModuleNotFoundError(
-                "The mandatory transformers-neuronx package is missing. Please install optimum[neuronx]."
+                "The mandatory transformers-neuronx package is missing. Please install optimum-neuron[neuronx]."
             )
         if isinstance(self.NEURONX_CLASS, type):
             self._neuronx_class = self.NEURONX_CLASS

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -834,6 +834,10 @@ class MistralParallelizer(Parallelizer):
                 **parallel_layer_specific_kwargs,
             )
         for layer in model.model.layers:
+            # FIXME: temporary workaround to avoid too many changes in the transformation code
+            layer.self_attn.num_heads = layer.self_attn.config.num_attention_heads
+            layer.self_attn.num_key_value_heads = layer.self_attn.config.num_key_value_heads
+            layer.self_attn.hidden_size = layer.self_attn.config.hidden_size
             layer.self_attn = MistralParallelSelfAttention.transform(
                 model,
                 layer.self_attn,

--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -588,6 +588,10 @@ class LlamaParallelizer(Parallelizer):
             layers = model.model.layers
 
         for layer in layers:
+            # FIXME: temporary workaround to avoid too many changes in the transformation code
+            layer.self_attn.num_heads = layer.self_attn.config.num_attention_heads
+            layer.self_attn.num_key_value_heads = layer.self_attn.config.num_key_value_heads
+            layer.self_attn.hidden_size = layer.self_attn.config.hidden_size
             layer.self_attn = LlamaParallelSelfAttention.transform(
                 model,
                 layer.self_attn,

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.0.28.dev0"
+__version__ = "0.0.28.dev1"
 
 __sdk_version__ = "2.20.2"

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ TESTS_REQUIRE = [
     "opencv-python-headless",
     "controlnet-aux",
     "mediapipe",
+    "timm >= 1.0.0",
 ]
 
 QUALITY_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ except Exception as error:
 
 
 INSTALL_REQUIRES = [
-    "transformers == 4.46.2",
+    "transformers ~= 4.48.1",
     "accelerate == 0.29.2",
-    "optimum ~= 1.23.0",
-    "huggingface_hub >= 0.20.1",
+    "optimum ~= 1.23.3",
+    "huggingface_hub >= 0.28.0",
     "numpy>=1.22.2, <=1.25.2",
     "protobuf>=3.20.3, <4",
 ]


### PR DESCRIPTION
# What does this PR do?

This bumps the transformers version to 4.48.1 to allow the deployment of images containing `optimum-neuron` in AWS services (all previous transformers versions are now rejected because they include some scripts identified as potentially harmful).

This also modifies the documentation to change the installation instructions: installing as an optimum extra is no longer recommended and will be soon deprecated.

There were some changes in transformers modeling for LLama and Mistral models attention forward that needed to be reflected in the distributed parallelization modeling code.

There were also some changes in the attributes of the transformers Attention classes for the same models that broke the parallelization dynamic transformations: the changes in this pull-request are just a workaround, and eventually these dynamic transformations should be replaced by explicit modeling code (the forward methods are already overloaded, so there is no point in patching dynamically the layers where it would be simpler to recreate them directly from the config). 