### PR TITLE
display available cached versions in TGI server error message

### DIFF
--- a/text-generation-inference/server/text_generation_server/model.py
+++ b/text-generation-inference/server/text_generation_server/model.py
@@ -99,10 +99,28 @@ def fetch_model(
     if not is_cached(model_id, neuron_config):
         hub_cache_url = "https://huggingface.co/aws-neuron/optimum-neuron-cache"
         neuron_export_url = "https://huggingface.co/docs/optimum-neuron/main/en/guides/export_model#exporting-neuron-models-using-neuronx-tgi"
+            
+        entries = get_hub_cached_entries(model_id, "inference")
+        available_configs = ""
+        if entries:
+            config_list = []
+            for entry in entries:
+                config = (
+                    f"batch_size={entry['batch_size']}, "
+                    f"sequence_length={entry['sequence_length']}, "
+                    f"num_cores={entry['num_cores']}, "
+                    f"auto_cast_type={entry['auto_cast_type']}"
+                )
+                config_list.append(config)
+            available_configs = "\nAvailable cached configurations for this model:\n- " + "\n- ".join(config_list)
+        else:
+            available_configs = "\nNo cached versions are currently available for that model with any configuration."
+            
         error_msg = (
             f"No cached version found for {model_id} with {neuron_config}."
-            f"You can start a discussion to request it on {hub_cache_url}"
-            f"Alternatively, you can export your own neuron model as explained in {neuron_export_url}"
+            f"{available_configs}"
+            f"\nYou can start a discussion to request it on {hub_cache_url}"
+            f"\nAlternatively, you can export your own neuron model as explained in {neuron_export_url}"
         )
         raise ValueError(error_msg)
     logger.warning(f"{model_id} is not a neuron model: it will be exported using cached artifacts.")


### PR DESCRIPTION
If a model is cached with a different configuration, I want to display alternative options to the user.  

If someone copies from the deploy code on Hugging Face and changes something (e.g. sequence length), it is not obvious why it isn't working from this code. (especially if they don't understand compiling because they are referencing the original model)

Based on a true story!

added some carriage returns to make it more readable 


get_hub_cached_entries does generate an error if it is fed a model that doesn't have a model_type.  For example:  (randomly selected) model_id = "hexgrad/Kokoro-82M"

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/aws_neuronx_venv_pytorch_2_1/lib/python3.10/site-packages/optimum/neuron/utils/hub_cache_utils.py", line 431, in get_hub_cached_entries
    model_type = target_entry.config["model_type"]
KeyError: 'model_type'

However, we already call that function inside of is_cached at the top of this block, so I don't know if we are filtering for certain types of models before we get to this point or not.  If not, the existing code would generate that error before it ever gets here.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
