### PR TITLE
Cache Hub API Changes

### DIFF
--- a/optimum/commands/neuron/cache.py
+++ b/optimum/commands/neuron/cache.py
@@ -191,21 +191,12 @@ class LookupRepoCommand(BaseOptimumCLICommand):
             default=None,
             help="The optional task to lookup cached versions for models supporting multiple tasks.",
         )
-        parser.add_argument(
-            "--mode",
-            type=str,
-            choices=["training", "inference", "all"],
-            default="all",
-            help='The mode you wish to lookup compilation files for. Can be either "training", "inference" or "all"',
-        )
         parser.add_argument("--repo_id", type=str, default=None, help="The name of the repo to use as remote cache.")
 
-    def _list_entries(self, mode: str):
-        entries = get_hub_cached_entries(
-            self.args.model_id, mode, task=self.args.task, cache_repo_id=self.args.repo_id
-        )
+    def _list_entries(self):
+        entries = get_hub_cached_entries(self.args.model_id, task=self.args.task, cache_repo_id=self.args.repo_id)
         n_entries = len(entries)
-        output = f"\n*** {n_entries} entrie(s) found in cache for {self.args.model_id} for {mode}.***\n\n"
+        output = f"\n*** {n_entries} entrie(s) found in cache for {self.args.model_id}.***\n\n"
         for entry in entries:
             for key, value in entry.items():
                 output += f"\n{key}: {value}"
@@ -213,11 +204,7 @@ class LookupRepoCommand(BaseOptimumCLICommand):
         print(output)
 
     def run(self):
-        if self.args.mode == "all":
-            self._list_entries("inference")
-            self._list_entries("training")
-        else:
-            self._list_entries(self.args.mode)
+        self._list_entries()
 
 
 class CustomCacheRepoCommand(BaseOptimumCLICommand):

--- a/optimum/neuron/backends/hlo/modeling_decoder.py
+++ b/optimum/neuron/backends/hlo/modeling_decoder.py
@@ -118,7 +118,7 @@ class HloModelForCausalLM(NeuronModelForCausalLM):
         )
 
         # Export the model using the Optimum Neuron Cache
