### PR TITLE
Training remove gpt neo models support

### DIFF
--- a/optimum/neuron/distributed/decoder_models.py
+++ b/optimum/neuron/distributed/decoder_models.py
@@ -22,7 +22,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.cache_utils import Cache
 from transformers.models.gpt_neo.modeling_gpt_neo import GPTNeoBlock, GPTNeoSelfAttention
-from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXAttention
 from transformers.models.llama.modeling_llama import (
     LlamaAttention,
     LlamaDecoderLayer,
@@ -44,7 +43,6 @@ from .parallel_layers import (
     ParallelEmbedding,
     ParallelMLP,
     ParallelSelfAttention,
-    ParallelSelfAttentionWithFusedQKV,
     SequenceCollectiveOpInfo,
 )
 from .utils import get_linear_weight_info, linear_to_parallel_linear
@@ -155,179 +153,6 @@ class GPTNeoParallelizer(Parallelizer):
             )
         if parallelize_embeddings:
             model = GPTNeoParallelCrossEntropy.transform(
-                model,
-                model,
-                sequence_parallel_enabled=sequence_parallel_enabled,
-                should_parallelize_layer_predicate_func=should_parallelize_layer_predicate_func,
-                device=device,
-                **parallel_layer_specific_kwargs,
-            )
-        return model
-
-
-class GPTNeoXParallelEmbedding(ParallelEmbedding):
-    EMBEDDING_NAME = "gpt_neox.embed_in"
-    LM_HEAD_NAME = "embed_out"
-
-
-class GPTNeoXParallelSelfAttention(ParallelSelfAttentionWithFusedQKV):
-    QUERY_KEY_VALUE_NAME = "query_key_value"
-    OUTPUT_PROJECTION_NAME = "dense"
-    NUM_ATTENTION_HEADS_NAME = "num_attention_heads"
-    ALL_HEAD_SIZE_NAME = "hidden_size"
-
-
-class GPTNeoXParallelMLP(ParallelMLP):
-    FIRST_LINEAR_NAME = "dense_h_to_4h"
-    SECOND_LINEAR_NAME = "dense_4h_to_h"
-
-
-class GPTNeoXParallelCrossEntropy(ParallelCrossEntropy):
-    LAST_LINEAR_PROJECTION_NAME = {"GPTNeoXForCausalLM": "embed_out"}
-
-
-class GPTNeoXSequenceParallelismSpecs(SequenceParallelismSpecs):
-    SEQUENCE_PARALLEL_LAYERNORM_PATTERNS = [
-        "gpt_neox.layers.[0-9]+.input_layernorm",
-        "gpt_neox.layers.[0-9]+.post_attention_layernorm",
-        "gpt_neox.final_layer_norm",
-    ]
-    SEQUENCE_COLLECTIVE_OPS_INFOS = [
-        SequenceCollectiveOpInfo("scatter", "gpt_neox.embed_in", "output", "first"),
-        SequenceCollectiveOpInfo("gather", torch.nn.LayerNorm, "output", "last"),
-    ]
-
-    @classmethod
-    def patch_for_sequence_parallelism(cls, model: "PreTrainedModel", sequence_parallel_enabled: bool):
-        if not sequence_parallel_enabled:
-            return
-
-        from transformers.models.gpt_neox.modeling_gpt_neox import apply_rotary_pos_emb
-
-        def sequence_parallel_forward(
-            self,
-            hidden_states: torch.FloatTensor,
-            attention_mask: torch.FloatTensor,
-            position_ids: torch.LongTensor,
-            head_mask: Optional[torch.FloatTensor] = None,
-            layer_past: Optional[Tuple[torch.Tensor]] = None,
-            use_cache: Optional[bool] = False,
-            output_attentions: Optional[bool] = False,
-        ):
-            has_layer_past = layer_past is not None
-
-            # Compute QKV
-            # If sequence_parallel_enabled:
-            #   --> [seq_len, batch, (num_heads * 3 * head_size)]
-            # Else:
-            #   --> [batch, seq_len, (num_heads * 3 * head_size)]
-            qkv = self.query_key_value(hidden_states)
-
-            # If sequence_parallel_enabled:
-            #   --> [seq_len, batch, num_heads, 3 * head_size]
-            # Else:
-            #   --> [batch, seq_len, num_heads, 3 * head_size]
-            new_qkv_shape = qkv.size()[:-1] + (self.num_attention_heads, 3 * self.head_size)
-            qkv = qkv.view(*new_qkv_shape)
-
-            if sequence_parallel_enabled:
-                # [seq_len, batch, num_attention_heads, 3 * head_size] --> 3 [batch, num_attention_heads, seq_len, head_size]
-                query = qkv[..., : self.head_size].permute(1, 2, 0, 3)
-                key = qkv[..., self.head_size : 2 * self.head_size].permute(1, 2, 0, 3)
-                value = qkv[..., 2 * self.head_size :].permute(1, 2, 0, 3)
-            else:
-                # [batch, seq_len, num_attention_heads, 3 * head_size] --> 3 [batch, num_attention_heads, seq_len, head_size]
-                query = qkv[..., : self.head_size].permute(0, 2, 1, 3)
-                key = qkv[..., self.head_size : 2 * self.head_size].permute(0, 2, 1, 3)
-                value = qkv[..., 2 * self.head_size :].permute(0, 2, 1, 3)
-
-            # Compute rotary embeddings on rotary_ndims
-            query_rot = query[..., : self.rotary_ndims]
-            query_pass = query[..., self.rotary_ndims :]
-            key_rot = key[..., : self.rotary_ndims]
-            key_pass = key[..., self.rotary_ndims :]
-
-            # Compute token offset for rotary embeddings (when decoding)
-            seq_len = key.shape[-2]
-            if has_layer_past:
-                seq_len += layer_past[0].shape[-2]
-            cos, sin = self.rotary_emb(value, seq_len=seq_len)
-            query, key = apply_rotary_pos_emb(query_rot, key_rot, cos, sin, position_ids)
-            query = torch.cat((query, query_pass), dim=-1)
-            key = torch.cat((key, key_pass), dim=-1)
-
-            # Cache QKV values
-            if has_layer_past:
-                past_key = layer_past[0]
-                past_value = layer_past[1]
-                key = torch.cat((past_key, key), dim=-2)
-                value = torch.cat((past_value, value), dim=-2)
-            present = (key, value) if use_cache else None
-
-            # Compute attention
-            attn_output, attn_weights = self._attn(query, key, value, attention_mask, head_mask)
-
-            # Reshape outputs
-            if sequence_parallel_enabled:
-                # [batch, num_attention_heads, seq_len, head_size] -> [seq_len, batch, hidden_size]
-                attn_output = attn_output.permute(2, 0, 1, 3).contiguous()
-                attn_output = attn_output.view(*attn_output.shape[:2], -1)
-            else:
-                attn_output = self._merge_heads(attn_output, self.num_attention_heads, self.head_size)
-            attn_output = self.dense(attn_output)
-
-            outputs = (attn_output, present)
-            if output_attentions:
-                outputs += (attn_weights,)
-
-            return outputs
-
-        for module in model.modules():
-            if isinstance(module, GPTNeoXAttention):
-                module.forward = sequence_parallel_forward.__get__(module)
-
-
-class GPTNeoXParallelizer(Parallelizer):
-    SEQUENCE_PARALLELSIM_SPECS_CLS = GPTNeoXSequenceParallelismSpecs
-
-    @classmethod
-    def _parallelize(
-        cls,
-        model: "PreTrainedModel",
-        device: Optional[torch.device] = None,
-        parallelize_embeddings: bool = True,
-        sequence_parallel_enabled: bool = False,
-        should_parallelize_layer_predicate_func: Optional[Callable[[torch.nn.Module], bool]] = None,
-        **parallel_layer_specific_kwargs,
-    ) -> "PreTrainedModel":
-        if parallelize_embeddings:
-            model = GPTNeoXParallelEmbedding.transform(
-                model,
-                model,
-                sequence_parallel_enabled=sequence_parallel_enabled,
-                should_parallelize_layer_predicate_func=should_parallelize_layer_predicate_func,
-                device=device,
-                **parallel_layer_specific_kwargs,
-            )
-        for layer in model.gpt_neox.layers:
-            layer.attention = GPTNeoXParallelSelfAttention.transform(
-                model,
-                layer.attention,
-                sequence_parallel_enabled=sequence_parallel_enabled,
-                should_parallelize_layer_predicate_func=should_parallelize_layer_predicate_func,
-                device=device,
-                **parallel_layer_specific_kwargs,
-            )
-            layer.mlp = GPTNeoXParallelMLP.transform(
-                model,
-                layer.mlp,
-                sequence_parallel_enabled=sequence_parallel_enabled,
-                should_parallelize_layer_predicate_func=should_parallelize_layer_predicate_func,
-                device=device,
-                **parallel_layer_specific_kwargs,
-            )
-        if parallelize_embeddings:
-            model = GPTNeoXParallelCrossEntropy.transform(
                 model,
                 model,
                 sequence_parallel_enabled=sequence_parallel_enabled,

--- a/optimum/neuron/distributed/parallelizers_manager.py
+++ b/optimum/neuron/distributed/parallelizers_manager.py
@@ -55,7 +55,6 @@ class ParallelizersManager:
         {
             "bert": "BertParallelizer",
             "roberta": "RobertaParallelizer",
-            "gpt_neo": "GPTNeoParallelizer",
             "llama": "LlamaParallelizer",
             "mistral": "MistralParallelizer",
             "t5": "T5Parallelizer",

--- a/optimum/neuron/distributed/parallelizers_manager.py
+++ b/optimum/neuron/distributed/parallelizers_manager.py
@@ -56,7 +56,6 @@ class ParallelizersManager:
             "bert": "BertParallelizer",
             "roberta": "RobertaParallelizer",
             "gpt_neo": "GPTNeoParallelizer",
-            "gpt_neox": "GPTNeoXParallelizer",
             "llama": "LlamaParallelizer",
             "mistral": "MistralParallelizer",
             "t5": "T5Parallelizer",

--- a/optimum/neuron/utils/training_utils.py
+++ b/optimum/neuron/utils/training_utils.py
@@ -105,7 +105,6 @@ _SUPPORTED_MODEL_TYPES = [
     "distilbert",
     "electra",
     "gpt-2",
-    "gpt_neo",
     "marian",
     "roberta",
     "t5",

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.1.0.dev3"
+__version__ = "0.2.0.dev0"
 
 __sdk_version__ = "2.21.1"

--- a/tests/distributed/test_model_parallelization.py
+++ b/tests/distributed/test_model_parallelization.py
@@ -113,13 +113,6 @@ LLAMA_TYPES_TO_TEST = ("llama", "michaelbenayoun/llama-2-tiny-4kv-heads-4layers-
 MODEL_TYPES_TO_TEST = [
     ("roberta", "hf-internal-testing/tiny-random-roberta", {"num_hidden_layers": "2"}),
     (
-        "gpt_neo",
-        "hf-internal-testing/tiny-random-GPTNeoModel",
-        {
-            "num_layers": "2",
-        },
-    ),
-    (
         "t5",
         "hf-internal-testing/tiny-random-T5Model",
         {"d_ff": "36", "num_layers": "2", "num_decoder_layers": "2"},
@@ -140,14 +133,6 @@ def _build_models_to_test(model_types_to_test):
 LLAMA_MODELS_TO_TEST = _build_models_to_test([LLAMA_TYPES_TO_TEST])
 NOT_LLAMA_TO_TEST = _build_models_to_test(MODEL_TYPES_TO_TEST)
 MODELS_TO_TEST = NOT_LLAMA_TO_TEST + LLAMA_MODELS_TO_TEST
-
-
-MODEL_CLASSES_TO_IGNORE = [
-    "GPTNeoForSequenceClassification",
-    "GPTNeoForTokenClassification",
-    "GPTNeoForQuestionAnswering",
-    "GPTNeoForCausalLM",
-]
 
 
 OUTPUTS_TO_IGNORE = {
@@ -218,9 +203,6 @@ def _parallel_model_matches_original_model(
     sequence_parallel_enabled,
     parallelize_embeddings,
 ):
-    if model_class.__name__ in MODEL_CLASSES_TO_IGNORE:
-        pytest.skip(f"Skipping test for {model_class.__name__} since it is buggy or a special case.")
-
     world_size, tp_size, pp_size = parallel_sizes
     dp_size = world_size // (tp_size * pp_size)
     pp_rank = get_pipeline_model_parallel_rank()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -224,7 +224,7 @@ _SCRIPT_TO_MODEL_MAPPING = {
     "run_mlm": _get_supported_models_for_script(MODELS_TO_TEST_MAPPING, MODEL_FOR_MASKED_LM_MAPPING),
     "run_swag": _get_supported_models_for_script(MODELS_TO_TEST_MAPPING, MODEL_FOR_MULTIPLE_CHOICE_MAPPING),
     "run_qa": _get_supported_models_for_script(
-        MODELS_TO_TEST_MAPPING, MODEL_FOR_QUESTION_ANSWERING_MAPPING, to_exclude={"gpt2", "gpt_neo", "bart", "t5"}
+        MODELS_TO_TEST_MAPPING, MODEL_FOR_QUESTION_ANSWERING_MAPPING, to_exclude={"gpt2", "bart", "t5"}
     ),
     "run_summarization": _get_supported_models_for_script(
         MODELS_TO_TEST_MAPPING, MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING, to_exclude={"marian", "m2m_100"}
@@ -233,10 +233,10 @@ _SCRIPT_TO_MODEL_MAPPING = {
         MODELS_TO_TEST_MAPPING, MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
     ),
     "run_glue": _get_supported_models_for_script(
-        MODELS_TO_TEST_MAPPING, MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, to_exclude={"gpt2", "gpt_neo", "bart", "t5"}
+        MODELS_TO_TEST_MAPPING, MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, to_exclude={"gpt2", "bart", "t5"}
     ),
     "run_ner": _get_supported_models_for_script(
-        MODELS_TO_TEST_MAPPING, MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING, to_exclude={"gpt2", "gpt_neo"}
+        MODELS_TO_TEST_MAPPING, MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING, to_exclude={"gpt2"}
     ),
     "run_image_classification": _get_supported_models_for_script(
         MODELS_TO_TEST_MAPPING, MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -139,12 +139,6 @@ MODELS_TO_TEST_MAPPING = {
         Coverage.MIDDLE,
         {"num_hidden_layers": 4},
     ),
-    "gpt_neo": (
-        "EleutherAI/gpt-neo-125M",
-        TPSupport.PARTIAL,
-        Coverage.HIGH,
-        {"num_hidden_layers": 4, "attention_types": [[["global", "local"], 2]]},
-    ),
     "marian": (
         "Helsinki-NLP/opus-mt-en-ro",
         TPSupport.NONE,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,8 +35,6 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 _TINY_BERT_MODEL_NAME = "hf-internal-testing/tiny-random-bert"
-_TINY_BART_MODEL_NAME = "hf-internal-testing/tiny-random-BartForConditionalGeneration"
-_TINY_VIT_MODEL_NAME = "hf-internal-testing/tiny-random-ViTForImageClassification"
 
 TO_TEST = [
     ("masked-lm", _TINY_BERT_MODEL_NAME, 128),
@@ -44,10 +42,6 @@ TO_TEST = [
     ("token-classification", _TINY_BERT_MODEL_NAME, 384),
     ("multiple-choice", "hf-internal-testing/tiny-random-BertForMultipleChoice", 384),
     ("question-answering", _TINY_BERT_MODEL_NAME, 384),
-    # The following tests are disabled because they fail with AWS Neuron SDK 2.16
-    # ("summarization", _TINY_BART_MODEL_NAME, [10, 10]),
-    # ("translation", _TINY_BART_MODEL_NAME, [10, 10]),
-    # ("image-classification", _TINY_VIT_MODEL_NAME, None),
 ]
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,13 +35,11 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 _TINY_BERT_MODEL_NAME = "hf-internal-testing/tiny-random-bert"
-_TINY_GPT_NEO_MODEL_NAME = "hf-internal-testing/tiny-random-GPTNeoForCausalLM"
 _TINY_BART_MODEL_NAME = "hf-internal-testing/tiny-random-BartForConditionalGeneration"
 _TINY_VIT_MODEL_NAME = "hf-internal-testing/tiny-random-ViTForImageClassification"
 
 TO_TEST = [
     ("masked-lm", _TINY_BERT_MODEL_NAME, 128),
-    ("causal-lm", _TINY_GPT_NEO_MODEL_NAME, 128),
     ("text-classification", _TINY_BERT_MODEL_NAME, 128),
     ("token-classification", _TINY_BERT_MODEL_NAME, 384),
     ("multiple-choice", "hf-internal-testing/tiny-random-BertForMultipleChoice", 384),

--- a/tools/auto_fill_neuron_cache.py
+++ b/tools/auto_fill_neuron_cache.py
@@ -120,9 +120,6 @@ ARCHITECTURES_TO_COMMON_PRETRAINED_WEIGHTS = {
         "gpt2": {
             "default": {"batch_size": 16, "sequence_length": 128},
         },
-        # "gpt2-large": {
-        #     "default": {"batch_size": 16, "sequence_length": 128},
-        # },
     },
     "gpt-neo": {
         "EleutherAI/gpt-neo-125M": {

--- a/tools/auto_fill_neuron_cache.py
+++ b/tools/auto_fill_neuron_cache.py
@@ -121,11 +121,6 @@ ARCHITECTURES_TO_COMMON_PRETRAINED_WEIGHTS = {
             "default": {"batch_size": 16, "sequence_length": 128},
         },
     },
-    "gpt-neo": {
-        "EleutherAI/gpt-neo-125M": {
-            "default": {"batch_size": 16, "sequence_length": 128},
-        },
-    },
     "marian": {
         "Helsinki-NLP/opus-mt-en-es": {
             "translation": {"batch_size": 4, "source_sequence_length": 512, "target_sequence_length": 512},


### PR DESCRIPTION
# What does this PR do?

This is part of the training tests cleanup. The idea is to remove support for models that are not very well tested and have a relatively small audience, such as gpt-neo and gpt-neox.