### PR TITLE
Refactor hub neuronx cache

### DIFF
--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -16,7 +16,7 @@
 
 from typing import TYPE_CHECKING
 
-from ...neuron.utils import get_hub_cached_entries, synchronize_hub_cache
+from ...neuron.cache import get_hub_cached_entries, synchronize_hub_cache
 from ...neuron.utils.cache_utils import (
     CACHE_REPO_NAME,
     HF_HOME_CACHE_REPO_FILE,
@@ -186,6 +186,12 @@ class LookupRepoCommand(BaseOptimumCLICommand):
             help="The model_id to lookup cached versions for.",
         )
         parser.add_argument(
+            "--task",
+            type=str,
+            default=None,
+            help="The optional task to lookup cached versions for models supporting multiple tasks.",
+        )
+        parser.add_argument(
             "--mode",
             type=str,
             choices=["training", "inference", "all"],
@@ -195,7 +201,9 @@ class LookupRepoCommand(BaseOptimumCLICommand):
         parser.add_argument("--repo_id", type=str, default=None, help="The name of the repo to use as remote cache.")
 
     def _list_entries(self, mode: str):
-        entries = get_hub_cached_entries(self.args.model_id, mode, cache_repo_id=self.args.repo_id)
+        entries = get_hub_cached_entries(
+            self.args.model_id, mode, task=self.args.task, cache_repo_id=self.args.repo_id
+        )
         n_entries = len(entries)
         output = f"\n*** {n_entries} entrie(s) found in cache for {self.args.model_id} for {mode}.***\n\n"
         for entry in entries:
@@ -206,8 +214,8 @@ class LookupRepoCommand(BaseOptimumCLICommand):
 
     def run(self):
         if self.args.mode == "all":
-            self._list_entries("training")
             self._list_entries("inference")
+            self._list_entries("training")
         else:
             self._list_entries(self.args.mode)
 

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -648,6 +648,7 @@ def main_export(
 
     _, neuron_outputs = export_models(
         models_and_neuron_configs=models_and_neuron_configs,
+        task=task,
         output_dir=output,
         disable_neuron_cache=disable_neuron_cache,
         compiler_workdir=compiler_workdir,

--- a/optimum/neuron/cache/__init__.py
+++ b/optimum/neuron/cache/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2024 The HuggingFace Team. All rights reserved.
+# Copyright 2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from libneuronxla.neuron_cc_wrapper import main as neuron_cc_wrapper_main
-
-from .cache_utils import get_hf_hub_cache_repos, get_neuron_cache_path
-from .hub_cache_utils import hub_neuronx_cache
-
-
-def main():
-    with hub_neuronx_cache("training", cache_repo_id=get_hf_hub_cache_repos()[0], cache_dir=get_neuron_cache_path()):
-        return neuron_cc_wrapper_main()
-
-
-if __name__ == "__main__":
-    main()
+# Only expose the hub cache public API
+from .hub_cache import get_hub_cached_entries, get_hub_cached_models, synchronize_hub_cache

--- a/optimum/neuron/cache/entries/cache_entry.py
+++ b/optimum/neuron/cache/entries/cache_entry.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from huggingface_hub import HfApi
+
+
+CACHE_WHITE_LIST = [
+    "_name_or_path",
+    "transformers_version",
+    "_diffusers_version",
+    "eos_token_id",
+    "bos_token_id",
+    "pad_token_id",
+    "torchscript",
+    "torch_dtype",
+    "_commit_hash",
+    "sample_size",
+    "projection_dim",
+    "_use_default_values",
+    "_attn_implementation_autoset",
+]
+
+
+@dataclass
+class ModelCacheEntry:
+    """A class describing a model cache entry
+
+    Args:
+        model_id (`str`):
+            The model id, used as a key for the cache entry.
+        model_type (`str`):
+            The model type, also used as a key for the cache entry.
+        task (`str`):
+            The task name.
+    """
+
+    model_id: str
+    model_type: str
+    task: str
+
+    # ModelCacheEntry API to be implemented by subclasses
+
+    def to_dict(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, model_id: str, task: str, configs: Dict[str, Any]) -> "ModelCacheEntry":
+        raise NotImplementedError
+
+    @property
+    def neuron_config(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def has_same_arch(self, other: "ModelCacheEntry"):
+        raise NotImplementedError
+
+    @classmethod
+    def from_hub(cls, model_id: str, task: str):
+        raise NotImplementedError
+
+    # Generic methods relying on the API above
+
+    @property
+    def hash(self):
+        hash_gen = hashlib.sha512()
+        hash_gen.update(self.serialize().encode("utf-8"))
+        return str(hash_gen.hexdigest())[:20]
+
+    @staticmethod
+    def create(model_id: str, task: str):
+        from .multi_model import MultiModelCacheEntry
+        from .single_model import SingleModelCacheEntry
+
+        api = HfApi()
+        if api.file_exists(model_id, "config.json"):
+            return SingleModelCacheEntry.from_hub(model_id, task)
+        elif api.file_exists(model_id, "model_index.json"):
+            return MultiModelCacheEntry.from_hub(model_id, task)
+        raise ValueError(f"Unable to evaluate model type for {model_id}: is it a diffusers or transformers model ?")
+
+    def serialize(self) -> str:
+        cache_dict = self.to_dict()
+        cache_dict["_entry_class"] = self.__class__.__name__
+        cache_dict["_model_id"] = self.model_id
+        cache_dict["_task"] = self.task
+        return json.dumps(cache_dict, sort_keys=True)
+
+    @staticmethod
+    def deserialize(data: str) -> "ModelCacheEntry":
+        cache_dict = json.loads(data)
+        entry_class = cache_dict.pop("_entry_class")
+        model_id = cache_dict.pop("_model_id")
+        task = cache_dict.pop("_task")
+        if entry_class == "SingleModelCacheEntry":
+            from .single_model import SingleModelCacheEntry
+
+            return SingleModelCacheEntry.from_dict(model_id, task, cache_dict)
+        elif entry_class == "MultiModelCacheEntry":
+            from .multi_model import MultiModelCacheEntry
+
+            return MultiModelCacheEntry.from_dict(model_id, task, cache_dict)
+        raise ValueError(f"Invalid cache entry of type {entry_class}")

--- a/optimum/neuron/cache/entries/multi_model.py
+++ b/optimum/neuron/cache/entries/multi_model.py
@@ -1,0 +1,179 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Union
+
+from huggingface_hub import HfApi
+from transformers import PretrainedConfig
+
+from .cache_entry import CACHE_WHITE_LIST, ModelCacheEntry
+
+
+NEURON_CONFIG_WHITE_LIST = ["input_names", "output_names", "model_type"]
+
+
+def _exclude_white_list_from_config(
+    config: Dict, white_list: Optional[List] = None, neuron_white_list: Optional[List] = None
+):
+    if white_list is None:
+        white_list = CACHE_WHITE_LIST
+
+    if neuron_white_list is None:
+        neuron_white_list = NEURON_CONFIG_WHITE_LIST
+
+    for param in white_list:
+        config.pop(param, None)
+
+    if "neuron" in config:
+        for param in neuron_white_list:
+            config["neuron"].pop(param, None)
+
+    return config
+
+
+def _clean_configs(
+    configs: Dict[str, Union[PretrainedConfig, Dict[str, Any]]],
+    white_list: Optional[List] = None,
+    neuron_white_list: Optional[List] = None,
+):
+    """Only applied on traced TorchScript models."""
+    clean_configs = {}
+    no_check_components = [
+        "vae",
+        "vae_encoder",
+        "vae_decoder",
+    ]  # Exclude vae configs from stable diffusion pipeline since it's complex and not mandatory
+    for name, config in configs.items():
+        if name in no_check_components:
+            continue
+        config = copy.deepcopy(config).to_diff_dict() if isinstance(config, PretrainedConfig) else config
+        config = _exclude_white_list_from_config(config, white_list, neuron_white_list)
+        clean_configs[name] = config
+    return clean_configs
+
+
+def _prepare_configs_for_matching(configs: Dict, model_type: str):
+    if model_type == "stable-diffusion":
+        non_checked_components = [
+            "vae",
+            "vae_encoder",
+            "vae_decoder",
+        ]  # Exclude vae configs from the check for now since it's complex and not mandatory
+    else:
+        # FIXME: this should be done also for diffusion transformer
+        raise NotImplementedError
+    new_configs = {}
+    for name in configs:
+        if name in non_checked_components:
+            continue
+        new_configs[name] = copy.deepcopy(configs[name])
+        # Remove neuron config for comparison
+        if "neuron" in new_configs[name]:
+            new_configs[name].pop("neuron")
+
+    return new_configs
+
+
+class MultiModelCacheEntry(ModelCacheEntry):
+    """A class describing a model cache entry
+
+    Args:
+        model_id (`str`):
+            The model id, used as a key for the cache entry.
+        model_type (`str`):
+            The model type, also used as a key for the cache entry.
+        configs (`Dict[str, Dict[str, Any]]`):
+            The configurations for the multi models pipeline.
+
+    """
+
+    def __init__(self, model_id: str, task: str, configs: Dict[str, Union[PretrainedConfig, Dict[str, Any]]]):
+        self._configs = _clean_configs(configs)
+        if "unet" in self._configs:
+            model_type = "stable-diffusion"
+        elif "transformer" in self._configs:
+            model_type = "diffusion-transformer"
+        elif "encoder" in self._configs:
+            model_type = self._configs["encoder"]["model_type"]
+        else:
+            raise NotImplementedError
+        super().__init__(model_id, model_type, task)
+
+    # ModelCacheEntry API implementation
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self._configs
+
+    @classmethod
+    def from_dict(cls, model_id: str, task: str, configs: Dict[str, Any]) -> "MultiModelCacheEntry":
+        return cls(model_id=model_id, task=task, configs=configs)
+
+    @property
+    def neuron_config(self) -> Dict[str, Any]:
+        # FIXME: Return neuron config of one of the models
+        if self.model_type == "stable-diffusion":
+            config = self._configs["unet"]
+        else:
+            raise NotImplementedError
+        return config.get("neuron", None)
+
+    def has_same_arch(self, other: "MultiModelCacheEntry"):
+        if not isinstance(other, MultiModelCacheEntry):
+            return False
+        if self.model_type != other.model_type or self.task != other.task:
+            return False
+        # When comparing configs we remove the neuron configs
+        configs = _prepare_configs_for_matching(self._configs, self.model_type)
+        other_configs = _prepare_configs_for_matching(other._configs, other.model_type)
+        if configs.keys() != other_configs.keys():
+            return False
+        for name, config in configs.items():
+            other_config = other_configs[name]
+
+            # We only verify that one of the configs contains the other
+            # This is because the configs are stripped down when serialized
+            def contains(container: Dict[str, Any], containee: Dict[str, Any]):
+                for name, value in containee.items():
+                    if name not in container:
+                        return False
+                    if value != container[name]:
+                        return False
+                return True
+
+            if not contains(config, other_config) and not contains(other_config, config):
+                return False
+        return True
+
+    @classmethod
+    def from_hub(cls, model_id: str, task: str):
+        api = HfApi()
+        repo_files = api.list_repo_files(model_id)
+        config_pattern = "/config.json"
+        config_files = [path for path in repo_files if config_pattern in path]
+        lookup_configs = {}
+        with TemporaryDirectory() as tmpdir:
+            for model_path in config_files:
+                local_path = api.hf_hub_download(model_id, model_path, local_dir=tmpdir)
+                with open(local_path) as f:
+                    entry_config = json.load(f)
+                    white_list = CACHE_WHITE_LIST
+                    for param in white_list:
+                        entry_config.pop(param, None)
+                    lookup_configs[model_path.split("/")[-2]] = entry_config
+
+        return cls(model_id, task, lookup_configs)

--- a/optimum/neuron/cache/entries/single_model.py
+++ b/optimum/neuron/cache/entries/single_model.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from typing import Any, Dict, Union
+
+from transformers import AutoConfig, PretrainedConfig
+
+from .cache_entry import CACHE_WHITE_LIST, ModelCacheEntry
+
+
+class SingleModelCacheEntry(ModelCacheEntry):
+    """A class describing a model cache entry
+
+    Args:
+        model_id (`str`):
+            The model id, used as a key for the cache entry.
+        config (`transformers.PretrainedConfig`):
+            The configuration of the model.
+
+    """
+
+    def __init__(self, model_id: str, task: str, config: Union[PretrainedConfig, Dict[str, Any]]):
+        config = copy.deepcopy(config)
+        # Remove keys set to default values
+        self._config = config.to_diff_dict() if isinstance(config, PretrainedConfig) else config
+        # Store neuron config separately (if any) as eventually it will be passed separately
+        self._neuron_config = self._config.pop("neuron", None)
+        # Also remove keys in white-list
+        for key in CACHE_WHITE_LIST:
+            self._config.pop(key, None)
+        super().__init__(model_id, self._config["model_type"], task)
+
+    # ModelCacheEntry API implementation
+
+    def to_dict(self) -> Dict[str, Any]:
+        # Add neuron config when serializing
+        config = copy.deepcopy(self._config)
+        config["neuron"] = self._neuron_config
+        return config
+
+    @classmethod
+    def from_dict(cls, model_id: str, task: str, config: Dict[str, Any]) -> "SingleModelCacheEntry":
+        return cls(model_id=model_id, task=task, config=config)
+
+    @property
+    def neuron_config(self) -> Dict[str, Any]:
+        return self._neuron_config
+
+    def has_same_arch(self, other: "SingleModelCacheEntry"):
+        if not isinstance(other, SingleModelCacheEntry):
+            return False
+        return self.model_type == other.model_type and self.task == other.task and self._config == other._config
+
+    @classmethod
+    def from_hub(cls, model_id: str, task: str):
+        config = AutoConfig.from_pretrained(model_id)
+        return cls(model_id, task, config)

--- a/optimum/neuron/cache/optimum_neuron_cc_wrapper.py
+++ b/optimum/neuron/cache/optimum_neuron_cc_wrapper.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libneuronxla.neuron_cc_wrapper import main as neuron_cc_wrapper_main
+
+from ..utils.cache_utils import get_hf_hub_cache_repos, get_neuron_cache_path
+from .hub_cache import hub_neuronx_cache
+
+
+def main():
+    with hub_neuronx_cache("training", cache_repo_id=get_hf_hub_cache_repos()[0], cache_dir=get_neuron_cache_path()):
+        return neuron_cc_wrapper_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optimum/neuron/cache/traced.py
+++ b/optimum/neuron/cache/traced.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from pathlib import Path
+
+from .hub_cache import ModelCacheEntry, create_hub_compile_cache_proxy, hub_neuronx_cache
+
+
+logger = logging.getLogger(__name__)
+
+
+def cache_traced_neuron_artifacts(neuron_dir: Path, cache_entry: ModelCacheEntry):
+    # Use the context manager just for creating registry, AOT compilation won't leverage `create_compile_cache`
+    # in `libneuronxla`, so we will need to cache compiled artifacts to local manually.
+    with hub_neuronx_cache("inference", entry=cache_entry):
+        compile_cache = create_hub_compile_cache_proxy()
+        model_cache_dir = compile_cache.default_cache.get_cache_dir_with_cache_key(f"MODULE_{cache_entry.hash}")
+        compile_cache.upload_folder(cache_dir=model_cache_dir, src_dir=neuron_dir)
+
+        logger.info(f"Model cached in: {model_cache_dir}.")

--- a/optimum/neuron/cache/training.py
+++ b/optimum/neuron/cache/training.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import shutil
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional, Union
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH_FOR_NEURON_CC_WRAPPER = Path(__file__).parent.as_posix()
+
+
+@contextmanager
+def patch_neuron_cc_wrapper(
+    directory: Optional[Union[str, Path]] = DEFAULT_PATH_FOR_NEURON_CC_WRAPPER, restore_path: bool = True
+):
+    """
+    Patches the `neuron_cc_wrapper` file to force it use our own version of it which essentially makes sure that it
+    uses our caching system.
+    """
+    context_manager = TemporaryDirectory() if directory is None else nullcontext(enter_result=directory)
+    tmpdirname = ""
+    try:
+        with context_manager as dirname:
+            tmpdirname = dirname
+            src = Path(__file__).parent / "neuron_cc_wrapper"
+            dst = Path(tmpdirname) / "neuron_cc_wrapper"
+            if src != dst:
+                shutil.copy(src, dst)
+
+            path = os.environ["PATH"]
+            os.environ["PATH"] = f"{tmpdirname}:{path}"
+
+            yield
+    except Exception as e:
+        raise e
+    finally:
+        if restore_path:
+            os.environ["PATH"] = os.environ["PATH"].replace(f"{tmpdirname}:", "")

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -30,8 +30,9 @@ from transformers import AutoConfig, AutoModel, GenerationConfig
 
 from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
+from .cache.entries.single_model import SingleModelCacheEntry
+from .cache.hub_cache import hub_neuronx_cache
 from .modeling_base import NeuronModel
-from .utils import ModelCacheEntry, hub_neuronx_cache
 from .utils.require_utils import requires_transformers_neuronx
 from .utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 
@@ -183,7 +184,11 @@ class NeuronDecoderModel(NeuronModel):
 
         # When compiling, only create a cache entry if the model comes from the hub
         checkpoint_id = neuron_config.get("checkpoint_id", None)
-        cache_entry = None if checkpoint_id is None else ModelCacheEntry(checkpoint_id, config)
+        cache_entry = (
+            None
+            if checkpoint_id is None
+            else SingleModelCacheEntry(model_id=checkpoint_id, task="text-generation", config=config)
+        )
 
         # Export the model using the Optimum Neuron Cache
         with hub_neuronx_cache("inference", entry=cache_entry):

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -42,6 +42,8 @@ from ..exporters.neuron import (
 from ..exporters.neuron.model_configs import *  # noqa: F403
 from ..exporters.tasks import TasksManager
 from ..utils import is_diffusers_available
+from .cache.entries.multi_model import MultiModelCacheEntry
+from .cache.hub_cache import create_hub_compile_cache_proxy
 from .modeling_traced import NeuronTracedModel
 from .utils import (
     DIFFUSION_MODEL_CONTROLNET_NAME,
@@ -59,11 +61,6 @@ from .utils import (
     is_neuronx_available,
     replace_weights,
     store_compilation_config,
-)
-from .utils.hub_cache_utils import (
-    ModelCacheEntry,
-    build_cache_config,
-    create_hub_compile_cache_proxy,
 )
 from .utils.require_utils import requires_torch_neuronx
 from .utils.version_utils import get_neuronxcc_version
@@ -1066,8 +1063,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 compilation_configs[name] = compilation_config
 
             # 3. Lookup cached config
-            cache_config = build_cache_config(compilation_configs)
-            cache_entry = ModelCacheEntry(model_id=model_id, config=cache_config)
+            cache_entry = MultiModelCacheEntry(model_id=model_id, task=task, configs=compilation_configs)
             compile_cache = create_hub_compile_cache_proxy()
             model_cache_dir = compile_cache.default_cache.get_cache_dir_with_cache_key(f"MODULE_{cache_entry.hash}")
             cache_exist = compile_cache.download_folder(model_cache_dir, model_cache_dir)

--- a/optimum/neuron/utils/__init__.py
+++ b/optimum/neuron/utils/__init__.py
@@ -41,13 +41,6 @@ _import_structure = {
         "ENCODER_NAME",
         "NEURON_FILE_NAME",
     ],
-    "hub_cache_utils": [
-        "ModelCacheEntry",
-        "get_hub_cached_entries",
-        "get_hub_cached_models",
-        "hub_neuronx_cache",
-        "synchronize_hub_cache",
-    ],
     "import_utils": [
         "is_accelerate_available",
         "is_neuron_available",
@@ -119,13 +112,6 @@ if TYPE_CHECKING:
         DIFFUSION_MODEL_VAE_ENCODER_NAME,
         ENCODER_NAME,
         NEURON_FILE_NAME,
-    )
-    from .hub_cache_utils import (
-        ModelCacheEntry,
-        get_hub_cached_entries,
-        get_hub_cached_models,
-        hub_neuronx_cache,
-        synchronize_hub_cache,
     )
     from .import_utils import (
         is_accelerate_available,

--- a/optimum/neuron/utils/argument_utils.py
+++ b/optimum/neuron/utils/argument_utils.py
@@ -310,6 +310,7 @@ def store_compilation_config(
     # Add args of optional outputs
     config_args["output_attentions"] = output_attentions
     config_args["output_hidden_states"] = output_hidden_states
+    config_args["task"] = task
 
     update_func("neuron", config_args)
 
@@ -317,7 +318,5 @@ def store_compilation_config(
         import diffusers
 
         update_func("_diffusers_version", diffusers.__version__)
-
-    update_func("task", task)
 
     return config

--- a/optimum/neuron/utils/torch_xla_and_neuronx_initialization.py
+++ b/optimum/neuron/utils/torch_xla_and_neuronx_initialization.py
@@ -20,8 +20,9 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from ...utils import logging
-from .hub_cache_utils import patch_neuron_cc_wrapper
+from optimum.utils import logging
+
+from ..cache.training import patch_neuron_cc_wrapper
 from .misc import is_main_worker
 from .require_utils import requires_torch_xla
 

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0.dev1"
 
 __sdk_version__ = "2.21.1"

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -32,7 +32,7 @@ from optimum.neuron import (
     NeuronStableDiffusionPipeline,
     NeuronStableDiffusionXLPipeline,
 )
-from optimum.neuron.utils import get_hub_cached_entries, get_hub_cached_models, synchronize_hub_cache
+from optimum.neuron.cache import get_hub_cached_entries, get_hub_cached_models, synchronize_hub_cache
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
@@ -186,7 +186,7 @@ def local_cache_size(cache_path):
 @requires_neuronx
 def test_decoder_cache(cache_repos):
     cache_path, cache_repo_id = cache_repos
-    model_id = "hf-internal-testing/tiny-random-gpt2"
+    model_id = "llamafactory/tiny-random-Llama-3"
     # Export the model a first time to populate the local cache
     model = export_decoder_model(model_id)
     check_decoder_generation(model)
@@ -200,7 +200,7 @@ def test_decoder_cache(cache_repos):
     assert model_entries[0] == model.config.neuron
     # Also verify that the model appears in the list of cached models
     cached_models = get_hub_cached_models("inference")
-    assert ("gpt2", "hf-internal-testing", "tiny-random-gpt2") in cached_models
+    assert ("llama", "llamafactory", "tiny-random-Llama-3") in cached_models
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):
         for f in files:
@@ -209,7 +209,7 @@ def test_decoder_cache(cache_repos):
             shutil.rmtree(os.path.join(root, d))
     assert local_cache_size(cache_path) == 0
     # Export the model again: the compilation artifacts should be fetched from the Hub
-    model = export_decoder_model("hf-internal-testing/tiny-random-gpt2")
+    model = export_decoder_model(model_id)
     check_decoder_generation(model)
     # Verify the local cache directory has not been populated
     assert len(get_local_cached_files(cache_path, "neff")) == 0
@@ -230,7 +230,9 @@ def test_encoder_cache(cache_repos):
     synchronize_hub_cache(cache_repo_id=cache_repo_id)
     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
     # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+    model_entries = get_hub_cached_entries(
+        model_id, "inference", task="text-classification", cache_repo_id=cache_repo_id
+    )
     assert len(model_entries) == 1
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):
@@ -320,7 +322,7 @@ def test_stable_diffusion_xl_cache(cache_repos):
 )
 def test_decoder_cache_unavailable(cache_repos, var, value, match):
     # Just exporting the model will only emit a warning
-    export_decoder_model("hf-internal-testing/tiny-random-gpt2")
+    export_decoder_model("llamafactory/tiny-random-Llama-3")
     prev_value = os.environ.get(var, None)
     # Modify the specified environment variable to trigger an error
     os.environ[var] = value
@@ -338,7 +340,7 @@ def test_decoder_cache_unavailable(cache_repos, var, value, match):
 @requires_neuronx
 def test_optimum_neuron_cli_cache_synchronize(cache_repos):
     cache_path, cache_repo_id = cache_repos
-    model_id = "hf-internal-testing/tiny-random-gpt2"
+    model_id = "llamafactory/tiny-random-Llama-3"
     # Export a model to populate the local cache
     export_decoder_model(model_id)
     # Synchronize the hub cache with the local cache

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -280,7 +280,6 @@ def test_stable_diffusion_cache(cache_repos):
 
 @is_inferentia_test
 @requires_neuronx
-@pytest.mark.skip("Disable the test due to https://github.com/aws-neuron/aws-neuron-sdk/issues/859")
 def test_stable_diffusion_xl_cache(cache_repos):
     cache_path, cache_repo_id = cache_repos
     model_id = "echarlaix/tiny-random-stable-diffusion-xl"

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from optimum.neuron import NeuronModelForCausalLM
-from optimum.neuron.utils import synchronize_hub_cache
+from optimum.neuron.cache import synchronize_hub_cache
 from optimum.neuron.version import __sdk_version__ as sdk_version
 from optimum.neuron.version import __version__ as version
 

--- a/tests/exporters/test_export.py
+++ b/tests/exporters/test_export.py
@@ -238,6 +238,7 @@ class NeuronStableDiffusionExportTestCase(unittest.TestCase):
             )
             _, neuron_outputs = export_models(
                 models_and_neuron_configs=models_and_neuron_configs,
+                task="text-to-image",
                 output_dir=Path(tmpdirname),
                 output_file_names=output_model_names,
                 compiler_kwargs=compiler_kwargs,
@@ -271,6 +272,7 @@ class NeuronStableDiffusionExportTestCase(unittest.TestCase):
             )
             _, neuron_outputs = export_models(
                 models_and_neuron_configs=models_and_neuron_configs,
+                task="text-to-image",
                 output_dir=Path(tmpdirname),
                 output_file_names=output_model_names,
                 compiler_kwargs=compiler_kwargs,
@@ -312,6 +314,7 @@ class NeuronStableDiffusionExportTestCase(unittest.TestCase):
             )
             _, neuron_outputs = export_models(
                 models_and_neuron_configs=models_and_neuron_configs,
+                task="text-to-image",
                 output_dir=Path(tmpdirname),
                 output_file_names=output_model_names,
                 compiler_kwargs=compiler_kwargs,
@@ -352,6 +355,7 @@ class NeuronEncoderDecoderExportTestCase(unittest.TestCase):
             )
             _, neuron_outputs = export_models(
                 models_and_neuron_configs=models_and_neuron_configs,
+                task="text2text-generation",
                 output_dir=Path(tmpdirname),
                 output_file_names=output_model_names,
             )


### PR DESCRIPTION
# What does this PR do?

This refactors the hub neuronx cache to prepare the support of cached NxD LLM models.

### Refactor the code to make it more modular

The current implementation is used in several configurations.

1 - Using caching at the NEFF level
- for the inference of LLM
- for the training of decoder models (either legacy ones like Bert of LLMs like LLama).

2 - Using caching at the model level (torch script modules)
- for the inference of transformers single models (like Bert for sequence classification),
- for the inference of  transformers multiple models (like encoder-decoder models),
- for the inference of diffusion pipelines.

This makes the code contained in the single `hub_cache_utils.py` difficult to understand and modify.

This pull-request splits the code in multiple files under the `optimum/neuron/cache` directory:

- the `hub_cache.py` file contains the high-level cache API,
- the `entries` directory defines the `ModelCacheEntry` abstract class that is specialized in two entries for single model and multiple models entries,
- the `traced.py` and `training.py` contains specific methods that are used only by these configurations.

### Add task in cached model registry

The pull-request also introduces the `task` as a mandatory parameter when creating an entry in the registry, because some models will have a different static graph for different tasks.

Adding this parameter required small modifications:
- in the traced model export code: task is now passed to `export_models`,
- in the neuron trainer: task is deduced from model.

### Better isolate standard model config from neuron specific configuration parameters

Finally, the pull-request tries to preserve the model config/configs as stored in the cache registry to simplify the compatibility checks. For that reason, the `task` parameter is now stored in the `neuron_config` for traced models only (and not in the `config` itself).