### PR TITLE
fix(tutorial): remove XLA_USE_BF16 from SFT tutorial

### DIFF
--- a/docs/source/training_tutorials/sft_lora_finetune_llm.mdx
+++ b/docs/source/training_tutorials/sft_lora_finetune_llm.mdx
@@ -250,7 +250,7 @@ else
 fi
 
 
-XLA_USE_BF16=1 torchrun --nproc_per_node $PROCESSES_PER_NODE docs/source/training_tutorials/sft_lora_finetune_llm.py \
+torchrun --nproc_per_node $PROCESSES_PER_NODE docs/source/training_tutorials/sft_lora_finetune_llm.py \
   --model_id $MODEL_NAME \
   --num_train_epochs $NUM_EPOCHS \
   --do_train \

--- a/docs/source/training_tutorials/sft_lora_finetune_llm.sh
+++ b/docs/source/training_tutorials/sft_lora_finetune_llm.sh
@@ -25,7 +25,7 @@ else
 fi
 
 
-XLA_USE_BF16=1 torchrun --nproc_per_node $PROCESSES_PER_NODE docs/source/training_tutorials/sft_lora_finetune_llm.py \
+torchrun --nproc_per_node $PROCESSES_PER_NODE docs/source/training_tutorials/sft_lora_finetune_llm.py \
   --model_id $MODEL_NAME \
   --num_train_epochs $NUM_EPOCHS \
   --do_train \


### PR DESCRIPTION
This flag is no longer required and it actually makes the grad norm to have unexpected values, so it is removed.

