### PR TITLE
Docs: Fixed All Typos in /docs

### DIFF
--- a/docs/source/benchmarks/inferentia-llama3.1-8b.mdx
+++ b/docs/source/benchmarks/inferentia-llama3.1-8b.mdx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Llama-3.1-8b performance on AWS Inferentia2 (Latency & Througput)
+# Llama-3.1-8b performance on AWS Inferentia2 (Latency & Throughput)
 
 How fast is Llama-3.1-8b on Inferentia2?  Let's figure out!
 

--- a/docs/source/benchmarks/inferentia-mistral-small.mdx
+++ b/docs/source/benchmarks/inferentia-mistral-small.mdx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Mistral-Small-Instruct performance on AWS Inferentia2 (Latency & Througput)
+# Mistral-Small-Instruct performance on AWS Inferentia2 (Latency & Throughput)
 
 How fast is Mistral on Inferentia2?  Let's figure out!
 

--- a/docs/source/guides/cache_system.mdx
+++ b/docs/source/guides/cache_system.mdx
@@ -161,7 +161,7 @@ Neuron cache created on the Hugging Face Hub: michaelbenayoun/optimum-neuron-cac
 Neuron cache name set locally to michaelbenayoun/optimum-neuron-cache in /home/michael/.cache/huggingface/optimum_neuron_custom_cache.
 ```
 
-Set a different Trainiun cache repository:
+Set a different Trainium cache repository:
 
 ```
 usage: optimum-cli neuron cache set [-h] name

--- a/docs/source/inference_tutorials/sentence_transformers.mdx
+++ b/docs/source/inference_tutorials/sentence_transformers.mdx
@@ -24,13 +24,13 @@ This guide explains how to compile, load, and use [Sentence Transformers (SBERT)
 
 ### Convert Sentence Transformers model to AWS Inferentia2  
 
-First, you need to convert your Sentence Transformers model to a format compatible with AWS Inferentia2. You can compile Sentence Transformers models with Optimum Neuron using the `optimum-cli` or `NeuronModelForSentenceTransformers` class. Below you will find an example for both approaches. We have to make sure `sentence-transformers` is installed. Thats only needed for exporting the model. 
+First, you need to convert your Sentence Transformers model to a format compatible with AWS Inferentia2. You can compile Sentence Transformers models with Optimum Neuron using the `optimum-cli` or `NeuronModelForSentenceTransformers` class. Below you will find an example for both approaches. We have to make sure `sentence-transformers` is installed. That's only needed for exporting the model. 
 
 ```bash
 pip install sentence-transformers
 ```
 
-Here we will use the `NeuronModelForSentenceTransformers`, which can be used to convert any Sntence Transformers model to a format compatible with AWS Inferentia2 or load already converted models. When exporting models with the `NeuronModelForSentenceTransformers` you need to set `export=True` and define the input shape and batch size. The input shape is defined by the `sequence_length` and the batch size by `batch_size`. 
+Here we will use the `NeuronModelForSentenceTransformers`, which can be used to convert any Sentence Transformers model to a format compatible with AWS Inferentia2 or load already converted models. When exporting models with the `NeuronModelForSentenceTransformers` you need to set `export=True` and define the input shape and batch size. The input shape is defined by the `sequence_length` and the batch size by `batch_size`. 
 
 ```python
 from optimum.neuron import NeuronModelForSentenceTransformers

--- a/docs/source/package_reference/export.mdx
+++ b/docs/source/package_reference/export.mdx
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Inferentia Exporter
 
-You can export a PyTorch model to Neuron with 🤗 Optimum to run inference on AWS [Inferntia 1](https://aws.amazon.com/ec2/instance-types/inf1/)
+You can export a PyTorch model to Neuron with 🤗 Optimum to run inference on AWS [Inferentia 1](https://aws.amazon.com/ec2/instance-types/inf1/)
 and [Inferentia 2](https://aws.amazon.com/ec2/instance-types/inf2/).
 
 ## Export functions

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -51,7 +51,7 @@ trainer = Trainer(
 ```
 
 All Trainium instances come at least with 2 Neuron Cores. To leverage those we need to launch the training whith `torchrun`.
-Below you see and example of how to launch a training script on a `trn1.2xlarge` instance using a `bert-base-uncased` model.
+Below you see an example of how to launch a training script on a `trn1.2xlarge` instance using a `bert-base-uncased` model.
 
 ```bash
 torchrun --nproc_per_node=2 huggingface-neuron-samples/text-classification/run_glue.py \

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -50,7 +50,7 @@ trainer = Trainer(
 )
 ```
 
-All Trainium instances come at least with 2 Neuron Cores. To leverage those we need to launch the training whith `torchrun`.
+All Trainium instances come at least with 2 Neuron Cores. To leverage those we need to launch the training with `torchrun`.
 Below you see an example of how to launch a training script on a `trn1.2xlarge` instance using a `bert-base-uncased` model.
 
 ```bash

--- a/docs/source/training_tutorials/fine_tune_bert.mdx
+++ b/docs/source/training_tutorials/fine_tune_bert.mdx
@@ -77,7 +77,7 @@ We can click on it, and a **`jupyter`** environment opens in our local browser.
 
 ![jupyter.webp](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/optimum/neuron/tutorial-fine-tune-bert-jupyter.png)
 
-We are going to use the Jupyter environment only for preparing the dataset and then `torchrun` for launching our training script on both neuron cores for distributed training. Lets create a new notebook and get started.
+We are going to use the Jupyter environment only for preparing the dataset and then `torchrun` for launching our training script on both neuron cores for distributed training. Let's create a new notebook and get started.
 
 ## 2. Load and process the dataset
 

--- a/docs/source/training_tutorials/finetune_llm.mdx
+++ b/docs/source/training_tutorials/finetune_llm.mdx
@@ -31,7 +31,7 @@ You will learn how to:
 
 <Tip>
 
-While we will use `Llama-3 8B` in this tutorial, it is completely possible to use other models, simply by swtiching the `model_id`.
+While we will use `Llama-3 8B` in this tutorial, it is completely possible to use other models, simply by switching the `model_id`.
 For instance, it is possible to fine-tune:
 
 - Mistral models, such as  [Mistral 7b (`mistralai/Mistral-7B-Instruct-v0.3`)](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)


### PR DESCRIPTION
# What does this PR do?
Fixed all typos in the docs section, this includes every single typos in any of the `.mdx` files.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@dacorvo @tengomucho 