### PR TITLE
ci: add cv2 to workaround transformers spurious import

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -45,6 +45,9 @@ jobs:
         uses: ./.github/actions/prepare_venv
       - name: Install optimum-neuron
         uses: ./.github/actions/install_optimum_neuron
+      - name: Install cv2 dependencies
+        run: |
+          sudo apt-get install python3-opencv -y
       - name: Create cache for ${{matrix.config}} models
         run: |
           source aws_neuron_venv_pytorch/bin/activate

--- a/.github/workflows/inference_cache_stable_diffusion.yml
+++ b/.github/workflows/inference_cache_stable_diffusion.yml
@@ -33,6 +33,9 @@ jobs:
         uses: ./.github/actions/prepare_venv
       - name: Install optimum-neuron
         uses: ./.github/actions/install_optimum_neuron
+      - name: Install cv2 dependencies
+        run: |
+          sudo apt-get install python3-opencv -y
       - name: Create cache for ${{matrix.config}} models
         run: |
           source aws_neuron_venv_pytorch/bin/activate


### PR DESCRIPTION
# What does this PR do?

This fixes an error due to a missing `cv2` library when importing transformers that prevents the cache workflow from running.
