### PR TITLE
Add IP adapter support for SDXL

### DIFF
--- a/optimum/exporters/neuron/model_wrappers.py
+++ b/optimum/exporters/neuron/model_wrappers.py
@@ -48,9 +48,11 @@ class UnetNeuronWrapper(torch.nn.Module):
         added_cond_kwargs = {
             "text_embeds": ordered_inputs.pop("text_embeds", None),
             "time_ids": ordered_inputs.pop("time_ids", None),
-            "image_embeds": ordered_inputs.pop("image_embeds", None)
-            or ordered_inputs.pop("image_enc_hidden_states", None),
         }
+        if "image_embeds" in ordered_inputs:
+            added_cond_kwargs["image_embeds"] = ordered_inputs.pop("image_embeds", None)
+        elif "image_enc_hidden_states" in ordered_inputs:
+            added_cond_kwargs["image_enc_hidden_states"] = ordered_inputs.pop("image_enc_hidden_states", None)
         sample = ordered_inputs.pop("sample", None)
         timestep = ordered_inputs.pop("timestep").float().expand((sample.shape[0],))
         encoder_hidden_states = ordered_inputs.pop("encoder_hidden_states", None)

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 import torch
 from huggingface_hub import snapshot_download
 from torch.nn import ModuleList
-from transformers import CLIPFeatureExtractor, CLIPTokenizer, PretrainedConfig, T5Tokenizer
+from transformers import CLIPFeatureExtractor, CLIPImageProcessor, CLIPTokenizer, PretrainedConfig, T5Tokenizer
 from transformers.modeling_outputs import ModelOutput
 
 from ..exporters.neuron import (
@@ -161,7 +161,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
         safety_checker: Optional[torch.jit._script.ScriptModule] = None,
         tokenizer: Optional[Union[CLIPTokenizer, T5Tokenizer]] = None,
         tokenizer_2: Optional[CLIPTokenizer] = None,
-        feature_extractor: Optional[CLIPFeatureExtractor] = None,
+        feature_extractor: Optional[Union[CLIPFeatureExtractor, CLIPImageProcessor]] = None,
         controlnet: Optional[
             Union[
                 torch.jit._script.ScriptModule,
@@ -214,7 +214,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
             tokenizer_2 (`Optional[CLIPTokenizer]`, defaults to `None`):
                 Second tokenizer of class
                 [CLIPTokenizer](https://huggingface.co/docs/transformers/v4.21.0/en/model_doc/clip#transformers.CLIPTokenizer).
-            feature_extractor (`Optional[CLIPFeatureExtractor]`, defaults to `None`):
+            feature_extractor (`Optional[Union[CLIPFeatureExtractor, CLIPImageProcessor]]`, defaults to `None`):
                 A model extracting features from generated images to be used as inputs for the `safety_checker`
             controlnet (`Optional[Union[torch.jit._script.ScriptModule, List[torch.jit._script.ScriptModule], "NeuronControlNetModel", "NeuronMultiControlNetModel"]]`, defaults to `None`):
                 The Neuron TorchScript module(s) associated to the ControlNet(s).
@@ -1326,7 +1326,7 @@ class NeuronModelUnet(_NeuronDiffusionModelPart):
             for idx in range(len(down_block_additional_residuals)):
                 inputs = inputs + (down_block_additional_residuals[idx],)
         if added_cond_kwargs:
-            optional_inputs_names = ["text_embeds", "time_ids", "image_embeds"]
+            optional_inputs_names = ["image_embeds", "text_embeds", "time_ids"]
             for optional_input_name in optional_inputs_names:
                 optional_input = added_cond_kwargs.get(optional_input_name, None)
                 if isinstance(optional_input, List):


### PR DESCRIPTION
as per title

* Export
```
optimum-cli export neuron --model stabilityai/stable-diffusion-xl-base-1.0 --ip_adapter_id h94/IP-Adapter --ip_adapter_subfolder sdxl_models --ip_adapter_weight_name ip-adapter_sdxl.bin --ip_adapter_scale 0.6 --batch_size 1 --height 512 --width 512 --num_images_per_prompt 1 --auto_cast matmul --auto_cast_type bf16 sdxl_ip_adapter_neuron_512/
```

* Inference

```python
from optimum.neuron import NeuronStableDiffusionXLPipeline


stable_diffusion = NeuronStableDiffusionXLPipeline.from_pretrained("sdxl_ip_adapter_neuron_512/")

# 1.
image = load_image(
    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ip_adapter_einstein_base.png"
)
generator = torch.Generator(device="cpu").manual_seed(26)
image = stable_diffusion(
    prompt="A photo of Einstein as a chef, wearing an apron, cooking in a French restaurant",
    ip_adapter_image=image,
    negative_prompt="lowres, bad anatomy, worst quality, low quality",
    num_inference_steps=100,
    generator=generator,
).images[0]

image.save("Einstein.png")
```

```python
# 2.
image = load_image(
    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ip_adapter_diner.png"
)
# generator = torch.Generator(device="cpu").manual_seed(0)
image_embeds = stable_diffusion.prepare_ip_adapter_image_embeds(
    ip_adapter_image=image,
    ip_adapter_image_embeds=None,
    device=None,
    num_images_per_prompt=1,
    do_classifier_free_guidance=True,
)
torch.save(image_embeds, "image_embeds.ipadpt")

image_embeds = torch.load("image_embeds.ipadpt")
image = stable_diffusion(
    prompt="a polar bear sitting in a chair drinking a milkshake",
    ip_adapter_image_embeds=image_embeds,
    negative_prompt="deformed, ugly, wrong proportion, low res, bad anatomy, worst quality, low quality",
    num_inference_steps=100,
    # generator=generator,
).images[0]

image.save("polar_bear.png")
```