-        with hub_neuronx_cache("inference", entry=cache_entry):
+        with hub_neuronx_cache(entry=cache_entry):
             available_cores = get_available_cores()
             if neuron_config.tp_degree > available_cores:
                 raise ValueError(

--- a/optimum/neuron/cache/hub_cache.py
+++ b/optimum/neuron/cache/hub_cache.py
@@ -27,7 +27,7 @@ from huggingface_hub.hf_api import RepoFile
 
 from optimum.exporters import TasksManager
 
-from ..utils.cache_utils import get_hf_hub_cache_repo, get_neuron_cache_path
+from ..utils.cache_utils import get_hf_hub_cache_repo
 from ..utils.import_utils import is_neuronx_available
 from ..utils.patching import patch_everywhere
 from ..utils.require_utils import requires_torch_neuronx
@@ -288,8 +288,6 @@ def hub_neuronx_cache(
             return create_compile_cache(cache_url)
 
     try:
-        if mode == "training" and cache_dir is None:
-            cache_dir = get_neuron_cache_path()
         if isinstance(cache_dir, Path):
             cache_dir = cache_dir.as_posix()
         default_cache = create_compile_cache(CacheUrl.get_cache_url(cache_dir=cache_dir))

--- a/optimum/neuron/cache/optimum_neuron_cc_wrapper.py
+++ b/optimum/neuron/cache/optimum_neuron_cc_wrapper.py
@@ -20,7 +20,7 @@ from .hub_cache import hub_neuronx_cache
 
 
 def main():
-    with hub_neuronx_cache("training", cache_repo_id=get_hf_hub_cache_repos()[0], cache_dir=get_neuron_cache_path()):
+    with hub_neuronx_cache(cache_repo_id=get_hf_hub_cache_repos()[0], cache_dir=get_neuron_cache_path()):
         return neuron_cc_wrapper_main()
 
 

--- a/optimum/neuron/cache/traced.py
+++ b/optimum/neuron/cache/traced.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def cache_traced_neuron_artifacts(neuron_dir: Path, cache_entry: ModelCacheEntry):
     # Use the context manager just for creating registry, AOT compilation won't leverage `create_compile_cache`
     # in `libneuronxla`, so we will need to cache compiled artifacts to local manually.
-    with hub_neuronx_cache("inference", entry=cache_entry):
+    with hub_neuronx_cache(entry=cache_entry):
         compile_cache = create_hub_compile_cache_proxy()
         model_cache_dir = compile_cache.default_cache.get_cache_dir_with_cache_key(f"MODULE_{cache_entry.hash}")
         compile_cache.upload_folder(cache_dir=model_cache_dir, src_dir=neuron_dir)

--- a/optimum/neuron/trainers.py
+++ b/optimum/neuron/trainers.py
@@ -85,11 +85,9 @@ from transformers.utils import (
     is_sagemaker_mp_enabled,
 )
 
-from optimum.exporters import TasksManager
 from optimum.utils import logging
 
 from .accelerate import NeuronAccelerator, NeuronDistributedType, NeuronPartialState
-from .cache.entries.single_model import SingleModelCacheEntry
 from .cache.hub_cache import hub_neuronx_cache, synchronize_hub_cache
 from .cache.training import patch_neuron_cc_wrapper
 from .distributed import Parallelizer, ParallelizersManager
@@ -102,9 +100,7 @@ from .utils import (
 )
 from .utils.cache_utils import (
     get_hf_hub_cache_repos,
-    get_model_name_or_path,
     get_neuron_cache_path,
-    get_num_neuron_cores_used,
     has_write_access_to_repo,
 )
 from .utils.import_utils import is_peft_available
@@ -119,7 +115,6 @@ from .utils.training_utils import (
     skip_first_batches,
 )
 from .utils.trl_utils import NeuronSFTConfig
-from .utils.version_utils import get_neuronxcc_version
 
 
 if is_torch_xla_available():
@@ -210,20 +205,6 @@ class _TrainerForNeuron:
 
         # Make the model Neuron-compatible for generation.
         patch_generation_mixin_to_neuron_generation_mixin(self.model)
-
-        # Model cache entry management.
-        model_name_or_path_for_cache_entry = get_model_name_or_path(self.model.config)
-        model_config_for_cache_entry = copy.deepcopy(self.model.config)
-        precision = "bfloat16" if self.accelerator.state.mixed_precision == "bf16" else "float32"
-
-        neuron_config_for_cache_entry = {
-            "model_class": self.model.__class__.__name__,
-            "precision": precision,
-            "num_neuron_cores_per_node": get_num_neuron_cores_used(),
-            "compiler_version": get_neuronxcc_version(),
-            "tensor_parallel_size": self.args.tensor_parallel_size,
-            "pipeline_parallel_size": self.args.pipeline_parallel_size,
-        }
 
     @property
     def mp_enabled(self):
@@ -405,7 +386,6 @@ class _TrainerForNeuron:
 
     def _prepare_inputs(self, inputs: Dict[str, Union[torch.Tensor, Any]]) -> Dict[str, Union[torch.Tensor, Any]]:
         inputs = super()._prepare_inputs(inputs)
-        input_specs_for_cache_entry = {k: v.shape if isinstance(v, torch.Tensor) else v for k, v in inputs.items()}
         return inputs
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
@@ -618,7 +598,7 @@ class _TrainerForNeuron:
     def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
         if not is_precompilation():  # Avoid unnecessary model saving during precompilation
             with patch_neuron_cc_wrapper():
-                with hub_neuronx_cache("training"):
+                with hub_neuronx_cache(cache_dir=get_neuron_cache_path()):
                     if output_dir is None:
                         output_dir = self.args.output_dir
 
@@ -1447,7 +1427,7 @@ class _TrainerForNeuron:
         ignore_keys_for_eval: Optional[List[str]] = None,
         **kwargs,
     ):
-        with hub_neuronx_cache("training"):
+        with hub_neuronx_cache(cache_dir=get_neuron_cache_path()):
             result = super().train(
                 resume_from_checkpoint=resume_from_checkpoint,
                 trial=trial,
@@ -1464,7 +1444,7 @@ class _TrainerForNeuron:
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
-        with hub_neuronx_cache("training"):
+        with hub_neuronx_cache(cache_dir=get_neuron_cache_path()):
             with self.args.world_size_as_dp_size():
                 result = super().evaluate(
                     eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
@@ -1476,7 +1456,7 @@ class _TrainerForNeuron:
     def predict(
         self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "test"
     ) -> PredictionOutput:
-        with hub_neuronx_cache("training"):
+        with hub_neuronx_cache(cache_dir=get_neuron_cache_path()):
             with self.args.world_size_as_dp_size():
                 result = super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
         if not is_precompilation():

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.2.0.dev3"
+__version__ = "0.2.0.dev4"
 
 __sdk_version__ = "2.22.0"

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -195,11 +195,11 @@ def test_decoder_cache(cache_repos):
     synchronize_hub_cache(cache_repo_id=cache_repo_id)
     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
     # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+    model_entries = get_hub_cached_entries(model_id, cache_repo_id=cache_repo_id)
     assert len(model_entries) == 1
     assert model_entries[0] == model.neuron_config.to_dict()
     # Also verify that the model appears in the list of cached models
-    cached_models = get_hub_cached_models("inference")
+    cached_models = get_hub_cached_models()
     assert ("llama", "llamafactory", "tiny-random-Llama-3") in cached_models
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):
@@ -230,9 +230,7 @@ def test_encoder_cache(cache_repos):
     synchronize_hub_cache(cache_repo_id=cache_repo_id)
     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
     # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(
-        model_id, "inference", task="text-classification", cache_repo_id=cache_repo_id
-    )
+    model_entries = get_hub_cached_entries(model_id, task="text-classification", cache_repo_id=cache_repo_id)
     assert len(model_entries) == 1
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):
@@ -262,7 +260,7 @@ def test_stable_diffusion_cache(cache_repos):
     synchronize_hub_cache(cache_repo_id=cache_repo_id)
     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
     # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+    model_entries = get_hub_cached_entries(model_id, cache_repo_id=cache_repo_id)
     assert len(model_entries) == 1
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):
@@ -292,7 +290,7 @@ def test_stable_diffusion_xl_cache(cache_repos):
     synchronize_hub_cache(cache_repo_id=cache_repo_id)
     assert_local_and_hub_cache_sync(cache_path, cache_repo_id)
     # Verify we are able to fetch the cached entry for the model
-    model_entries = get_hub_cached_entries(model_id, "inference", cache_repo_id=cache_repo_id)
+    model_entries = get_hub_cached_entries(model_id, cache_repo_id=cache_repo_id)
     assert len(model_entries) == 1
     # Clear the local cache
     for root, dirs, files in os.walk(cache_path):


### PR DESCRIPTION
# What does this PR do?

Drop the registry usage from training, given that we did not identify cache registry usage for training. This allows to simplify the API for hub handling, that requires less parameters.
Also, the "inference" subfolder is removed from the registry tree.

