### PR TITLE
Cache granite and phi4 models

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -27,6 +27,8 @@ jobs:
           gpt2,
           llama,
           qwen2.5,
+          granite,
+          phi4,
           llama3.1-70b,
           qwen2.5-large,
           mistral,


### PR DESCRIPTION
This modifies the inference cache CI workflow to automatically cache `granite` and `phi4` models.