### PR TITLE
Set task to none for multi models cache entry

### DIFF
--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -417,7 +417,7 @@ def export_models(
             cache_config = list(compile_configs.values())[0]
             cache_entry = SingleModelCacheEntry(model_id=model_id, task=task, config=cache_config)
         else:
-            cache_entry = MultiModelCacheEntry(model_id=model_id, task=task, configs=compile_configs)
+            cache_entry = MultiModelCacheEntry(model_id=model_id, configs=compile_configs)
         cache_traced_neuron_artifacts(neuron_dir=output_dir, cache_entry=cache_entry)
 
     # remove models failed to export

--- a/optimum/neuron/cache/entries/cache_entry.py
+++ b/optimum/neuron/cache/entries/cache_entry.py
@@ -99,7 +99,7 @@ class ModelCacheEntry:
         cache_dict["_entry_class"] = self.__class__.__name__
         cache_dict["_model_id"] = self.model_id
         cache_dict["_task"] = self.task
-        return json.dumps(cache_dict, sort_keys=True)
+        return json.dumps(cache_dict, indent=2, sort_keys=True)
 
     @staticmethod
     def deserialize(data: str) -> "ModelCacheEntry":

--- a/optimum/neuron/cache/entries/cache_entry.py
+++ b/optimum/neuron/cache/entries/cache_entry.py
@@ -59,19 +59,11 @@ class ModelCacheEntry:
     def to_dict(self) -> Dict[str, Any]:
         raise NotImplementedError
 
-    @classmethod
-    def from_dict(cls, model_id: str, task: str, configs: Dict[str, Any]) -> "ModelCacheEntry":
-        raise NotImplementedError
-
     @property
     def neuron_config(self) -> Dict[str, Any]:
         raise NotImplementedError
 
     def has_same_arch(self, other: "ModelCacheEntry"):
-        raise NotImplementedError
-
-    @classmethod
-    def from_hub(cls, model_id: str, task: str):
         raise NotImplementedError
 
     # Generic methods relying on the API above
@@ -91,7 +83,7 @@ class ModelCacheEntry:
         if api.file_exists(model_id, "config.json"):
             return SingleModelCacheEntry.from_hub(model_id, task)
         elif api.file_exists(model_id, "model_index.json"):
-            return MultiModelCacheEntry.from_hub(model_id, task)
+            return MultiModelCacheEntry.from_hub(model_id)
         raise ValueError(f"Unable to evaluate model type for {model_id}: is it a diffusers or transformers model ?")
 
     def serialize(self) -> str:
@@ -114,5 +106,5 @@ class ModelCacheEntry:
         elif entry_class == "MultiModelCacheEntry":
             from .multi_model import MultiModelCacheEntry
 
-            return MultiModelCacheEntry.from_dict(model_id, task, cache_dict)
+            return MultiModelCacheEntry.from_dict(model_id, cache_dict)
         raise ValueError(f"Invalid cache entry of type {entry_class}")

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -1063,7 +1063,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 compilation_configs[name] = compilation_config
 
             # 3. Lookup cached config
-            cache_entry = MultiModelCacheEntry(model_id=model_id, task=task, configs=compilation_configs)
+            cache_entry = MultiModelCacheEntry(model_id=model_id, configs=compilation_configs)
             compile_cache = create_hub_compile_cache_proxy()
             model_cache_dir = compile_cache.default_cache.get_cache_dir_with_cache_key(f"MODULE_{cache_entry.hash}")
             cache_exist = compile_cache.download_folder(model_cache_dir, model_cache_dir)

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.2.0.dev1"
+__version__ = "0.2.0.dev2"
 
 __sdk_version__ = "2.22.0"


### PR DESCRIPTION
# What does this PR do?

When exporting pipelines we put all possible sub-models in the script module, regardless of the target task. This means that all tasks are supported by the same cached artifacts.

This pull-request therefore modifies the `MultiModelCacheEntry` to always set the task to None.
