### PR TITLE
Update modeling_seq2seq.py - comment nit

### DIFF
--- a/optimum/neuron/modeling_seq2seq.py
+++ b/optimum/neuron/modeling_seq2seq.py
@@ -807,7 +807,7 @@ SPEECH_RECOGNITION_EXAMPLE = r"""
 
     ```python
     from datasets import load_dataset
-    from transformers import {processor_class}
+    from transformers import AutoProcessor,{processor_class}
     from optimum.neuron import {model_class}
 
     # Select an audio file and read it:


### PR DESCRIPTION
Missing AutoProcessor import in example

# What does this PR do?

You have some example code you display that uses AutoProcessor, but doesn't import it

This isn't really code I'm fixing, just an example / comment that has code.

Metacode?

## Before submitting
- [Kind of ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
