### PR TITLE
Enable hub fast transfers in CI pipelines

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -16,6 +16,7 @@ jobs:
       group: aws-inf2-48xlarge
     env:
       AWS_REGION: us-east-1
+      HF_HUB_ENABLE_HF_TRANSFER: 1
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +51,7 @@ jobs:
           source aws_neuron_venv_pytorch/bin/activate
           python -m pip install -U pip
           python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+          python -m pip install hf_transfer
       - name: Install optimum neuron
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/inference_cache_stable_diffusion.yml
+++ b/.github/workflows/inference_cache_stable_diffusion.yml
@@ -16,6 +16,7 @@ jobs:
       group: aws-inf2-8xlarge
     env:
       AWS_REGION: us-east-1
+      HF_HUB_ENABLE_HF_TRANSFER: 1
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +41,7 @@ jobs:
           source aws_neuron_venv_pytorch/bin/activate
           python -m pip install -U pip
           python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+          python -m pip install hf_transfer
       - name: Install optimum neuron
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_llm.yml
+++ b/.github/workflows/test_inf2_llm.yml
@@ -23,6 +23,8 @@ jobs:
     name: Run INF2 LLM tests
     runs-on:
       group: aws-inf2-8xlarge
+    env:
+      HF_HUB_ENABLE_HF_TRANSFER: 1
     steps:
       - name: Install Neuron runtime
         run: |

--- a/.github/workflows/test_inf2_tgi.yml
+++ b/.github/workflows/test_inf2_tgi.yml
@@ -25,6 +25,8 @@ jobs:
     name: Run TGI tests
     runs-on:
       group: aws-inf2-8xlarge
+    env:
+      HF_HUB_ENABLE_HF_TRANSFER: 1
     steps:
       - name: Install Neuron runtime
         run: |
@@ -45,6 +47,7 @@ jobs:
           source aws_neuron_venv_pytorch/bin/activate
           python -m pip install -U pip
           python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+          python -m pip install hf_transfer
       - name: Install integration tests prerequisites
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.0.28.dev2"
+__version__ = "0.1.0.dev0"
 
 __sdk_version__ = "2.20.2"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ TESTS_REQUIRE = [
     "controlnet-aux",
     "mediapipe",
     "timm >= 1.0.0",
+    "hf_transfer",
 ]
 
 QUALITY_REQUIRES = [

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import subprocess
 import sys
 from tempfile import TemporaryDirectory
 
@@ -57,16 +56,11 @@ def _get_hub_neuron_model_id(config_name: str):
 
 
 def _export_model(model_id, export_kwargs, neuron_model_path):
-    export_command = ["optimum-cli", "export", "neuron", "-m", model_id, "--task", "text-generation"]
-    for kwarg, value in export_kwargs.items():
-        export_command.append(f"--{kwarg}")
-        export_command.append(str(value))
-    export_command.append(neuron_model_path)
-    logger.info(f"Exporting {model_id} with {export_kwargs}")
     try:
-        subprocess.run(export_command, check=True)
-    except subprocess.CalledProcessError as e:
-        raise SystemError(f"Failed to export model: {e}")
+        model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, **export_kwargs)
+        model.save_pretrained(neuron_model_path)
+    except Exception as e:
+        raise ValueError(f"Failed to export {model_id}: {e}")
 
 
 @pytest.fixture(scope="session", params=DECODER_MODEL_CONFIGURATIONS.keys())


### PR DESCRIPTION
# What does this PR do?

This modifies the test prerequisites and the CI pipelines to use fast hub transfers whenever big model weights need to be retrieved.

Note on CI errors:
- TGI errors are actually related to read time-outs from the hub,
- Trainium errors are also present on main.