### PR TITLE
ci: populate caches when tagging

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Schedule the workflow to run every day at midnight UTC
     - cron: '0 0 * * *'
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/inference_cache_stable_diffusion.yml
+++ b/.github/workflows/inference_cache_stable_diffusion.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Schedule the workflow to run every Saturday at midnight UTC
     - cron: '0 0 * * 6'
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
# What does this PR do?

The inference caches will now be updated when pushing a new release tag. This removes the need for running the workflow manually later on (although it is still possible).