### PR TITLE
chore(ci): mitigate trufflehog false positives

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,3 +16,5 @@ jobs:
           fetch-depth: 0
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
This only will trigger an error on verified errors. This is aligned to what it has been done in TGI, see here:

https://github.com/huggingface/text-generation-inference/pull/2990/commits/b3436da43db35daf89b28a48dd566aff46aba6dc

