### PR TITLE
chore: bump AMI base version for Neuron SDK 2.22

### DIFF
--- a/infrastructure/ami/hcl2-files/variables.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/variables.pkr.hcl
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "source_ami" {
-  default     = "ami-0349dc82277d50797"
+  default     = "ami-0a6d8151c96a08153"
   description = "Base Image"
   type        = string
   /*


### PR DESCRIPTION
# What does this PR do?

Since we updated `optimum-neuron` to use the AWS Neuron SDK 2.22 packages, we also need to bump the base AMI version to reflect those changes.