### PR TITLE
ci: use actions to share common steps

### DIFF
--- a/.github/actions/install_neuronx_runtime/action.yml
+++ b/.github/actions/install_neuronx_runtime/action.yml
@@ -1,0 +1,16 @@
+name: Install Neuronx SDK
+description: install system and python packages for an AWS Neuronx SDK version
+runs:
+    using: "composite"
+    steps:
+      - name: Install Neuronx system packages
+        shell: bash
+        run: |
+          . /etc/os-release
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt-get update -y
+          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
+          export PATH=/opt/aws/neuron/bin:$PATH

--- a/.github/actions/install_optimum_neuron/action.yml
+++ b/.github/actions/install_optimum_neuron/action.yml
@@ -1,0 +1,10 @@
+name: Install optimum-neuron
+description: install optimum-neuron (prepare_venv need to have been called first)
+runs:
+    using: "composite"
+    steps:
+      - name: Install optimum-neuron and Neuronx python package
+        shell: bash
+        run: |
+          source aws_neuron_venv_pytorch/bin/activate
+          python -m pip install .[neuronx,tests]

--- a/.github/actions/prepare_venv/action.yml
+++ b/.github/actions/prepare_venv/action.yml
@@ -1,0 +1,15 @@
+name: Prepare virtual environment
+description: prepare virtual environment to install pyhton packages
+runs:
+    using: "composite"
+    steps:
+      - name: Prepare virtual environment
+        shell: bash
+        run: |
+          sudo apt install python3-venv python3-dev -y
+          python3 -m venv aws_neuron_venv_pytorch
+          source aws_neuron_venv_pytorch/bin/activate
+          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+          python -m pip install -U pip
+          python -m pip install --upgrade setuptools==69.5.1
+          python -m pip install hf_transfer

--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -32,30 +32,14 @@ jobs:
           mixtral
         ]
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install python and create venv
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install hf_transfer
-      - name: Install optimum neuron
-        run: |
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install .[neuronx]
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Create cache for ${{matrix.config}} models
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/inference_cache_stable_diffusion.yml
+++ b/.github/workflows/inference_cache_stable_diffusion.yml
@@ -22,30 +22,14 @@ jobs:
       matrix:
         config: [stable-diffusion]
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install python and create venv
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install hf_transfer
-      - name: Install optimum neuron
-        run: |
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install .[neuronx,diffusers]
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Create cache for ${{matrix.config}} models
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2.yml
+++ b/.github/workflows/test_inf2.yml
@@ -24,27 +24,14 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Run cache tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_export.yml
+++ b/.github/workflows/test_inf2_export.yml
@@ -24,27 +24,14 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Run exporters tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_full_export.yml
+++ b/.github/workflows/test_inf2_full_export.yml
@@ -22,27 +22,14 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Run exporters tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_inference.yml
+++ b/.github/workflows/test_inf2_inference.yml
@@ -24,30 +24,17 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
       - name: Install cv2 dependencies
         run: |
           sudo apt-get install ffmpeg libsm6 libxext6  -y
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Run inference tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_llm.yml
+++ b/.github/workflows/test_inf2_llm.yml
@@ -26,27 +26,14 @@ jobs:
     env:
       HF_HUB_ENABLE_HF_TRANSFER: 1
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Run decoder tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_inf2_tgi.yml
+++ b/.github/workflows/test_inf2_tgi.yml
@@ -28,26 +28,12 @@ jobs:
     env:
       HF_HUB_ENABLE_HF_TRANSFER: 1
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python and create venv
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install hf_transfer
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
       - name: Install integration tests prerequisites
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_trainium_common.yml
+++ b/.github/workflows/test_trainium_common.yml
@@ -26,30 +26,17 @@ jobs:
     env:
       TESTS_TO_IGNORE_FLAGS: --ignore tests/distributed/ --ignore tests/test_examples.py
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
       - name: Install cv2 dependencies
         run: |
           sudo apt-get install ffmpeg libsm6 libxext6  -y
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Collect tests on Neuron Cores
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_trainium_distributed.yml
+++ b/.github/workflows/test_trainium_distributed.yml
@@ -25,32 +25,19 @@ jobs:
     runs-on:
       group: aws-trn1-32xlarge
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
       - name: Install cv2 dependencies
         run: |
           sudo apt-get install ffmpeg libsm6 libxext6  -y
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Setup PATH
         run: echo "/home/ubuntu/.local/bin" >> $GITHUB_PATH
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
       - name: Collect tests on Neuron Cores
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/test_trainium_examples.yml
+++ b/.github/workflows/test_trainium_examples.yml
@@ -33,32 +33,19 @@ jobs:
     env:
       RUN_TINY: ${{ github.event.inputs.model_size == "tiny" && "1" || "0" }}
     steps:
-      - name: Install Neuron runtime
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
-          deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt-get update -y
-          sudo apt-get install aws-neuronx-tools=2.19.0.0 aws-neuronx-runtime-lib=2.22.19.0-5856c0b42 aws-neuronx-collectives=2.22.33.0-d2128d1aa  -y
-          export PATH=/opt/aws/neuron/bin:$PATH
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Neuronx runtime
+        uses: ./.github/actions/install_neuronx_runtime
       - name: Install cv2 dependencies
         run: |
           sudo apt-get install ffmpeg libsm6 libxext6  -y
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Prepare virtual environment
+        uses: ./.github/actions/prepare_venv
+      - name: Install optimum-neuron
+        uses: ./.github/actions/install_optimum_neuron
       - name: Setup PATH
         run: echo "/home/ubuntu/.local/bin" >> $GITHUB_PATH
-      - name: Install python dependencies
-        run: |
-          sudo apt install python3-venv python3-dev -y
-          python3 -m venv aws_neuron_venv_pytorch
-          source aws_neuron_venv_pytorch/bin/activate
-          python -m pip install -U pip
-          pip install --upgrade setuptools==69.5.1
-          python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
-          python -m pip install .[neuronx,tests]
       - name: Collect example tests on Neuron Cores
         run: |
           source aws_neuron_venv_pytorch/bin/activate


### PR DESCRIPTION
# What does this PR do?

Most of our CI workflows share some common actions: this adds them in individual action files to simplify the maintenance of our pipelines.