### PR TITLE
Add decoder custom modeling for inference based on NxD

### DIFF
--- a/.github/workflows/test_inf2_llm.yml
+++ b/.github/workflows/test_inf2_llm.yml
@@ -41,3 +41,8 @@ jobs:
         run: |
           source aws_neuron_venv_pytorch/bin/activate
           HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} pytest -m is_inferentia_test tests/decoder
+      - name: Run llama tests with NxD backend
+        run: |
+          source aws_neuron_venv_pytorch/bin/activate
+          export OPTIMUM_NEURON_PRIORITIZE_NXD_BACKEND=1
+          HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} pytest -m is_inferentia_test tests/decoder -k llama

--- a/examples/text-generation/generation.py
+++ b/examples/text-generation/generation.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         model = NeuronModelForCausalLM.from_pretrained(args.model, export=False, low_cpu_mem_usage=True)
         end = time.time()
         print(f"Neuron model loaded in {end - start:.2f} s.")
-        batch_size = model.config.neuron["batch_size"]
+        batch_size = model.neuron_config.batch_size
         prompts = args.prompts.split("|")
         if len(prompts) < batch_size:
             prompts = prompts + [prompts[-1]] * (batch_size - len(prompts))

--- a/optimum/neuron/configuration_utils.py
+++ b/optimum/neuron/configuration_utils.py
@@ -256,18 +256,6 @@ class NeuronConfig(PushToHubMixin):
         logger.info(f"Neuron config {config}")
         return config
 
-    def dict_torch_dtype_to_str(self, d: Dict[str, Any]) -> None:
-        """
-        Checks whether the passed dictionary and its nested dicts have a *torch_dtype* key and if it's not None,
-        converts torch.dtype to a string of just the type. For example, `torch.float32` get converted into *"float32"*
-        string, which can then be stored in the json format.
-        """
-        if d.get("torch_dtype", None) is not None and not isinstance(d["torch_dtype"], str):
-            d["torch_dtype"] = str(d["torch_dtype"]).split(".")[1]
-        for value in d.values():
-            if isinstance(value, dict):
-                self.dict_torch_dtype_to_str(value)
-
     def to_dict(self) -> Dict[str, Any]:
         """
         Serializes this instance to a Python dictionary.
@@ -292,6 +280,8 @@ class NeuronConfig(PushToHubMixin):
                 return {_to_dict(k): _to_dict(v) for k, v in obj.items()}
             elif isinstance(obj, tuple):
                 return str(tuple(_to_dict(e) for e in obj))
+            elif isinstance(obj, torch.dtype):
+                return str(obj).split(".")[1]
             else:
                 as_dict = obj.__dict__
                 return _to_dict(as_dict)

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -24,7 +24,7 @@ import torch
 from huggingface_hub import HfApi
 from transformers import AutoModelForCausalLM, GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
-from transformers.generation import GenerationMixin, StoppingCriteriaList
+from transformers.generation import StoppingCriteriaList
 
 from .configuration_utils import NeuronConfig
 from .modeling_base import NeuronModel
@@ -103,7 +103,7 @@ def get_neuron_causal_lm_model_class(config: PretrainedConfig):
     """,
     NEURON_CAUSALLM_MODEL_START_DOCSTRING,
 )
-class NeuronModelForCausalLM(NeuronModel, GenerationMixin, ABC):
+class NeuronModelForCausalLM(NeuronModel, ABC):
     auto_model_class = AutoModelForCausalLM
     main_input_name = "input_ids"
     preprocessors = []  # Required by optimum OptimizedModel
@@ -279,10 +279,6 @@ class NeuronModelForCausalLM(NeuronModel, GenerationMixin, ABC):
         # Find the correct model class
         cls = get_neuron_causal_lm_model_class(config)
         return cls._from_pretrained(model_id, config, **kwargs)
-
-    def can_generate(self) -> bool:
-        """Returns True to validate the check made in `GenerationMixin.generate()`."""
-        return True
 
     @add_start_docstrings(
         NEURON_CAUSALLM_MODEL_GENERATE_DOCSTRING

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -22,7 +22,7 @@ from typing import Optional, Union
 
 import torch
 from huggingface_hub import HfApi
-from transformers import AutoModelForCausalLM, GenerationConfig, PretrainedConfig
+from transformers import GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 from transformers.generation import StoppingCriteriaList
 
@@ -104,8 +104,6 @@ def get_neuron_causal_lm_model_class(config: PretrainedConfig):
     NEURON_CAUSALLM_MODEL_START_DOCSTRING,
 )
 class NeuronModelForCausalLM(NeuronModel, ABC):
-    auto_model_class = AutoModelForCausalLM
-    main_input_name = "input_ids"
     preprocessors = []  # Required by optimum OptimizedModel
 
     @classmethod

--- a/optimum/neuron/models/inference/auto_models.py
+++ b/optimum/neuron/models/inference/auto_models.py
@@ -19,12 +19,18 @@ Add each neuron model class supported for inference below to allow it to be inst
 automatically by the neuron factory classes such as NeuronModelForCausalLM.
 """
 
+import os
+
 from ..auto_model import register_neuron_model
 from .hlo.granite.model import GraniteHloModelForCausalLM
 from .hlo.llama.model import LlamaHloModelForCausalLM
 from .hlo.phi3.model import Phi3HloModelForCausalLM
 from .hlo.qwen2.model import Qwen2HloModelForCausalLM
+from .nxd.llama.modeling_llama import LlamaNxDModelForCausalLM
 from .nxd.mixtral.modeling_mixtral import MixtralNxDModelForCausalLM
+
+
+prioritize_nxd_backend = os.environ.get("OPTIMUM_NEURON_PRIORITIZE_NXD_BACKEND", "0") == "1"
 
 
 def register_neuron_model_for_inference(model_type: str, task: str):
@@ -43,13 +49,24 @@ class GraniteModelForCausalLM(GraniteHloModelForCausalLM):
     pass
 
 
-@register_neuron_model_for_inference("llama", "text-generation")
-class LLamaModelForCausalLM(LlamaHloModelForCausalLM):
-    """
-    Llama model with HLO backend for inference on AWS Neuron.
-    """
+if prioritize_nxd_backend:
 
-    pass
+    @register_neuron_model_for_inference("llama", "text-generation")
+    class LLamaModelForCausalLM(LlamaNxDModelForCausalLM):
+        """
+        Llama model with NxD backend for inference on AWS Neuron.
+        """
+
+        pass
+else:
+
+    @register_neuron_model_for_inference("llama", "text-generation")
+    class LLamaModelForCausalLM(LlamaHloModelForCausalLM):
+        """
+        Llama model with HLO backend for inference on AWS Neuron.
+        """
+
+        pass
 
 
 @register_neuron_model_for_inference("phi3", "text-generation")

--- a/optimum/neuron/models/inference/auto_models.py
+++ b/optimum/neuron/models/inference/auto_models.py
@@ -24,6 +24,7 @@ from .hlo.granite.model import GraniteHloModelForCausalLM
 from .hlo.llama.model import LlamaHloModelForCausalLM
 from .hlo.phi3.model import Phi3HloModelForCausalLM
 from .hlo.qwen2.model import Qwen2HloModelForCausalLM
+from .nxd.mixtral.modeling_mixtral import MixtralNxDModelForCausalLM
 
 
 def register_neuron_model_for_inference(model_type: str, task: str):
@@ -64,6 +65,15 @@ class Phi3ModelForCausalLM(Phi3HloModelForCausalLM):
 class Qwen2ModelForCausalLM(Qwen2HloModelForCausalLM):
     """
     Qwen2 model with HLO backend for inference on AWS Neuron.
+    """
+
+    pass
+
+
+@register_neuron_model_for_inference("mixtral", "text-generation")
+class MixtralNeuronModelForCausalLM(MixtralNxDModelForCausalLM):
+    """
+    Mixtral model with NxD backend for inference on AWS Neuron.
     """
 
     pass

--- a/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
+++ b/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
@@ -63,8 +63,9 @@ class HloModelForCausalLM(NeuronModelForCausalLM, GenerationMixin):
         - generation_config ([`~transformers.GenerationConfig`]) -- The generation configuration used by default when calling `generate()`.
     """
 
-    model_type = "neuron_model"
-    auto_model_class = AutoModel
+    # The class used to instantiate the neuron model
+    # This attribute must be set by the model subclass
+    # (e.g. LlamaHloModelForCausalLM, Qwen2HloModelForCausalLM, etc.)
     neuron_model_class = None
 
     CHECKPOINT_DIR = "checkpoint"
@@ -93,9 +94,8 @@ class HloModelForCausalLM(NeuronModelForCausalLM, GenerationMixin):
         self.generation_config = generation_config
         # Registers the NeuronModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating
         # a pipeline https://github.com/huggingface/transformers/blob/3d3204c025b6b5de013e07dd364208e28b4d9589/src/transformers/pipelines/base.py#L940
-        AutoConfig.register(self.model_type, AutoConfig)
-        if hasattr(self.auto_model_class, "register"):
-            self.auto_model_class.register(AutoConfig, self.__class__)
+        AutoConfig.register("neuron_model", AutoConfig)
+        AutoModel.register(AutoConfig, self.__class__)
 
         # Instantiate neuronx model
         checkpoint_path = checkpoint_dir.name if isinstance(checkpoint_dir, TemporaryDirectory) else checkpoint_dir

--- a/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
+++ b/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import torch
 from huggingface_hub import HfApi, snapshot_download
-from transformers import AutoConfig, AutoModel, GenerationConfig
+from transformers import AutoConfig, AutoModel, GenerationConfig, GenerationMixin
 from transformers.modeling_outputs import ModelOutput
 
 from optimum.exporters.tasks import TasksManager
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class HloModelForCausalLM(NeuronModelForCausalLM):
+class HloModelForCausalLM(NeuronModelForCausalLM, GenerationMixin):
     """
     Base class to convert and run pre-trained transformers decoder models on Neuron devices.
 
@@ -328,6 +328,15 @@ class HloModelForCausalLM(NeuronModelForCausalLM):
         )
 
     # GenerationMixin implementation below
+
+    def can_generate(self) -> bool:
+        """
+        Called by the transformers code to identify generation models.
+
+        Returns:
+            `bool`: `True` if the model can generate sequences, `False` otherwise.
+        """
+        return True
 
     def get_start_ids(
         self,

--- a/optimum/neuron/models/inference/nxd/backend/__init__.py
+++ b/optimum/neuron/models/inference/nxd/backend/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/optimum/neuron/models/inference/nxd/backend/cache.py
+++ b/optimum/neuron/models/inference/nxd/backend/cache.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cache decorator for NeuronX compilation based on `libneuronxla`."""
+
+import hashlib
+import json
+import logging
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import List, Optional, Union
+
+from libneuronxla.neuron_cc_cache import CacheUrl, create_compile_cache
+from torch_neuronx.xla_impl.trace import HloArtifacts, NeffArtifacts, generate_neff, hlo_compile, setup_compiler_dirs
+
+from .....utils.patching import patch_everywhere
+
+
+logger = logging.getLogger("Neuron")
+
+
+# Use the same hash function as in transformers_neuronx
+def get_hash_module(hlo_module, flags):
+    # Hashing is pretty fast and neglegible compared to compilation time
+    hash_gen = hashlib.sha256()
+    text = str(hlo_module)
+    if flags is not None:
+        text += flags.replace(" ", "")
+    hash_gen.update(text.encode("utf-8"))
+    hash = str(hash_gen.hexdigest())[:20]
+    return hash
+
+
+@contextmanager
+def neff_cache(cache_dir: Optional[str] = None):
+    """
+    Context manager to patch `torch_neuronx.xla_impl.trace.generate_neff`.
+
+    This temporarily replaces the original function in the `torch_neuronx.xla_impl.trace` module
+    to use a cache for storing and retrieving compiled NEFF files.
+
+    Usage:
+
+        with neff_cache(cache_dir="/path/to/cache"):
+            # Your code that generates NEFF files goes here
+            # The cache will be used to store and retrieve compiled NEFF files
+            # The original function will be restored after exiting the context
+
+    This function uses the `libneuronxla` library to create a compile cache.
+    Each entry in the cache is identified by a hash of the HLO module and its compilation flags.
+
+    Args:
+        cache_dir (`str`, *optional*):
+            Directory to store the cache. If not provided, a default directory will be used.
+    """
+
+    def generate_neff_with_cache(
+        hlo_artifacts: HloArtifacts,
+        compiler_workdir: Optional[Union[str, pathlib.Path]] = None,
+        compiler_args: Optional[Union[List[str], str]] = None,
+        inline_weights_to_neff: bool = True,
+    ):
+        """
+        Generate a NEFF file from the HLO artifacts using the specified compiler arguments.
+
+        Unlike the original implementation, this function uses a cache to store and retrieve compiled NEFF files.
+        If the weights were not in the optimal layout, the compiler also produces a wrapped neff HLO stub that needs
+        to be cached as well.
+
+        Args:
+            hlo_artifacts (`HloArtifacts`):
+                HLO artifacts containing the HLO module and constant parameter tensors.
+            compiler_workdir (`str`, *optional*):
+                Directory to store the compiler workdir. If not provided, a default directory will be used.
+            compiler_args (`List[str]` or `str`, *optional*):
+                Compiler arguments to be used for compilation. If not provided, a default set of arguments will be used.
+            inline_weights_to_neff (`bool`, *optional*):
+                Whether to inline weights to NEFF. Defaults to `True`.
+        Returns:
+            `NeffArtifacts`:
+                NEFF artifacts containing the path to the compiled NEFF file.
+        """
+        if inline_weights_to_neff:
+            # We don't cache compilation artifacts containing weights
+            return generate_neff(
+                hlo_artifacts,
+                compiler_workdir=compiler_workdir,
+                compiler_args=compiler_args,
+                inline_weights_to_neff=inline_weights_to_neff,
+            )
+
+        # Generate the HLO and other artifacts required for compilation
+        compiler_target = setup_compiler_dirs(
+            hlo_artifacts.hlo_module,
+            compiler_workdir,
+            hlo_artifacts.constant_parameter_tensors,
+            inline_weights_to_neff,
+        )
+
+        # Create compile cache
+        cache_url = CacheUrl.get_cache_url(cache_dir=cache_dir)
+        compile_cache = create_compile_cache(cache_url)
+
+        # The cache key is a hash of the HLO module and the compiler arguments
+        cache_key = get_hash_module(hlo_artifacts.hlo_module, compiler_args)
+
+        # Look in the cache
+        compile_flags_str = json.dumps(compiler_args)
+        entry = compile_cache.lookup(cache_key, compiler_args)
+
+        # The result of the compilation that we need to fetch or produce in the compiler
+        # working directory is composed of the NEFF file and an optional wrapped neff HLO stub
+        neff_filename = os.path.join(compiler_workdir, "graph.neff")
+        wrapped_neff_filename = os.path.join(compiler_workdir, "wrapped_neff.hlo")
+
+        with entry:
+            if entry.exists:
+                # There is an entry in the cache, download it at the expected location
+                entry.download_neff(neff_filename)
+                # If the weights were not in the optimal layout, there might also be a wrapped neff HLO stub
+                entry.download_wrapped_neff(wrapped_neff_filename)
+                logger.info(f"Using a cached neff at {entry.neff_path}")
+                return NeffArtifacts(neff_filename)
+
+        # This graph doesn't have a NEFF in the cache yet, and we're holding the lock for it
+        # First make sure the inputs are in the cache
+        entry.upload_inputs(compiler_target, compile_flags_str)
+
+        # Now compile the graph
+        compiled_neff_filename = hlo_compile(
+            compiler_target, compiler_workdir=compiler_workdir, compiler_args=compiler_args
+        )
+        if compiled_neff_filename != neff_filename:
+            # The compiled NEFF file is not at the expected location, which reveals that the hlo_compile implementation has evolved
+            raise ValueError(
+                "Incompatible torch_neuronx.xla_impl.trace.hlo_compile implementation. Did you update the library ?"
+            )
+
+        # Store the generated artifacts in the cache
+        logger.info(f"Caching neff at {entry.neff_path}")
+        entry.upload_neff(neff_filename)
+        if os.path.exists(wrapped_neff_filename):
+            logger.info(f"Caching wrapped neff HLO stub at {entry.neff_path}")
+            entry.upload_wrapped_neff(wrapped_neff_filename)
+
+        return NeffArtifacts(neff_filename)
+
+    try:
+        patch_everywhere("generate_neff", generate_neff_with_cache, "torch_neuronx.xla_impl.trace")
+        yield
+    finally:
+        patch_everywhere("generate_neff", generate_neff, "torch_neuronx.xla_impl.trace")

--- a/optimum/neuron/models/inference/nxd/backend/cache.py
+++ b/optimum/neuron/models/inference/nxd/backend/cache.py
@@ -22,9 +22,10 @@ import pathlib
 from contextlib import contextmanager
 from typing import List, Optional, Union
 
-from libneuronxla.neuron_cc_cache import CacheUrl, create_compile_cache
+from libneuronxla.neuron_cc_cache import CacheUrl
 from torch_neuronx.xla_impl.trace import HloArtifacts, NeffArtifacts, generate_neff, hlo_compile, setup_compiler_dirs
 
+from .....cache.hub_cache import create_hub_compile_cache_proxy
 from .....utils.patching import patch_everywhere
 
 
@@ -109,9 +110,10 @@ def neff_cache(cache_dir: Optional[str] = None):
             inline_weights_to_neff,
         )
 
-        # Create compile cache
+        # Create a hub compile cache proxying the libneuronxla cache
+        # It will fetch contents from the hub if they are not found in the local cache
         cache_url = CacheUrl.get_cache_url(cache_dir=cache_dir)
-        compile_cache = create_compile_cache(cache_url)
+        compile_cache = create_hub_compile_cache_proxy(cache_url)
 
         # The cache key is a hash of the HLO module and the compiler arguments
         cache_key = get_hash_module(hlo_artifacts.hlo_module, compiler_args)

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/models/config.py
 from typing import List, Optional, Union
 
 import torch
@@ -59,6 +60,8 @@ class NxDNeuronConfig(NeuronConfig):
 
     This class contains attributes that are needed for various inference
     optimization/features in NxD.
+
+    These attributes are a subset of the attributes in the original NxDI config class.
     """
 
     def __init__(

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -1,0 +1,210 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional, Union
+
+import torch
+
+from .....configuration_utils import NeuronConfig, register_neuron_config
+
+
+NEURON_CONFIG_FILE = "neuron_config.json"
+
+
+def to_torch_dtype(dtype_str: str) -> torch.dtype:
+    dtype_mapping = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "fp32": torch.float32,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    assert dtype_str in dtype_mapping, f"Unsupported dtype: {dtype_str}"
+    return dtype_mapping[dtype_str]
+
+
+def to_dict(obj):
+    if type(obj) is dict:
+        return {k: to_dict(v) for k, v in obj.items()}
+    elif type(obj) is list:
+        return [to_dict(v) for v in obj]
+    elif hasattr(obj, "__dict__"):
+        return {k: to_dict(v) for k, v in obj.__dict__.items()}
+    elif type(obj) is torch.dtype:
+        return str(obj).split(".")[1]
+    else:
+        return obj
+
+
+class IncompatibleConfigError(ValueError):
+    pass
+
+
+@register_neuron_config
+class NxDNeuronConfig(NeuronConfig):
+    """
+    Base config class for inference in NxD.
+
+    This class contains attributes that are needed for various inference
+    optimization/features in NxD.
+    """
+
+    def __init__(
+        self,
+        checkpoint_id: str = None,
+        checkpoint_revision: str = None,
+        batch_size: Optional[int] = 1,
+        ctx_batch_size: Optional[int] = None,
+        tkg_batch_size: Optional[int] = None,
+        max_batch_size: Optional[int] = None,
+        is_continuous_batching: Optional[bool] = False,
+        speculation_length: Optional[int] = 0,
+        sequence_length: Optional[int] = 128,
+        tp_degree: Optional[int] = 1,
+        ep_degree: Optional[int] = 1,
+        pp_degree: Optional[int] = 1,
+        torch_dtype: Optional[Union[str, torch.dtype]] = torch.bfloat16,
+        rpl_reduce_dtype: Optional[Union[str, torch.dtype]] = None,
+        n_active_tokens: Optional[int] = None,
+        max_context_length: Optional[int] = None,
+        output_logits: Optional[bool] = False,
+        padding_side: Optional[str] = "right",
+        fused_qkv: Optional[bool] = False,
+        vocab_parallel: Optional[bool] = False,
+        sequence_parallel_enabled: Optional[bool] = False,
+        is_chunked_prefill: Optional[bool] = False,
+        flash_decoding_enabled: Optional[bool] = False,
+        async_mode: Optional[bool] = False,
+        qk_layernorm: Optional[bool] = False,
+        attn_kernel_enabled: Optional[bool] = False,
+        qkv_kernel_enabled: Optional[bool] = False,
+        mlp_kernel_enabled: Optional[bool] = False,
+        mlp_kernel_fuse_residual_add: Optional[bool] = False,
+        enable_bucketing: Optional[bool] = False,
+        target: Optional[str] = None,  # Set to "trn2" for trn2
+        logical_nc_config: Optional[int] = 1,
+        cc_pipeline_tiling_factor: Optional[int] = 2,
+        num_cores_per_group: Optional[int] = 1,
+        on_device_sampling: Optional[bool] = False,
+        max_topk: Optional[int] = 256,
+        start_rank_id: Optional[int] = 0,
+        local_ranks_size: Optional[int] = None,
+        capacity_factor: float = None,
+        glu_mlp: bool = True,
+    ) -> None:
+        # Required to retrieve a checkpoint from the hub
+        self.checkpoint_id = checkpoint_id
+        self.checkpoint_revision = checkpoint_revision
+        # Basic config for inference in NxD
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        self.tp_degree = tp_degree
+        self.torch_dtype = torch_dtype
+        if isinstance(self.torch_dtype, str):
+            self.torch_dtype = to_torch_dtype(self.torch_dtype)
+        self.n_active_tokens = self.sequence_length if n_active_tokens is None else n_active_tokens
+        self.output_logits = output_logits
+
+        self.padding_side = padding_side
+
+        self.rpl_reduce_dtype = torch_dtype if rpl_reduce_dtype is None else rpl_reduce_dtype
+        if isinstance(self.rpl_reduce_dtype, str):
+            self.rpl_reduce_dtype = to_torch_dtype(self.rpl_reduce_dtype)
+
+        # fallback to sequence_length is for compatibility with vllm
+        self.max_context_length = max_context_length
+        if self.max_context_length is None:
+            self.max_context_length = sequence_length
+
+        # Graph transforms
+        self.fused_qkv = fused_qkv
+
+        # Functional parallelism
+        self.vocab_parallel = vocab_parallel
+        self.sequence_parallel_enabled = sequence_parallel_enabled
+        self.is_chunked_prefill = is_chunked_prefill
+
+        # Continuous batching
+        # TODO: Check if we really need different batch size for CTE and TKG, given
+        # that we anyway provide two different config instance for them.
+        self.ctx_batch_size = batch_size if ctx_batch_size is None else ctx_batch_size
+        self.tkg_batch_size = batch_size if tkg_batch_size is None else tkg_batch_size
+        self.max_batch_size = batch_size if max_batch_size is None else max_batch_size
+        self.is_continuous_batching = is_continuous_batching
+
+        # On-device sampling
+        self.on_device_sampling = on_device_sampling
+        self.max_topk = max_topk
+
+        # async
+        self.async_mode = async_mode
+
+        # Bucketing
+        self.enable_bucketing = enable_bucketing
+
+        # Speculative decoding
+        self.speculation_length = speculation_length
+        if self.speculation_length > 0 and self.async_mode:
+            raise IncompatibleConfigError("Speculative Decoding is not yet supported with async.")
+
+        # Distributed config
+        self.pp_degree = pp_degree
+        self.ep_degree = ep_degree
+
+        # QK layer normalization
+        self.qk_layernorm = qk_layernorm
+
+        # Multi-node
+        # TODO: Check if start_rank_id can be modified dynamically at runtime
+        # Otherwise, we need multiple exports for different start_rank_id
+        self.start_rank_id = start_rank_id
+        self.local_ranks_size = local_ranks_size
+        if self.local_ranks_size is None:
+            self.local_ranks_size = self.world_size
+
+        # Flash decoding
+        self.flash_decoding_enabled = flash_decoding_enabled
+        self.num_cores_per_group = num_cores_per_group
+
+        # Kernels
+        self.attn_kernel_enabled = attn_kernel_enabled
+        self.qkv_kernel_enabled = qkv_kernel_enabled
+        self.mlp_kernel_enabled = mlp_kernel_enabled
+        self.mlp_kernel_fuse_residual_add = mlp_kernel_fuse_residual_add
+
+        # compiler flags
+        self.logical_nc_config = logical_nc_config
+        self.cc_pipeline_tiling_factor = cc_pipeline_tiling_factor
+        self.target = target
+
+        # MoE specific
+        self.capacity_factor = float(capacity_factor) if capacity_factor is not None else None
+        self.glu_mlp = glu_mlp
+
+    @property
+    def world_size(self) -> int:
+        """
+        The total number of ranks in the distributed setup.
+        """
+        return self.tp_degree * self.pp_degree * self.ep_degree
+
+    @property
+    def weights_to_skip_layout_optimization(self) -> List[str]:
+        """
+        List of weights to skip layout optimization.
+
+        Can be overridden by subclasses to specify weights that should not be optimized.
+        """
+        return []

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -104,6 +104,21 @@ class NxDNeuronConfig(NeuronConfig):
         capacity_factor: float = None,
         glu_mlp: bool = True,
     ) -> None:
+        # TODO: these flags are suposed to work in NxDI. Either make them work or remove them
+        if is_chunked_prefill:
+            raise ValueError("`is_chunked_prefill` is not supported in optimum-neuron.")
+        if flash_decoding_enabled:
+            raise ValueError("`flash_decoding_enabled` is not supported in optimum-neuron.")
+        if async_mode:
+            raise ValueError("`async_mode` is not supported in optimum-neuron.")
+        if qkv_kernel_enabled or mlp_kernel_enabled:
+            raise ValueError("`qkv_kernel_enabled` and `mlp_kernel_enabled` are not supported for trn1 chips.")
+        if vocab_parallel:
+            raise ValueError("`vocab_parallel` is not supported in optimum-neuron.")
+        if qk_layernorm:
+            raise ValueError(
+                "`qk_layernorm` is not supported in optimum-neuron. It is actually a modeling flag that affects the attention layer."
+            )
         # Required to retrieve a checkpoint from the hub
         self.checkpoint_id = checkpoint_id
         self.checkpoint_revision = checkpoint_revision

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -18,22 +18,10 @@ from typing import List, Optional, Union
 import torch
 
 from .....configuration_utils import NeuronConfig, register_neuron_config
+from .....utils import map_torch_dtype
 
 
 NEURON_CONFIG_FILE = "neuron_config.json"
-
-
-def to_torch_dtype(dtype_str: str) -> torch.dtype:
-    dtype_mapping = {
-        "float32": torch.float32,
-        "float16": torch.float16,
-        "bfloat16": torch.bfloat16,
-        "fp32": torch.float32,
-        "fp16": torch.float16,
-        "bf16": torch.bfloat16,
-    }
-    assert dtype_str in dtype_mapping, f"Unsupported dtype: {dtype_str}"
-    return dtype_mapping[dtype_str]
 
 
 def to_dict(obj):
@@ -131,7 +119,7 @@ class NxDNeuronConfig(NeuronConfig):
         self.tp_degree = tp_degree
         self.torch_dtype = torch_dtype
         if isinstance(self.torch_dtype, str):
-            self.torch_dtype = to_torch_dtype(self.torch_dtype)
+            self.torch_dtype = map_torch_dtype(self.torch_dtype)
         self.n_active_tokens = self.sequence_length if n_active_tokens is None else n_active_tokens
         self.output_logits = output_logits
 
@@ -139,7 +127,7 @@ class NxDNeuronConfig(NeuronConfig):
 
         self.rpl_reduce_dtype = torch_dtype if rpl_reduce_dtype is None else rpl_reduce_dtype
         if isinstance(self.rpl_reduce_dtype, str):
-            self.rpl_reduce_dtype = to_torch_dtype(self.rpl_reduce_dtype)
+            self.rpl_reduce_dtype = map_torch_dtype(self.rpl_reduce_dtype)
 
         # fallback to sequence_length is for compatibility with vllm
         self.max_context_length = max_context_length

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -69,7 +69,7 @@ class NxDNeuronConfig(NeuronConfig):
         ctx_batch_size: Optional[int] = None,
         tkg_batch_size: Optional[int] = None,
         max_batch_size: Optional[int] = None,
-        is_continuous_batching: Optional[bool] = False,
+        continuous_batching: Optional[bool] = False,
         speculation_length: Optional[int] = 0,
         sequence_length: Optional[int] = 128,
         tp_degree: Optional[int] = 1,
@@ -157,7 +157,7 @@ class NxDNeuronConfig(NeuronConfig):
         self.ctx_batch_size = batch_size if ctx_batch_size is None else ctx_batch_size
         self.tkg_batch_size = batch_size if tkg_batch_size is None else tkg_batch_size
         self.max_batch_size = batch_size if max_batch_size is None else max_batch_size
-        self.is_continuous_batching = is_continuous_batching
+        self.continuous_batching = continuous_batching
 
         # On-device sampling
         self.on_device_sampling = on_device_sampling

--- a/optimum/neuron/models/inference/nxd/backend/model_wrapper.py
+++ b/optimum/neuron/models/inference/nxd/backend/model_wrapper.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import abstractmethod
+from typing import List
+
+import torch
+from neuronx_distributed.trace.model_builder import BaseModelInstance
+from torch_neuronx import BucketModelConfig
+
+
+class NxDModelWrapper(torch.nn.Module):
+    def __init__(self, tag: str, priority_model_idx: int):
+        super().__init__()
+        self.tag = tag
+        self.priority_model_idx = priority_model_idx
+
+    @abstractmethod
+    def input_generator(self) -> List[torch.Tensor]:
+        """Return the list of the model input tensors
+
+        Used at compilation time only when tracing the model.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_model_instance(self) -> BaseModelInstance:
+        """Return the underlying ModelInstance
+
+        Used at compilation time only when tracing the model.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_bucket_config(self) -> BucketModelConfig:
+        """Return the bucket configuration
+
+        Used at compilation time only when tracing the model.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def forward(self, *args) -> List[torch.Tensor]:
+        raise NotImplementedError

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/__init__.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/attention_base.py
@@ -1,0 +1,450 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import math
+import warnings
+from enum import Enum
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor, nn
+from torch.distributed import ProcessGroup
+from transformers import PretrainedConfig
+
+from .utils import (
+    apply_rotary_pos_emb,
+    distributed_softmax,
+    manual_softmax,
+    move_heads_front,
+    repeat_kv,
+)
+
+
+# Try except for the compatibility with older compiler version
+try:
+    from neuronxcc.nki._private_kernels.attention import attention_isa_kernel  # noqa: E402
+except ImportError:
+    from neuronxcc.nki.kernels.attention import attention_isa_kernel  # noqa: E402
+
+import neuronx_distributed as nxd
+import torch_xla.core.xla_model as xm
+from neuronx_distributed.parallel_layers import parallel_state, utils  # noqa: E402
+from neuronx_distributed.parallel_layers.layers import SPMDRank
+from neuronx_distributed.parallel_layers.parallel_state import get_kv_shared_group
+from neuronxcc.nki.language import nc
+from torch_neuronx.xla_impl.ops import nki_jit  # noqa: E402
+
+from ...config import NxDNeuronConfig
+from .gqa import GQA, GroupQueryAttention_O, GroupQueryAttention_QKV  # noqa: E402
+
+
+logger = logging.getLogger("Neuron")
+
+_flash_fwd_call = nki_jit()(attention_isa_kernel)
+
+
+class FlashAttentionStrategy(Enum):
+    NONE = 0
+    UNSHARDED_KERNEL = 1
+    SHARDED_KERNEL = 2
+
+
+class NeuronAttentionBase(nn.Module):
+    """
+    This base attention class implements the core Neuron related adaptation including
+    1. replaces the q_proj, k_proj, v_proj with column parallel layer
+    2. replaces the o_proj with row parallel layer
+    3. update self.num_head to be self.num_head / tp_degree
+    4. update self.num_key_value_heads to be self.num_key_value_heads / tp_degree
+    5. update forward() method to adjust to changes from self.num_head
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        neuron_config: NxDNeuronConfig,
+        tensor_model_parallel_group: Optional[ProcessGroup] = None,
+    ):
+        super().__init__()
+
+        if tensor_model_parallel_group is not None:
+            self.tensor_model_parallel_group = tensor_model_parallel_group
+            self.rank_util = SPMDRank(world_size=self.tensor_model_parallel_group.size())
+        elif nxd.parallel_layers.parallel_state.model_parallel_is_initialized():
+            self.tensor_model_parallel_group = nxd.parallel_layers.parallel_state.get_tensor_model_parallel_group()
+            self.rank_util = SPMDRank(world_size=self.tensor_model_parallel_group.size())
+        else:
+            # CPU flow doesn't need rank_util and TP group now
+            self.tensor_model_parallel_group = None
+            self.rank_util = None
+
+        self.is_causal = True
+        self.hidden_size = config.hidden_size
+        self.num_attention_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.head_dim = self.hidden_size // self.num_attention_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.padding_side = neuron_config.padding_side
+        self.torch_dtype = neuron_config.torch_dtype
+        self.qk_layernorm = neuron_config.qk_layernorm
+        self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
+        self.num_cores_per_group = neuron_config.num_cores_per_group
+        self.bias = getattr(config, "attention_bias", False)
+        self.rpl_reduce_dtype = neuron_config.rpl_reduce_dtype
+        self.mlp_kernel_enabled = neuron_config.mlp_kernel_enabled
+        self.rms_norm_eps = config.rms_norm_eps
+
+        if parallel_state.model_parallel_is_initialized():
+            self.tp_degree = neuron_config.tp_degree
+        else:
+            self.tp_degree = 1
+        self.fused_qkv = neuron_config.fused_qkv
+        self.clip_qkv = None
+
+        self.o_proj_layer_name = "o_proj"
+
+        if (self.head_dim * self.num_attention_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_attention_heads})."
+            )
+
+        self.sequence_parallel_enabled = neuron_config.sequence_parallel_enabled
+        self.sequence_dimension = 1 if self.sequence_parallel_enabled else None
+        self.qkv_proj = GroupQueryAttention_QKV(
+            hidden_size=self.hidden_size,
+            head_dim=self.head_dim,
+            num_attention_heads=self.num_attention_heads,
+            num_key_value_heads=self.num_key_value_heads,
+            tp_degree=self.tp_degree,
+            dtype=self.torch_dtype,
+            bias=self.bias,
+            gather_output=False,
+            fused_qkv=self.fused_qkv,
+            clip_qkv=self.clip_qkv,
+            sequence_parallel_enabled=self.sequence_parallel_enabled,
+            sequence_dimension=self.sequence_dimension,
+            tensor_model_parallel_group=self.tensor_model_parallel_group,
+            rms_norm_eps=self.rms_norm_eps,
+            qkv_kernel_enabled=neuron_config.qkv_kernel_enabled,
+            logical_nc_config=neuron_config.logical_nc_config,
+        )
+        self.o_proj = GroupQueryAttention_O(
+            hidden_size=self.hidden_size,
+            head_dim=self.head_dim,
+            num_attention_heads=self.num_attention_heads,
+            num_key_value_heads=self.num_key_value_heads,
+            tp_degree=self.tp_degree,
+            dtype=self.torch_dtype,
+            bias=self.bias,
+            input_is_parallel=True,
+            layer_name=self.o_proj_layer_name,
+            sequence_parallel_enabled=self.sequence_parallel_enabled,
+            sequence_dimension=self.sequence_dimension,
+            tensor_model_parallel_group=self.tensor_model_parallel_group,
+            rpl_reduce_dtype=self.rpl_reduce_dtype,
+        )
+        self.num_heads = utils.divide(self.qkv_proj.get_num_attention_heads(), self.tp_degree)
+        self.num_key_value_heads = utils.divide(self.qkv_proj.get_num_key_value_heads(), self.tp_degree)
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.q_layernorm = nn.LayerNorm(self.head_dim) if self.qk_layernorm else None
+        self.k_layernorm = nn.LayerNorm(self.head_dim) if self.qk_layernorm else None
+        self.attn_kernel_enabled = neuron_config.attn_kernel_enabled
+        self.logical_nc_config = neuron_config.logical_nc_config
+
+    def scaled_qk(self, Q, K, attention_mask):
+        QK = torch.matmul(Q, K.transpose(2, 3)) / math.sqrt(self.head_dim)
+        QK = torch.where(attention_mask, QK, torch.finfo(QK.dtype).min)
+        return QK
+
+    def prep_qkv_tensors(
+        self,
+        position_ids,
+        hidden_states,
+        past_key_value,
+        cos_cache=None,
+        sin_cache=None,
+        rmsnorm=None,
+    ):
+        """take care of the shape, layout, group query, custom position encoding, etc."""
+        Q, K, V = self.qkv_proj(hidden_states=hidden_states, rmsnorm=rmsnorm)
+
+        # Divide hidden_dim across heads for MHA
+        # Change layout: BSHD -> BHSD
+        bsz, q_len, _ = hidden_states.size()
+        if self.sequence_parallel_enabled:
+            q_len *= self.tensor_model_parallel_group.size()
+
+        Q = move_heads_front(Q, bsz, q_len, self.num_heads, self.head_dim, layernorm=self.q_layernorm)
+        K = move_heads_front(K, bsz, q_len, self.num_key_value_heads, self.head_dim, layernorm=self.k_layernorm)
+        V = move_heads_front(V, bsz, q_len, self.num_key_value_heads, self.head_dim, layernorm=None)
+
+        # Rotate Q and K
+        if self.rotary_emb is not None:
+            if cos_cache is None or sin_cache is None:
+                cos_cache, sin_cache = self.rotary_emb(V, position_ids)
+
+            Q, K = apply_rotary_pos_emb(Q, K, cos_cache, sin_cache)
+
+        return Q, K, V, cos_cache, sin_cache
+
+    def perform_prefill(self, Q, K, V, q_len, bsz, attention_mask) -> Tensor:
+        """attention computation at prefilling (context encoding) phase"""
+        K_active = repeat_kv(K, self.num_key_value_groups)
+        V_active = repeat_kv(V, self.num_key_value_groups)
+
+        flash_attn_strategy = self.get_flash_attention_strategy(q_len)
+        logger.debug(f"Flash attention strategy: {flash_attn_strategy}")
+
+        if flash_attn_strategy != FlashAttentionStrategy.NONE:
+            logger.debug(f"ATTN kernel: logical_nc_config={self.logical_nc_config}")
+            # if we are using left padding, then the bzs needs be 1 (otherwise we get wrong result
+            # because flash attention does not use attention_mask). In practice, we use right
+            # padding so this is unlikely to cause issues
+            assert self.padding_side == "right" or bsz == 1
+
+            # original shape of q, k, v is BHSD, and expected output is also BHSD.
+            logger.debug(f"Using flash_fwd for Q.shape={Q.shape}")
+            # make sure to cast inputs to torch_dtype (this is needed because the downcast to bf16
+            # might happen after the kernel hlo creation step). Also convert shapes as expected by the kernel.
+
+            # original Q shape: batch, num_heads, seqlen, d_head
+            Q = (
+                Q.permute(0, 1, 3, 2)  # after permute: batch, num_heads, d_head, seqlen
+                .reshape((bsz * self.num_heads, self.head_dim, q_len))
+                .to(self.torch_dtype)
+            )
+            Q = Q / math.sqrt(self.head_dim)
+            K_active = (
+                K_active.permute(0, 1, 3, 2).reshape((bsz * self.num_heads, self.head_dim, q_len)).to(self.torch_dtype)
+            )
+            V_active = V_active.reshape((bsz * self.num_heads, q_len, self.head_dim)).to(self.torch_dtype)
+            # shape: (B*H)DS
+            attn_output = torch.zeros(bsz * self.num_heads, self.head_dim, q_len, dtype=Q.dtype, device=Q.device)
+
+            logger.debug("Input parameter shapes")
+            logger.debug(f"Q input shape {Q.shape}")
+            logger.debug(f"K input shape {K_active.shape}")
+            logger.debug(f"V input shape {V_active.shape}")
+            logger.debug(f"Attn output shape {attn_output.shape}")
+
+            if flash_attn_strategy == FlashAttentionStrategy.SHARDED_KERNEL:
+                grid = (nc(self.logical_nc_config),)
+
+                _flash_fwd_call[grid](
+                    Q,
+                    K_active,
+                    V_active,
+                    1.0,
+                    attn_output,
+                    kernel_name="CausalAttentionMMSoftmaxMMWithoutSwap",
+                )
+            elif flash_attn_strategy == FlashAttentionStrategy.UNSHARDED_KERNEL:
+                _flash_fwd_call(
+                    Q,
+                    K_active,
+                    V_active,
+                    1.0,
+                    attn_output,
+                    kernel_name="CausalAttentionMMSoftmaxMMWithoutSwap",
+                )
+            else:
+                raise ValueError(f"Invalid flash attention strategy: {flash_attn_strategy}")
+
+            # shape: BHDS
+            attn_output = attn_output.reshape((bsz, self.num_heads, self.head_dim, q_len))
+            logger.debug(f"Attn output after reshape {attn_output.shape}")
+        else:
+            logger.debug("ATTN: native compiler")
+            logger.debug(f"Not using flash_fwd for Q.shape={Q.shape}")
+            active_scores = self.scaled_qk(Q, K_active, attention_mask)
+            active_scores = nn.functional.softmax(active_scores, dim=-1, dtype=torch.float32).to(Q.dtype)
+            attn_output = torch.matmul(active_scores, V_active)
+        return attn_output, flash_attn_strategy
+
+    def get_flash_attention_strategy(self, q_len) -> FlashAttentionStrategy:
+        """
+        Gets the flash attention strategy.
+
+        For LNC1, use the unsharded kernel if sequence length is at least 4096 to get the best performance.
+        The unsharded kernel requires a sequence length of at least 512.
+
+        For LNC2, use the sharded kernel if sequence length is divisible by 1024. Otherwise, use no
+        kernel, because the unsharded kernel has worse performance than no kernel.
+        The sharded kernel requires a sequence length of at least 1024.
+
+        These constraints may change later.
+
+        TODO: Throw an exception instead of disabling flash attention if explicitly enabled but not eligible.
+              This must consider bucketing to avoid throwing an exception for smaller buckets.
+        """
+        if int(self.logical_nc_config) > 1:
+            if q_len < 1024:
+                return FlashAttentionStrategy.NONE
+
+            if q_len % 1024 == 0:
+                return FlashAttentionStrategy.SHARDED_KERNEL
+            else:
+                warnings.warn("Flash attention disabled. LNC2 requires seq_len % 1024 for flash attn to be performant")
+                return FlashAttentionStrategy.NONE
+
+        # If seq_len is at least 4096, enable flash attn automatically to improve performance.
+        if q_len >= 4096:
+            return FlashAttentionStrategy.UNSHARDED_KERNEL
+
+        # At lower seq lens, enable only if explicitly enabled.
+        if self.attn_kernel_enabled and q_len >= 512:
+            return FlashAttentionStrategy.UNSHARDED_KERNEL
+
+        return FlashAttentionStrategy.NONE
+
+    def compute_for_flash_decoding(self, Q, K, V, past_key_value, attention_mask, active_mask) -> Tensor:
+        # TODO: refactor/decompose this to reduce duplication with compute_for_token_gen
+        # active attention
+        n_repeat = Q.shape[1]
+        K_active = repeat_kv(K, n_repeat)
+        V_active = repeat_kv(V, n_repeat)
+        active_scores = (torch.matmul(Q, K_active.transpose(2, 3)) / math.sqrt(self.head_dim)).to(torch.float32)
+        active_scores = torch.where(active_mask, active_scores, torch.finfo(active_scores.dtype).min)
+
+        # prior attention
+        K_prior = repeat_kv(past_key_value[0], n_repeat)
+        V_prior = repeat_kv(past_key_value[1], n_repeat)
+        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) / math.sqrt(self.head_dim)
+        prior_scores = torch.where(attention_mask, prior_scores, torch.finfo(prior_scores.dtype).min)
+        prior_scores = prior_scores.to(torch.float32)
+
+        # attention scores
+        softmax_prior, softmax_active = distributed_softmax(prior_scores, active_scores)
+        softmax_prior, softmax_active = softmax_prior.to(Q.dtype), softmax_active.to(Q.dtype)
+        attn_prior = torch.matmul(softmax_prior, V_prior)
+        attn_active = torch.matmul(softmax_active, V_active)
+        attn_output = attn_prior + attn_active
+
+        return attn_output
+
+    def compute_for_token_gen(self, Q, K, V, position_ids, past_key_value, attention_mask, active_mask) -> Tensor:
+        """attention computation at token generation phase"""
+        is_speculation = position_ids.shape[-1] > 1
+
+        # Attention computation: softmax((Q.K/√dkv) + mask).V
+        # i. prior (cached) KV
+        K_prior = past_key_value[0]
+        V_prior = past_key_value[1]
+        K_prior = repeat_kv(K_prior, self.num_key_value_groups)
+        V_prior = repeat_kv(V_prior, self.num_key_value_groups)
+        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) / math.sqrt(self.head_dim)
+        prior_scores = torch.where(attention_mask, prior_scores, torch.finfo(prior_scores.dtype).min)
+        prior_scores = prior_scores.to(torch.float32)
+
+        # ii. active (current/new) KV
+        K_active = repeat_kv(K, self.num_key_value_groups)
+        V_active = repeat_kv(V, self.num_key_value_groups)
+        active_scores = torch.matmul(Q, K_active.transpose(2, 3)) / math.sqrt(self.head_dim)
+        if is_speculation:
+            active_scores = torch.where(active_mask, active_scores, torch.finfo(active_scores.dtype).min)
+        active_scores = active_scores.to(torch.float32)
+
+        # iii. attention scores
+        softmax_prior, softmax_active = manual_softmax(prior_scores, active_scores, is_speculation)
+        softmax_prior, softmax_active = softmax_prior.to(Q.dtype), softmax_active.to(Q.dtype)
+        attn_prior = torch.matmul(softmax_prior, V_prior)
+        attn_active = torch.matmul(softmax_active, V_active)
+        attn_output = attn_prior + attn_active
+
+        return attn_output
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        active_mask: Optional[torch.LongTensor] = None,
+        cos_cache: Optional[torch.Tensor] = None,
+        sin_cache: Optional[torch.Tensor] = None,
+        rmsnorm=None,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+        """Implements each layer's forward pass for the attention block."""
+        bsz, q_len, _ = hidden_states.size()
+        if self.sequence_parallel_enabled:
+            q_len *= self.tensor_model_parallel_group.size()
+
+        Q, K, V, cos_cache, sin_cache = self.prep_qkv_tensors(
+            position_ids,
+            hidden_states,
+            past_key_value,
+            cos_cache=cos_cache,
+            sin_cache=sin_cache,
+            rmsnorm=rmsnorm,
+        )
+
+        flash_attn_strategy = FlashAttentionStrategy.NONE
+        if past_key_value is None:
+            attn_output, flash_attn_strategy = self.perform_prefill(Q, K, V, q_len, bsz, attention_mask)
+            if self.flash_decoding_enabled:
+                assert self.qkv_proj.sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE, (
+                    "Flash decoding lives in the context of GQA (grouped query attention) and traditional MHA "
+                    "multi-head attention) won't work!"
+                )
+                rank_id = self.rank_util.get_rank()
+                rank_id_in_kv_group = torch.remainder(rank_id, self.num_cores_per_group).to(torch.int64)
+                # shard KV by seq len and pick the values based on rank
+                assert q_len == Q.shape[2], f"Q shape is {Q.shape}"
+                # selecting positions (on S dim) that belongs to the current rank
+                offset = torch.arange(0, q_len, self.num_cores_per_group, dtype=torch.int64, device=Q.device)
+                selected_seq_pos = offset + rank_id_in_kv_group
+                K = torch.index_select(input=K, dim=2, index=selected_seq_pos)
+                V = torch.index_select(input=V, dim=2, index=selected_seq_pos)
+        else:
+            if self.flash_decoding_enabled:
+                assert active_mask is not None, "Flash decoding requires active mask is not None!"
+                # gather Q from all cores in its KV group
+                groups = get_kv_shared_group(as_list=True)
+                Q = xm.all_gather(Q, dim=1, groups=groups, pin_layout=False)
+
+                attn_output = self.compute_for_flash_decoding(Q, K, V, past_key_value, attention_mask, active_mask)
+                attn_output = xm.reduce_scatter(
+                    xm.REDUCE_SUM,
+                    attn_output,
+                    scale=1,
+                    scatter_dim=1,
+                    shard_count=len(groups[0]),
+                    groups=groups,
+                    pin_layout=False,
+                )
+            else:
+                attn_output = self.compute_for_token_gen(
+                    Q, K, V, position_ids, past_key_value, attention_mask, active_mask
+                )
+
+        if flash_attn_strategy != FlashAttentionStrategy.NONE:
+            # transpose BHDS -> BSHD
+            # this layout avoids additional transposes between attention kernel and output projection
+            attn_output = attn_output.permute(0, 3, 1, 2)
+        else:
+            # transpose BHSD -> BSHD
+            attn_output = attn_output.transpose(1, 2).contiguous()
+
+        # merge multi head hidden
+        attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.head_dim)
+
+        # Z = Z.Wo
+        attn_output = self.o_proj(attn_output)
+
+        past_key_value: Tuple[Tensor, Tensor] = (K, V)
+
+        return attn_output, past_key_value, cos_cache, sin_cache

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/attention_base.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/attention/attention_base.py
 import logging
 import math
 import warnings

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/gqa.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/gqa.py
@@ -1,0 +1,803 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import enum
+import logging
+from typing import Optional, Tuple
+
+import torch
+from neuronx_distributed.parallel_layers import parallel_state
+from neuronx_distributed.parallel_layers.layers import ColumnParallelLinear, RowParallelLinear
+from neuronx_distributed.parallel_layers.mappings import gather_from_sequence_parallel_region
+from neuronx_distributed.parallel_layers.pad import get_number_of_extra_heads
+from neuronxcc.nki._private_kernels.qkv import rmsnorm_qkv_isa_kernel
+from neuronxcc.nki.language import nc
+from torch import nn
+from torch.distributed import ProcessGroup
+from torch.nn import functional as F
+from torch_neuronx.xla_impl.ops import nki_jit  # noqa: E402
+
+from .utils import transpose_parallel_linear_layer
+
+
+logger = logging.getLogger("Neuron")
+
+_traced_qkv_kernel = nki_jit()(rmsnorm_qkv_isa_kernel)
+
+
+class GQA(enum.Enum):
+    # This transforms a GQA attention mechanism into a traditional MHA mechanism
+    # by replicating the K/V heads to evenly match the corresponding Q heads.
+    # This consumes more memory than would otherwise be used with other sharding
+    # mechanisms but works in all cases.
+    # Example:
+    # tp_degree = 32
+    # num_attention_heads: 56 -> 64
+    # num_kev_value_heads: 8  -> 64
+    # | K1 K1 | K2 K2 | ... | K7 K7| Pad Pad | ... | Pad Pad |
+    # | Q1 Q2 | Q3 Q4 | ... | Q55 Q56 | Pad Pad | ... | Pad Pad |
+    CONVERT_TO_MHA = "convert-to-mha"
+
+    # This transforms a GQA attention mechanism such that there is exactly
+    # one K/V head per tp_degree through replication e.g. 8 K/V heads with
+    # tp_degree=32 results in 32 K/V heads. This is more memory efficient but
+    # does not work for all configurations. Q heads are padded interleaved
+    # to retain correct alignment between Q and K/V heads.
+    # Example:
+    # tp_degree = 32
+    # num_attention_heads: 56 -> 64
+    # num_kev_value_heads: 8  -> 32
+    # | K1    | K1    | K1    | K1     | K2    | ...
+    # | Q1 Q2 | Q3 Q4 | Q5 Q6 | Q7 Pad | Q8 Q9 | ...
+    REPLICATE_TO_TP_DEGREE = "replicate-to-tp-degree"
+
+
+def determine_sharding_strategy(
+    tp_degree: int, source_key_value_heads: int, desired_sharding_strategy: Optional[GQA] = None
+) -> GQA:
+    sharding_strategy = desired_sharding_strategy if desired_sharding_strategy else GQA.REPLICATE_TO_TP_DEGREE
+
+    if sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE and (tp_degree % source_key_value_heads != 0):
+        sharding_strategy = GQA.CONVERT_TO_MHA
+
+    return sharding_strategy
+
+
+def get_shardable_head_counts(
+    tp_degree: int, num_attention_heads: int, num_key_value_heads: int, sharding_strategy: GQA
+) -> Tuple[int, int]:
+    # Pad attention heads
+    updated_num_attention_heads = num_attention_heads + get_number_of_extra_heads(num_attention_heads, tp_degree)
+
+    # Replicate and pad K/V heads
+    updated_num_key_value_heads = num_key_value_heads
+    if num_attention_heads == num_key_value_heads:  # MHA
+        updated_num_key_value_heads = updated_num_attention_heads
+    else:  # GQA / MQA
+        if (num_key_value_heads < tp_degree) or (num_key_value_heads % tp_degree != 0):
+            if sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE:
+                assert tp_degree % num_key_value_heads == 0, (
+                    "GQA.REPLICATE_TO_TP_DEGREE requires tp_degree to be divisible by num_key_value_heads"
+                )
+                updated_num_key_value_heads = tp_degree
+            elif sharding_strategy == GQA.CONVERT_TO_MHA:
+                updated_num_key_value_heads = updated_num_attention_heads
+
+    return updated_num_attention_heads, updated_num_key_value_heads
+
+
+def maybe_pad_interleaved(tensor, pad_dim: int, source_heads: int, target_heads: int, source_group_size: int):
+    if tensor is None:
+        return tensor
+
+    # Why we convert FP8 tensor to bfloat16?
+    # Torch does not support torch.cat, or torch.zeros (for large dimensions) for f8e4m3/f8e5m2
+    # So we cast it to bfloat16, perform padding, and then recast back to f8e4m3/f8e5m2
+    recast_dtype = None
+    if tensor.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
+        recast_dtype = tensor.dtype
+        tensor = tensor.to(torch.bfloat16)
+
+    shape = (
+        tensor.shape[:pad_dim] + (source_heads, tensor.shape[pad_dim] // source_heads) + tensor.shape[pad_dim + 1 :]
+    )
+    tensor = tensor.view(shape)
+
+    splits = torch.split(tensor, source_group_size, dim=pad_dim)
+
+    pad_size = list(splits[0].size())
+    pad_size[pad_dim] = (target_heads - source_heads) // (source_heads // source_group_size)
+    pads = [torch.zeros(pad_size, dtype=tensor.dtype)] * len(splits)
+
+    interleaved = [t for pair in zip(splits, pads) for t in pair]
+    tensor = torch.cat(interleaved, dim=pad_dim)
+
+    shape = tensor.shape[:pad_dim] + (tensor.shape[pad_dim] * tensor.shape[pad_dim + 1],) + tensor.shape[pad_dim + 2 :]
+
+    if recast_dtype is not None:
+        tensor = tensor.to(recast_dtype)
+
+    return tensor.view(shape)
+
+
+def maybe_pad_tail(tensor, source_heads: int, target_heads: int, pad_dim: int):
+    if tensor is None:
+        return tensor
+    size_to_pad = int((tensor.shape[pad_dim] // source_heads) * target_heads - tensor.shape[pad_dim])
+
+    dims_after_pad_dim = len(tensor.size()) - pad_dim
+    pad_length = dims_after_pad_dim * 2
+    pad = (0,) * (pad_length - 1) + (size_to_pad,)
+
+    return F.pad(tensor, pad)
+
+
+def replicate_kv(tensor, source_heads: int, repeats: int, head_dim=0):
+    if tensor is None:
+        return tensor
+    shape = (
+        tensor.shape[:head_dim] + (source_heads, tensor.shape[head_dim] // source_heads) + tensor.shape[head_dim + 1 :]
+    )
+    tensor = tensor.view(shape)
+    tensor = torch.repeat_interleave(tensor, repeats=repeats, dim=head_dim)
+    shape = (
+        tensor.shape[:head_dim] + (tensor.shape[head_dim] * tensor.shape[head_dim + 1],) + tensor.shape[head_dim + 2 :]
+    )
+    return tensor.view(shape)
+
+
+class BaseGroupQueryAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        tp_degree: int = 1,
+        dtype: torch.dtype = torch.float32,
+        bias: bool = False,
+        desired_sharding_strategy: Optional[GQA] = None,
+        tensor_model_parallel_group: Optional[ProcessGroup] = None,
+    ):
+        super().__init__()
+
+        if tensor_model_parallel_group is not None:
+            self.tensor_model_parallel_group = tensor_model_parallel_group
+        elif parallel_state.model_parallel_is_initialized():
+            self.tensor_model_parallel_group = parallel_state.get_tensor_model_parallel_group()
+        else:
+            self.tensor_model_parallel_group = None
+
+        if tensor_model_parallel_group:
+            if tp_degree == 1:
+                # update default value
+                tp_degree = tensor_model_parallel_group.size()
+            else:
+                assert tp_degree == self.tensor_model_parallel_group.size(), (
+                    f"TP Degree {tp_degree} and tensor model parallel group size {self.tensor_model_parallel_group.size()} does not match"
+                )
+
+        self.hidden_size = hidden_size
+        self.tp_degree = tp_degree
+        self.head_dim = head_dim
+        self.dtype = dtype
+        self.bias = bias
+        self._src_num_attention_heads = num_attention_heads
+        self._src_num_key_value_heads = num_key_value_heads
+
+        self.sharding_strategy = determine_sharding_strategy(
+            tp_degree,
+            self._src_num_key_value_heads,
+            desired_sharding_strategy=desired_sharding_strategy,
+        )
+        self.num_attention_heads, self.num_key_value_heads = get_shardable_head_counts(
+            tp_degree,
+            self._src_num_attention_heads,
+            self._src_num_key_value_heads,
+            self.sharding_strategy,
+        )
+
+    def get_sharding_strategy(self) -> GQA:
+        return self.sharding_strategy
+
+    def get_num_attention_heads(self) -> int:
+        return self.num_attention_heads
+
+    def get_num_key_value_heads(self) -> int:
+        return self.num_key_value_heads
+
+    def preshard_hook(self, model_state_dict: dict, prefix: str) -> bool:
+        raise NotImplementedError
+
+    def replace_prefixes(self, old_prefix, new_prefix, model_state_dict):
+        old_keys = []
+        new_keys = []
+        for key in model_state_dict.keys():
+            if old_prefix in key:
+                new_key = key.replace(old_prefix, new_prefix)
+                new_keys.append(new_key)
+                old_keys.append(key)
+
+        for key_index in range(len(old_keys)):
+            model_state_dict[new_keys[key_index]] = model_state_dict.pop(old_keys[key_index])
+
+
+class GroupQueryAttention_QKV(BaseGroupQueryAttention):
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        tp_degree: int = 1,
+        dtype: torch.dtype = torch.float32,
+        bias: bool = False,
+        desired_sharding_strategy: Optional[GQA] = None,
+        gather_output: bool = True,
+        fused_qkv: bool = False,
+        clip_qkv: Optional[float] = None,
+        sequence_parallel_enabled: bool = False,
+        sequence_dimension: Optional[int] = None,
+        tensor_model_parallel_group: Optional[ProcessGroup] = None,
+        rms_norm_eps: float = None,
+        qkv_kernel_enabled: bool = False,
+        logical_nc_config: int = 1,
+    ):
+        super().__init__(
+            hidden_size=hidden_size,
+            head_dim=head_dim,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            tp_degree=tp_degree,
+            dtype=dtype,
+            bias=bias,
+            desired_sharding_strategy=desired_sharding_strategy,
+            tensor_model_parallel_group=tensor_model_parallel_group,
+        )
+        if fused_qkv and gather_output:
+            raise ValueError(
+                "Gathering states followed by fused qkv is not allowed as it has a different weight sharding scheme."
+            )
+
+        self.gather_output = gather_output
+        self.fused_qkv = fused_qkv
+        self.clip_qkv = clip_qkv
+
+        self.sequence_parallel_enabled = sequence_parallel_enabled
+        self.sequence_dimension = sequence_dimension
+        self.rms_norm_eps = rms_norm_eps
+        self.qkv_kernel_enabled = qkv_kernel_enabled
+        self.logical_nc_config = logical_nc_config
+
+        if self.tensor_model_parallel_group is not None:
+            if self.fused_qkv:
+                self.Wqkv = ColumnParallelLinear(
+                    self.hidden_size,
+                    (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim,
+                    bias=self.bias,
+                    gather_output=self.gather_output,
+                    dtype=dtype,
+                    tensor_model_parallel_group=self.tensor_model_parallel_group,
+                )
+                if self.qkv_kernel_enabled:
+                    # we need to transpose the weights on the CPU side to avoid
+                    # needing to transpose on the device when using QKV kernel
+                    self.Wqkv.weight = transpose_parallel_linear_layer(self.Wqkv.weight)
+
+                # Set heads info as weight parameter attributes to be used in weights sharding
+                setattr(self.Wqkv.weight, "fused_qkv", True)
+                setattr(self.Wqkv.weight, "num_attention_heads", self.num_attention_heads)
+                setattr(self.Wqkv.weight, "num_key_value_heads", self.num_key_value_heads)
+                setattr(self.Wqkv.weight, "head_dim", self.head_dim)
+
+            else:
+                self.q_proj = ColumnParallelLinear(
+                    self.hidden_size,
+                    self.num_attention_heads * self.head_dim,
+                    bias=self.bias,
+                    gather_output=self.gather_output,
+                    dtype=dtype,
+                    sequence_parallel_enabled=False,
+                    tensor_model_parallel_group=self.tensor_model_parallel_group,
+                )
+                self.k_proj = ColumnParallelLinear(
+                    self.hidden_size,
+                    self.num_key_value_heads * self.head_dim,
+                    bias=self.bias,
+                    gather_output=self.gather_output,
+                    dtype=dtype,
+                    sequence_parallel_enabled=False,
+                    tensor_model_parallel_group=self.tensor_model_parallel_group,
+                )
+                self.v_proj = ColumnParallelLinear(
+                    self.hidden_size,
+                    self.num_key_value_heads * self.head_dim,
+                    bias=self.bias,
+                    gather_output=self.gather_output,
+                    dtype=dtype,
+                    sequence_parallel_enabled=False,
+                    tensor_model_parallel_group=self.tensor_model_parallel_group,
+                )
+        else:
+            if self.fused_qkv:
+                self.Wqkv = nn.Linear(
+                    self.hidden_size,
+                    (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim,
+                    bias=self.bias,
+                )
+            else:
+                self.q_proj = nn.Linear(self.hidden_size, self.num_attention_heads * self.head_dim, bias=self.bias)
+                self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=self.bias)
+                self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=self.bias)
+
+    def forward(self, hidden_states: torch.Tensor, rmsnorm=None):
+        if self.sequence_parallel_enabled and self.tensor_model_parallel_group is not None:
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                self.sequence_dimension,
+                process_group=self.tensor_model_parallel_group,
+            )
+
+        if self.qkv_kernel_enabled:
+            assert self.fused_qkv, "QKV kernel only supported when fused_qkv is TRUE"
+            fused_rmsnorm = not self.sequence_parallel_enabled
+            return self._kernel_qkv_forward(hidden_states, fused_rmsnorm, rmsnorm)
+        else:
+            return self._native_qkv_forward(hidden_states)
+
+    def _native_qkv_forward(self, hidden_states: torch.Tensor):
+        if self.fused_qkv:
+            logger.debug("QKV: native compiler")
+            QKV = self.Wqkv(hidden_states)
+            return self._split_fused_qkv(QKV)
+        else:
+            Q = self.q_proj(hidden_states)
+            K = self.k_proj(hidden_states)
+            V = self.v_proj(hidden_states)
+            if self.clip_qkv is not None:
+                Q = Q.clamp(min=-self.clip_qkv, max=self.clip_qkv)
+                K = K.clamp(min=-self.clip_qkv, max=self.clip_qkv)
+                V = V.clamp(min=-self.clip_qkv, max=self.clip_qkv)
+            return Q, K, V
+
+    def _split_fused_qkv(self, QKV):
+        logger.debug(f"Fused QKV tensor has shape {QKV.shape}")
+        if self.clip_qkv is not None:
+            QKV = QKV.clamp(min=-self.clip_qkv, max=self.clip_qkv)
+
+        # shape of QKV is [batch, seqlen, fused_qkv_size]
+        # we split the fused QKV (dim=2) into Q, K, V
+        # for example:
+        #   for 405B, TP=128, num_att_heads=128
+        #   LNC=2/TP=64 will split QKV from [batch, seqlen, 512] into:
+        #   Q [batch, seqlen, 256]
+        #   K [batch, seqlen, 128]
+        #   V [batch, seqlen, 128]
+        # torch.split has accuracy issue and leads to more reshapes in hlo.
+        # Using torch.tensor_split here. NAPP-3145
+        q_end_index = self.num_attention_heads * self.head_dim // self.tp_degree
+        k_end_index = q_end_index + self.num_key_value_heads * self.head_dim // self.tp_degree
+        Q, K, V = torch.tensor_split(
+            QKV,
+            (
+                q_end_index,
+                k_end_index,
+                # rest of the QKV will go to V output
+            ),
+            dim=2,
+        )
+        logger.debug(f"QKV shape before tensor_split: {QKV.shape}")
+        logger.debug(f"Q shape after tensor_split: {Q.shape}")
+        logger.debug(f"K shape after tensor_split: {K.shape}")
+        logger.debug(f"V shape after tensor_split: {V.shape}")
+        return Q, K, V
+
+    def _kernel_qkv_forward(self, hidden_states, fused_rmsnorm, rmsnorm):
+        logger.debug(f"QKV kernel: fused_rmsnorm={fused_rmsnorm} logical_nc_config={self.logical_nc_config}")
+        bs, seqlen, h = hidden_states.shape
+
+        h2, fused_qkv_size = self.Wqkv.weight.shape
+        logger.debug(f"fused QKV projection weight - shape: {self.Wqkv.weight.shape}, dtype: {self.Wqkv.weight.dtype}")
+
+        # shape checks
+        assert (
+            fused_qkv_size
+            == (self.num_attention_heads + 2 * self.num_key_value_heads) * self.head_dim // self.tp_degree
+        )
+        assert h == h2
+
+        QKV = torch.zeros(
+            bs,
+            seqlen,
+            fused_qkv_size,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        grid = (nc(self.logical_nc_config),)
+
+        # the QKV kernel will automatically switch to the TKG QKV if seqlen==1
+        _traced_qkv_kernel[grid](
+            hidden_states,
+            self.Wqkv.weight,
+            # unsqueeze so that shape of RMS gamma weight is [1, hidden] instead of [hidden]
+            # should be fine to pass this is as a dummy even if not using fused rmsnorm
+            rmsnorm.weight.unsqueeze(0) if rmsnorm else torch.ones((1, h), device=hidden_states.device),
+            QKV,
+            eps=self.rms_norm_eps,
+            kernel_name="QKV",
+            # Run RMSNorm inside the kernel if NOT using SP norm
+            fused_rmsnorm=(fused_rmsnorm and rmsnorm is not None),
+        )
+        return self._split_fused_qkv(QKV)
+
+    def get_weight(
+        self, prefix: str, layer: torch.nn.Module, layer_name, model_state_dict: dict
+    ) -> Tuple[torch.Tensor]:
+        if hasattr(layer, "get_weight_from_state_dict"):
+            return layer.get_weight_from_state_dict(prefix=f"{prefix}.{layer_name}.", state_dict=model_state_dict)
+        return model_state_dict[f"{prefix}.{layer_name}.weight"]
+
+    def get_bias(
+        self, prefix: str, layer: torch.nn.Module, layer_name: str, model_state_dict: dict
+    ) -> Tuple[torch.Tensor]:
+        if hasattr(layer, "get_bias_from_state_dict"):
+            return layer.get_bias_from_state_dict(prefix=f"{prefix}.{layer_name}.", state_dict=model_state_dict)
+        return model_state_dict.get(f"{prefix}.{layer_name}.bias")
+
+    def set_weight(
+        self,
+        tensor: torch.Tensor,
+        prefix: str,
+        layer: torch.nn.Module,
+        layer_name,
+        model_state_dict: dict,
+    ) -> Tuple[torch.Tensor]:
+        # TODO: set weight to state dict support is pending.
+        model_state_dict[f"{prefix}.{layer_name}.weight"] = tensor
+
+    def set_bias(
+        self,
+        tensor: torch.Tensor,
+        prefix: str,
+        layer: torch.nn.Module,
+        layer_name: str,
+        model_state_dict: dict,
+    ) -> Tuple[torch.Tensor]:
+        if hasattr(layer, "set_bias_to_state_dict"):
+            layer.set_bias_to_state_dict(prefix=f"{prefix}.{layer_name}.", tensor=tensor, state_dict=model_state_dict)
+        else:
+            model_state_dict[f"{prefix}.{layer_name}.bias"] = tensor
+
+    def preshard_hook(self, model_state_dict: dict, prefix: str) -> bool:
+        prefix_parts = prefix.split(".")
+        prefix = ".".join(prefix_parts[:-1])
+        hf_prefix = ".".join(prefix_parts[:-2])
+        if self.fused_qkv:
+            self.replace_prefixes(
+                old_prefix=f"{hf_prefix}.Wqkv",
+                new_prefix=f"{prefix}.Wqkv",
+                model_state_dict=model_state_dict,
+            )
+            qkv_weight = self.get_weight(
+                prefix=prefix, layer=self.Wqkv, layer_name="Wqkv", model_state_dict=model_state_dict
+            )
+            q_proj_weight, k_proj_weight, v_proj_weight = qkv_weight.split(
+                [
+                    self._src_num_attention_heads * self.head_dim,
+                    self._src_num_key_value_heads * self.head_dim,
+                    self._src_num_key_value_heads * self.head_dim,
+                ],
+                dim=0,
+            )
+            qkv_bias = self.get_bias(
+                prefix=prefix, layer=self.Wqkv, layer_name="Wqkv", model_state_dict=model_state_dict
+            )
+            if qkv_bias is not None:
+                q_proj_bias, k_proj_bias, v_proj_bias = qkv_bias.split(
+                    [
+                        self._src_num_attention_heads * self.head_dim,
+                        self._src_num_key_value_heads * self.head_dim,
+                        self._src_num_key_value_heads * self.head_dim,
+                    ],
+                    dim=0,
+                )
+            else:
+                q_proj_bias, k_proj_bias, v_proj_bias = None, None, None
+        else:
+            self.replace_prefixes(
+                old_prefix=f"{hf_prefix}.q_proj",
+                new_prefix=f"{prefix}.q_proj",
+                model_state_dict=model_state_dict,
+            )
+            self.replace_prefixes(
+                old_prefix=f"{hf_prefix}.k_proj",
+                new_prefix=f"{prefix}.k_proj",
+                model_state_dict=model_state_dict,
+            )
+            self.replace_prefixes(
+                old_prefix=f"{hf_prefix}.v_proj",
+                new_prefix=f"{prefix}.v_proj",
+                model_state_dict=model_state_dict,
+            )
+
+            q_proj_weight = self.get_weight(
+                prefix=prefix,
+                layer=self.q_proj,
+                layer_name="q_proj",
+                model_state_dict=model_state_dict,
+            )
+            k_proj_weight = self.get_weight(
+                prefix=prefix,
+                layer=self.k_proj,
+                layer_name="k_proj",
+                model_state_dict=model_state_dict,
+            )
+            v_proj_weight = self.get_weight(
+                prefix=prefix,
+                layer=self.v_proj,
+                layer_name="v_proj",
+                model_state_dict=model_state_dict,
+            )
+
+            q_proj_bias = self.get_bias(
+                prefix=prefix,
+                layer=self.q_proj,
+                layer_name="q_proj",
+                model_state_dict=model_state_dict,
+            )
+            k_proj_bias = self.get_bias(
+                prefix=prefix,
+                layer=self.k_proj,
+                layer_name="k_proj",
+                model_state_dict=model_state_dict,
+            )
+            v_proj_bias = self.get_bias(
+                prefix=prefix,
+                layer=self.v_proj,
+                layer_name="v_proj",
+                model_state_dict=model_state_dict,
+            )
+
+        if self.num_key_value_heads != self._src_num_key_value_heads:
+            if self.sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE:
+                repeats = self.tp_degree // self._src_num_key_value_heads
+            elif self.sharding_strategy == GQA.CONVERT_TO_MHA:
+                repeats = self._src_num_attention_heads // self._src_num_key_value_heads
+            k_proj_weight = replicate_kv(
+                k_proj_weight,
+                source_heads=self._src_num_key_value_heads,
+                repeats=repeats,
+                head_dim=0,
+            )
+            k_proj_bias = replicate_kv(
+                k_proj_bias, source_heads=self._src_num_key_value_heads, repeats=repeats, head_dim=0
+            )
+            v_proj_weight = replicate_kv(
+                v_proj_weight,
+                source_heads=self._src_num_key_value_heads,
+                repeats=repeats,
+                head_dim=0,
+            )
+            v_proj_bias = replicate_kv(
+                v_proj_bias, source_heads=self._src_num_key_value_heads, repeats=repeats, head_dim=0
+            )
+
+        if self.sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE:
+            q_proj_weight = maybe_pad_interleaved(
+                q_proj_weight,
+                pad_dim=0,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                source_group_size=self._src_num_attention_heads // self._src_num_key_value_heads,
+            )
+            q_proj_bias = maybe_pad_interleaved(
+                q_proj_bias,
+                pad_dim=0,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                source_group_size=self._src_num_attention_heads // self._src_num_key_value_heads,
+            )
+
+        if self.sharding_strategy == GQA.CONVERT_TO_MHA:
+            q_proj_weight = maybe_pad_tail(
+                q_proj_weight,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                pad_dim=0,
+            )
+            q_proj_bias = maybe_pad_tail(
+                q_proj_bias,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                pad_dim=0,
+            )
+            k_proj_weight = maybe_pad_tail(
+                k_proj_weight,
+                source_heads=self._src_num_key_value_heads,
+                target_heads=self.num_key_value_heads,
+                pad_dim=0,
+            )
+            k_proj_bias = maybe_pad_tail(
+                k_proj_bias,
+                source_heads=self._src_num_key_value_heads,
+                target_heads=self.num_key_value_heads,
+                pad_dim=0,
+            )
+            v_proj_weight = maybe_pad_tail(
+                v_proj_weight,
+                source_heads=self._src_num_key_value_heads,
+                target_heads=self.num_key_value_heads,
+                pad_dim=0,
+            )
+            v_proj_bias = maybe_pad_tail(
+                v_proj_bias,
+                source_heads=self._src_num_key_value_heads,
+                target_heads=self.num_key_value_heads,
+                pad_dim=0,
+            )
+
+        if self.fused_qkv:
+            qkv_weight = torch.cat([q_proj_weight, k_proj_weight, v_proj_weight], dim=0)
+            self.set_weight(
+                tensor=qkv_weight,
+                prefix=prefix,
+                layer=self.Wqkv,
+                layer_name="Wqkv",
+                model_state_dict=model_state_dict,
+            )
+            if self.bias:
+                qkv_bias = torch.cat([q_proj_bias, k_proj_bias, v_proj_bias], dim=0)
+                self.set_bias(
+                    tensor=qkv_bias,
+                    prefix=prefix,
+                    layer=self.Wqkv,
+                    layer_name="Wqkv",
+                    model_state_dict=model_state_dict,
+                )
+        else:
+            self.set_weight(
+                tensor=q_proj_weight,
+                prefix=prefix,
+                layer=self.q_proj,
+                layer_name="q_proj",
+                model_state_dict=model_state_dict,
+            )
+            self.set_weight(
+                tensor=k_proj_weight,
+                prefix=prefix,
+                layer=self.k_proj,
+                layer_name="k_proj",
+                model_state_dict=model_state_dict,
+            )
+            self.set_weight(
+                tensor=v_proj_weight,
+                prefix=prefix,
+                layer=self.v_proj,
+                layer_name="v_proj",
+                model_state_dict=model_state_dict,
+            )
+
+            if self.bias:
+                self.set_bias(
+                    tensor=q_proj_bias,
+                    prefix=prefix,
+                    layer=self.q_proj,
+                    layer_name="q_proj",
+                    model_state_dict=model_state_dict,
+                )
+                self.set_bias(
+                    tensor=k_proj_bias,
+                    prefix=prefix,
+                    layer=self.k_proj,
+                    layer_name="k_proj",
+                    model_state_dict=model_state_dict,
+                )
+                self.set_bias(
+                    tensor=v_proj_bias,
+                    prefix=prefix,
+                    layer=self.v_proj,
+                    layer_name="v_proj",
+                    model_state_dict=model_state_dict,
+                )
+
+        return True
+
+
+class GroupQueryAttention_O(BaseGroupQueryAttention):
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        tp_degree: int = 1,
+        dtype: torch.dtype = torch.float32,
+        bias: bool = False,
+        desired_sharding_strategy: Optional[GQA] = None,
+        input_is_parallel: bool = False,
+        layer_name: str = "o_proj",
+        sequence_parallel_enabled: bool = False,
+        sequence_dimension: Optional[int] = None,
+        tensor_model_parallel_group: Optional[ProcessGroup] = None,
+        rpl_reduce_dtype: torch.dtype = None,
+    ):
+        super().__init__(
+            hidden_size=hidden_size,
+            head_dim=head_dim,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            tp_degree=tp_degree,
+            dtype=dtype,
+            bias=bias,
+            desired_sharding_strategy=desired_sharding_strategy,
+            tensor_model_parallel_group=tensor_model_parallel_group,
+        )
+
+        self.input_is_parallel = input_is_parallel
+
+        if self.tensor_model_parallel_group is not None:
+            self.o_proj = RowParallelLinear(
+                self.num_attention_heads * self.head_dim,
+                self.hidden_size,
+                bias=self.bias,
+                input_is_parallel=self.input_is_parallel,
+                dtype=self.dtype,
+                sequence_parallel_enabled=sequence_parallel_enabled,
+                sequence_dimension=sequence_dimension,
+                tensor_model_parallel_group=self.tensor_model_parallel_group,
+                reduce_dtype=rpl_reduce_dtype,
+            )
+        else:
+            self.o_proj = nn.Linear(self.num_attention_heads * self.head_dim, self.hidden_size, bias=self.bias)
+
+        # Prepared for changing "o_proj" to the corresponding name in model_state_dict
+        # For example, in CLIP vision model, we use "out_proj"
+        self.layer_name = layer_name
+
+    def forward(self, attention_output: torch.Tensor):
+        return self.o_proj(attention_output)
+
+    def preshard_hook(self, model_state_dict: dict, prefix: str) -> bool:
+        prefix_parts = prefix.split(".")
+        prefix = ".".join(prefix_parts[:-1])
+        hf_prefix = ".".join(prefix_parts[:-2])
+
+        self.replace_prefixes(
+            old_prefix=f"{hf_prefix}.{self.layer_name}",
+            new_prefix=f"{prefix}.o_proj",
+            model_state_dict=model_state_dict,
+        )
+        o_proj_weight = model_state_dict[f"{prefix}.o_proj.weight"]
+
+        if self.sharding_strategy == GQA.REPLICATE_TO_TP_DEGREE:
+            o_proj_weight = maybe_pad_interleaved(
+                o_proj_weight,
+                pad_dim=1,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                source_group_size=self._src_num_attention_heads // self._src_num_key_value_heads,
+            )
+
+        if self.sharding_strategy == GQA.CONVERT_TO_MHA:
+            o_proj_weight = maybe_pad_tail(
+                o_proj_weight,
+                source_heads=self._src_num_attention_heads,
+                target_heads=self.num_attention_heads,
+                pad_dim=1,
+            )
+
+        model_state_dict[f"{prefix}.o_proj.weight"] = o_proj_weight
+
+        return True

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/gqa.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/gqa.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/attention/gqa.py
 import enum
 import logging
 from typing import Optional, Tuple

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/attention/utils.py
 import math
 from typing import Any, Dict, Tuple
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/attention/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/attention/utils.py
@@ -1,0 +1,334 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import math
+from typing import Any, Dict, Tuple
+
+import torch
+import torch_xla.core.xla_model as xm
+from neuronx_distributed.parallel_layers.parallel_state import (
+    get_kv_shared_group,
+    get_tensor_model_parallel_group,
+)
+from neuronx_distributed.parallel_layers.utils import get_padding_length
+from torch import Tensor, nn
+
+
+torch.manual_seed(0)
+
+weight_cache = {}
+
+
+def _get_weight_from_state_dict(prefix: str, state_dict: Dict[str, Any]) -> torch.Tensor:
+    if prefix in weight_cache:
+        return weight_cache[prefix]
+
+    if (prefix + "weight") in state_dict:
+        transposed_weight = state_dict[prefix + "weight"].t()
+        weight_cache[prefix] = transposed_weight
+        return transposed_weight
+
+    else:
+        raise RuntimeError(f"Cannot find {(prefix + 'weight')} in the state_dict")
+
+
+def _set_weight_to_state_dict(prefix: str, tensor: torch.Tensor, state_dict: Dict[str, Any]) -> None:
+    if (prefix + "weight") in state_dict:
+        state_dict[prefix + "weight"] = tensor.t()
+    else:
+        raise RuntimeError(f"Cannot find {(prefix + 'weight')} in the state_dict")
+
+
+def transpose_parallel_linear_layer(parallel_layer):
+    """
+    This function clones and transposes a ColumnParallelLinear or RowParallelLinear
+    The attributes are also cloned and partition_dim is updated
+    """
+    orig_attrs = vars(parallel_layer)
+    new_layer = torch.nn.Parameter(parallel_layer.clone().T, requires_grad=False)
+    new_layer.__dict__.update(orig_attrs)
+    # flip the partition_dim from 0->1 or 1->0
+    setattr(new_layer, "partition_dim", 1 - getattr(new_layer, "partition_dim"))
+    setattr(new_layer, "get_tensor_from_state_dict", _get_weight_from_state_dict)
+    setattr(new_layer, "set_tensor_to_state_dict", _set_weight_to_state_dict)
+    return new_layer
+
+
+def pad_to_128_multiple(x, dim):
+    # Strided padding for unsharded weight, so after sharding
+    # each rank will have dense padding at the end.
+    # Eg orig shape = [16384, 53248], with dim = 1
+    # We reshape to [16384, 128, 416] (TP_degree = 128)
+    # Then pad to [16384, 128, 512].
+    # Then collapse the original dim [16384, 65536].
+    TP_DEGREE = get_tensor_model_parallel_group().size()
+    orig_shape = x.shape
+    new_shape = list(x.shape)
+    new_shape[dim] = orig_shape[dim] // TP_DEGREE
+    new_shape.insert(dim, TP_DEGREE)
+    x = x.reshape(new_shape)
+    dim += 1
+    padding_length = get_padding_length(x.shape[dim], 128)
+    dimlist = [0] * (len(x.shape) * 2)
+    dimlist[dim * 2] = padding_length
+    padded = torch.nn.functional.pad(x, tuple(dimlist[::-1]))
+    new_padded_shape = list(orig_shape)
+    new_padded_shape[dim - 1] = -1
+    padded = padded.reshape(new_padded_shape)
+    return padded
+
+
+def move_heads_front(tensor: Tensor, bsz: int, seq_len: int, num_head: int, head_dim: int, layernorm=None) -> Tensor:
+    """Reshape input tensor: BSHD -> BHSD, and apply layer normalization if layernorm is specified"""
+    tensor = tensor.view(bsz, seq_len, num_head, head_dim)
+    if layernorm:
+        tensor = layernorm(tensor)
+    return tensor.transpose(1, 2).contiguous()
+
+
+def repeat_kv(hidden_states: Tensor, n_rep: int) -> Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def _rotate_half(x) -> Tensor:
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_scaling(freqs: torch.Tensor):
+    # Values obtained from grid search, specifically for Llama3.2 MM PyTorch Implementation
+    scale_factor = 8
+    low_freq_factor = 1
+    high_freq_factor = 4
+    old_context_len = 8192  # original llama3 length
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+    new_freqs = []
+    for freq in freqs:
+        wavelen = 2 * math.pi / freq
+        if wavelen < high_freq_wavelen:
+            new_freqs.append(freq)
+        elif wavelen > low_freq_wavelen:
+            new_freqs.append(freq / scale_factor)
+        else:
+            assert low_freq_wavelen != high_freq_wavelen
+            smooth = (old_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, use_scaled: bool = False):
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+    if use_scaled:
+        freqs = apply_scaling(freqs)
+    freqs = torch.outer(t, freqs)
+    return freqs
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1) -> Tuple[Tensor, Tensor]:
+    """Applies Rotary Position Embedding to the query and key tensors."""
+
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def apply_rotary_polar_compatible(query, key, freqs_cis):
+    freqs_cis_real = freqs_cis.cos().unsqueeze(2)
+    freqs_cis_imag = freqs_cis.sin().unsqueeze(2)
+
+    def rotate(input):
+        real = input[..., ::2]
+        imag = input[..., 1::2]
+
+        # For complex multiplication
+        # (a + ib) * (c + id) = (ac - bd) + i(ad + bc)
+
+        # ac - bd
+        rot_real = (real * freqs_cis_real) - (imag * freqs_cis_imag)
+
+        # ad + bc
+        rot_imag = (real * freqs_cis_imag) + (freqs_cis_real * imag)
+
+        return torch.cat([rot_real.unsqueeze(-1), rot_imag.unsqueeze(-1)], dim=-1).reshape(input.shape)
+
+    query_rot = rotate(query)
+    key_rot = rotate(key)
+
+    return query_rot.type_as(query), key_rot.type_as(key)
+
+
+def manual_softmax(prior_scores, active_scores, is_speculation) -> Tuple[Tensor, Tensor]:
+    """
+    simple softmax computation: denominator is the sum of exp over all vocab and only need compute numerator (exp)
+    """
+    max_score = torch.max(prior_scores, dim=-1, keepdim=True)[0]
+    max_active_score = torch.max(active_scores, dim=-1, keepdim=True)[0]
+    max_score = (
+        torch.maximum(max_score, max_active_score) if is_speculation else torch.maximum(max_score, active_scores)
+    )
+
+    exp_prior = torch.exp(prior_scores - max_score)
+    exp_active = torch.exp(active_scores - max_score)
+    denominator = exp_prior.sum(dim=-1, keepdim=True) + exp_active.sum(dim=-1, keepdim=True)
+
+    softmax_prior = exp_prior / denominator
+    softmax_active = exp_active / denominator
+    return softmax_prior, softmax_active
+
+
+def distributed_softmax(prior_scores, active_scores) -> Tuple[Tensor, Tensor]:
+    """
+    compute partial softmax and then gather and correct final softmax.
+    """
+    # find local max
+    max_score = torch.max(prior_scores, dim=-1, keepdim=True)[0]
+    max_active_score = torch.max(active_scores, dim=-1, keepdim=True)[0]
+    local_max_score = torch.maximum(max_score, max_active_score)
+
+    exp_prior = torch.exp(prior_scores - local_max_score)
+    exp_active = torch.exp(active_scores - local_max_score)
+    denominator = exp_prior.sum(dim=-1, keepdim=True) + exp_active.sum(dim=-1, keepdim=True)
+
+    # collect for global max and exp sum (denominator)
+    groups = get_kv_shared_group(as_list=True)
+    gather_payload = torch.cat((local_max_score, denominator), dim=0)
+    gathered_res = xm.all_gather(gather_payload, dim=-1, groups=groups, pin_layout=False)
+    gathered_max, gathered_denom = torch.chunk(gathered_res, 2, dim=0)
+    global_max = torch.max(gathered_max, dim=-1, keepdim=True)[0]
+
+    # softmax correction
+    scaling_factor = torch.exp(gathered_max - global_max.expand(gathered_max.shape))
+    corrected_denominator = torch.multiply(scaling_factor, gathered_denom)
+    corrected_denominator = torch.sum(corrected_denominator, dim=-1, keepdim=True)
+
+    corrected_exp_prior = torch.exp(prior_scores - global_max)
+    corrected_exp_active = torch.exp(active_scores - global_max)
+
+    softmax_prior = corrected_exp_prior / corrected_denominator
+    softmax_active = corrected_exp_active / corrected_denominator
+    return softmax_prior, softmax_active
+
+
+class RotaryEmbedding(nn.Module):
+    """
+    Adapted from Llama 4.0 impl https://github.com/huggingface/transformers/blob/v4.40.0/src/transformers/models
+    /llama/modeling_llama.py#L96-L145
+    """
+
+    def __init__(self, dim, max_position_embeddings=2048, base=10000):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        self.register_buffer("inv_freq", None, persistent=False)
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        if self.inv_freq is None:
+            self.inv_freq = 1.0 / (
+                self.base ** (torch.arange(0, self.dim, 2, dtype=torch.int64).float().to(x.device) / self.dim)
+            )
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        position_ids_expanded = position_ids[:, None, :].float()
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# Utility functions to create attention mask
+def create_block_diagonal_attn_mask(
+    query_lens: torch.Tensor,
+    key_lens: torch.Tensor,
+    max_query_len: torch.Tensor,
+    max_key_len: torch.Tensor,
+):
+    """
+    Return a block diagonal atttention mask which can be used by chunked
+    prefill.
+
+    This function is written in a way that it can be traced, so it can
+    be used inside the NeuronDecoderModel class.
+
+    Example:
+        query_lens = [2,3,1,0]
+        key_lens = [4,5,4,0]
+        max_query_len = 8
+        max_key_len = 16
+
+        mask = [
+            [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], # At position 3 attend to 1st sequence
+            [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], # At position 4 attend to 1st sequence
+            [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0], # At position 3 attend to 2nd sequence
+            [0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0], # At position 4 attend to 2nd sequence
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], # At position 5 attend to 2nd sequence
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0], # At position 3 attend to 3rd sequence
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], # padding
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], # padding
+        ]
+    Args:
+        query_lens: a list of query lengths for each sequence
+        key_lens: a list of key lengths for each sequence
+        max_query_len: the max value of the sum of query lengths
+        max_key_len: the max value of the sum of key lengths
+
+    Return:
+        mask: the causal attention mask for chunked prefill
+    """
+    batch_size = query_lens.shape[0]
+
+    row_idx = torch.arange(max_query_len, dtype=torch.int).reshape(-1, 1)
+    col_idx = torch.arange(max_key_len, dtype=torch.int).reshape(1, -1)
+
+    q_cumsum = torch.cumsum(query_lens, dim=0)
+    q_cumsum = torch.cat([torch.tensor(0).reshape(1), q_cumsum])
+    k_cumsum = torch.cumsum(key_lens, dim=0)
+    k_cumsum = torch.cat([torch.tensor(0).reshape(1), k_cumsum])
+
+    mask = torch.zeros(max_query_len, max_key_len, dtype=torch.bool)
+    for seq_id in range(batch_size):
+        ri = q_cumsum[seq_id]  # row index
+        ci = k_cumsum[seq_id]  # column index
+        nr = query_lens[seq_id]  # number of rows
+        nc = key_lens[seq_id]  # number of columns
+
+        offset = ci + nc - ri - nr
+        # upper right triangle is set to false
+        diagonal_mask = (row_idx - col_idx + offset) >= 0
+
+        left_mask = col_idx >= ci
+        top_mask = row_idx >= ri
+        bottom_mask = row_idx < ri + nr
+
+        mask_per_seq = diagonal_mask & left_mask & top_mask & bottom_mask
+        mask = mask | mask_per_seq
+
+    return mask

--- a/optimum/neuron/models/inference/nxd/backend/modules/autobucketing.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/autobucketing.py
@@ -1,0 +1,157 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from math import log2
+from typing import List
+
+import torch
+
+
+def generate_buckets(min_length: int, max_length: int):
+    if min_length == max_length:
+        return [max_length]
+
+    min_bound = int(log2(min_length))
+    max_bound = round(log2(max_length))  # we use round because it creates optimal bucket spacing
+
+    # NOTE: because range operates on [a,b), and we rounded the log2 result
+    # we won't get 2**i results close to the max_length.
+    # ex. we won't see bucket spacing of [128,256,512,513] or [128,256,510,512]
+    buckets = [2**i for i in range(min_bound, max_bound)] + [max_length]
+    return buckets
+
+
+def slice_rhs(tensor, bucket: int, max_idx: int, dim: int):
+    tensor = torch.ops.aten.slice(tensor, dim, max_idx - bucket, max_idx, 1)
+    return tensor
+
+
+def slice_lhs(tensor, bucket: int, dim: int):
+    tensor = torch.ops.aten.slice(tensor, dim, 0, bucket, 1)
+    return tensor
+
+
+@torch.jit.script
+def generation_model_bk(
+    tensors: List[torch.Tensor], buckets: torch.Tensor, padding_side: str, speculation_length: int
+):
+    """
+    The Bucket Kernel for Token Generation Models.
+
+    1) tensors: A list of torch tensors after running through the flattener
+    2) buckets: A torch.tensor of the bucket sizes
+    3) padding_side: A string specifying padding side, must be "left" or "right"
+    """
+    # assume tensors[1] is either pos id or attention mask (seq dim == 1 => pos id)
+    item = tensors[1]
+    attention_mask_is_removed = item.shape[1] == 1  # indicates item is position Id
+    if attention_mask_is_removed:
+        position_ids = tensors[1]
+        max_position_id = (
+            position_ids[:, -1] + speculation_length
+            if (position_ids[:, -1] + speculation_length).all() <= buckets[-1]
+            else position_ids[:, -1]
+        )
+        bucket_mask = (buckets <= (max_position_id).unsqueeze(1)).to(torch.int)
+        bucket_idx = torch.max(torch.argmin(bucket_mask, dim=1))
+    else:
+        attention_mask = tensors[1]
+        position_ids = tensors[2]
+        max_position_id = (
+            position_ids[:, -1] + speculation_length
+            if (position_ids[:, -1] + speculation_length).all() <= buckets[-1]
+            else position_ids[:, -1]
+        )
+        bucket_mask = (buckets <= (max_position_id).unsqueeze(1)).to(torch.int)
+        bucket_idx = torch.max(torch.argmin(bucket_mask, dim=1))
+        bucket = buckets[bucket_idx]
+        # slice the attention mask based on the selected bucket size
+        if padding_side == "right":
+            tensors[1] = slice_lhs(attention_mask, bucket, 1)
+        else:
+            tensors[1] = slice_rhs(attention_mask, bucket, buckets[-1], 1)
+
+    return tensors, bucket_idx.to(torch.int)
+
+
+def get_generation_model_bk():
+    return generation_model_bk
+
+
+@torch.jit.script
+def context_encoder_bk(tensors: List[torch.Tensor], buckets, padding_side: str, pad_token: int):
+    """
+    The Bucket Kernel for Context Encoding Models.
+
+    1) tensors: A list of torch tensors after running through the flattener
+    2) buckets: A torch.tensor of the bucket sizes
+    3) padding_side: A string specifying padding side, must be "left" or "right"
+    4) pad_token: An integer representing the pad token id. Typically this is 0.
+    """
+    input_ids = tensors[0]
+
+    # -----Remarks for calculating position_idx-----
+    # finds the number of non pad tokens and that is the active sequence_length
+    # The resulting tensor is of shape (batch_size,)
+    #
+    # NOTE: We derive position_ids from input_ids because
+    # position_ids is eliminated from the flattener for context encoding models.
+    # ----------------------------------------------
+    position_idx = (input_ids != pad_token).sum(dim=1)
+    position_idx = position_idx[:, None]  # shape (batch_size, 1)
+    buckets = buckets[None, :]  # shape (1, seq_len)
+
+    # -----Remarks for choosing the bucket_idx-----
+    # 1. (buckets < position_idx) produces a bucket_mask where invalid buckets are 0
+    # 2. We convert the boolean tensor to int because argmin doesn't support
+    # boolean tensors
+    # 3. We choose the minimum valid bucket, which is the first 1 value
+    # 4. From the minimum valid buckets, we choose the largest bucket, otherwise
+    # we'd be truncating generated tokens from longer sequences.
+    # 5. DO NOT USE argmax since we monkeypatch it,
+    # causing issues with torch.jit.script
+    # ---------------------------------------------
+    bucket_mask = (buckets < position_idx).to(torch.int)  # shape (batch_size, seq_len)
+    bucket_idx = torch.max(torch.argmin(bucket_mask, dim=1))
+
+    # select the chosen bucket after squeezing back to original form
+    bucket = buckets.squeeze(0)[bucket_idx]
+
+    new_tensors = []
+
+    # ---------Remarks on handling padding sides-------
+    # 1. slice from the opposite side for padding
+    # 2. Identify seq_id tensors by shape and don't slice it
+    # -------------------------------------------------
+    if padding_side == "right":
+        for i, tens in enumerate(tensors):
+            # identifies the seq_ids, which don't need to be sliced
+            if len(tens.shape) == 1:
+                new_tensors.append(tens)
+            else:  # all other tensors are of shape (batch_size,seq_len) so we slice on seq_len
+                new_tensors.append(slice_lhs(tens, bucket, 1))
+    else:
+        max_idx = buckets[-1][-1]
+        for i, tens in enumerate(tensors):
+            # identifies the seq_ids, which don't need to be sliced
+            if len(tens.shape) == 1:
+                new_tensors.append(tens)
+            else:
+                new_tensors.append(slice_rhs(tens, bucket, max_idx, 1))
+
+    return new_tensors, bucket_idx.to(torch.int)
+
+
+def get_context_encoder_bk():
+    return context_encoder_bk

--- a/optimum/neuron/models/inference/nxd/backend/modules/autobucketing.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/autobucketing.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/autobucketing.py
 from math import log2
 from typing import List
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/checkpoint.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/checkpoint.py
@@ -1,0 +1,185 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from typing import Callable, Dict, List
+
+import torch
+from huggingface_hub import split_torch_state_dict_into_shards
+from safetensors.torch import load_file, save_file
+
+
+_SAFETENSORS_MODEL_INDEX_FILENAME_JSON = "model.safetensors.index.json"
+_SAFETENSORS_MODEL_FILENAME = "model.safetensors"
+_PYTORCH_MODEL_BIN_INDEX_FILENAME_JSON = "pytorch_model.bin.index.json"
+_PYTORCH_MODEL_BIN_FILENAME = "pytorch_model.bin"
+
+
+def _is_using_pt2() -> bool:
+    pt_version = torch.__version__
+    return pt_version.startswith("2.")
+
+
+def load_state_dict(state_dict_dir: str) -> Dict[str, torch.Tensor]:
+    """
+    Load state_dict from the given dir where its model weight files are in one of the
+    following HF-compatbile formats:
+        1. single file in safetensors format
+        2. multiple sharded files in safetensors format
+        3. single file in torch bin pt format
+        4. multiple sharded files in torch bin pt format
+
+    Loading is done in priority of fastest -> slowest (in case multiple variants exist).
+    """
+    # Standard checkpoint filenames
+    state_dict_safetensor_path = os.path.join(state_dict_dir, _SAFETENSORS_MODEL_FILENAME)
+    safetensors_index_path = os.path.join(state_dict_dir, _SAFETENSORS_MODEL_INDEX_FILENAME_JSON)
+    state_dict_path = os.path.join(state_dict_dir, _PYTORCH_MODEL_BIN_FILENAME)
+    pytorch_model_bin_index_path = os.path.join(state_dict_dir, _PYTORCH_MODEL_BIN_INDEX_FILENAME_JSON)
+
+    # Non-sharded safetensors checkpoint
+    if os.path.isfile(state_dict_safetensor_path):
+        state_dict = load_safetensors(state_dict_dir)
+    # Sharded safetensors checkpoint
+    elif os.path.isfile(safetensors_index_path):
+        state_dict = load_safetensors_sharded(state_dict_dir)
+    # Non-sharded pytorch_model.bin checkpoint
+    elif os.path.isfile(state_dict_path):
+        state_dict = load_pytorch_model_bin(state_dict_dir)
+    # Sharded pytorch model bin
+    elif os.path.isfile(pytorch_model_bin_index_path):
+        state_dict = load_pytorch_model_bin_sharded(state_dict_dir)
+    else:
+        raise FileNotFoundError(f"Can not find model.safetensors or pytorch_model.bin in {state_dict_dir}")
+
+    return state_dict
+
+
+def load_safetensors(state_dict_dir: str) -> Dict[str, torch.Tensor]:
+    filename = os.path.join(state_dict_dir, _SAFETENSORS_MODEL_FILENAME)
+    return load_file(filename)
+
+
+def _load_from_files(filenames: List[str], state_dict_dir: str, load_func: Callable) -> Dict[str, torch.Tensor]:
+    """
+    Load from multiple files, using the provided load_func.
+
+    Args:
+        filenames: A list of filenames that contains the state dict.
+        state_dict_dir: The dir that contains the files in `filenames`.
+        load_func: A function to load file based on different file format.
+
+    Returns:
+        dict: The state dict provided by the files.
+    """
+    state_dict = {}
+    for filename in set(filenames):
+        part_state_dict_path = os.path.join(state_dict_dir, filename)
+        part_state_dict = load_func(part_state_dict_path)
+
+        for key in part_state_dict.keys():
+            if key in state_dict:
+                raise Exception(
+                    f"Found value overriden for key {key} from file "
+                    + f"{part_state_dict_path}, please ensure the provided files are correct."
+                )
+
+        state_dict.update(part_state_dict)
+    return state_dict
+
+
+def load_safetensors_sharded(state_dict_dir: str) -> Dict[str, torch.Tensor]:
+    index_path = os.path.join(state_dict_dir, _SAFETENSORS_MODEL_INDEX_FILENAME_JSON)
+    with open(index_path, "r") as f:
+        key_to_filename = json.load(f)["weight_map"]
+
+    state_dict = _load_from_files(
+        key_to_filename.values(),
+        state_dict_dir,
+        load_file,
+    )
+    return state_dict
+
+
+def _torch_load(file_path: str) -> Dict[str, torch.Tensor]:
+    """
+    Load torch bin pt file.
+
+    If pytorch2 is available, will load it using mmap mode,
+    so it won't cause large memory overhead during loading.
+    """
+    if _is_using_pt2():
+        pt_file = torch.load(file_path, mmap=True, map_location="cpu")
+    else:
+        pt_file = torch.load(file_path)
+    return pt_file
+
+
+def load_pytorch_model_bin(state_dict_dir: str) -> Dict[str, torch.Tensor]:
+    state_dict_path = os.path.join(state_dict_dir, _PYTORCH_MODEL_BIN_FILENAME)
+    return _torch_load(state_dict_path)
+
+
+def load_pytorch_model_bin_sharded(state_dict_dir: str) -> Dict[str, torch.Tensor]:
+    index = os.path.join(state_dict_dir, _PYTORCH_MODEL_BIN_INDEX_FILENAME_JSON)
+    with open(index, "r") as f:
+        key_to_filename = json.load(f)["weight_map"]
+
+    state_dict = _load_from_files(
+        key_to_filename.values(),
+        state_dict_dir,
+        _torch_load,
+    )
+    return state_dict
+
+
+def save_state_dict_safetensors(state_dict: dict, state_dict_dir: str, max_shard_size: str = "10GB"):
+    """
+    Shard and save state dict in safetensors format following HF convention.
+    """
+    sharded_state_dict = split_torch_state_dict_into_shards(
+        state_dict, filename_pattern="model.safetensors", max_shard_size=max_shard_size
+    )
+
+    os.makedirs(state_dict_dir, exist_ok=True)
+    if sharded_state_dict.is_sharded:
+        index = {
+            "metadata": sharded_state_dict.metadata,
+            "weight_map": sharded_state_dict.tensor_to_filename,
+        }
+        index_path = os.path.join(state_dict_dir, _SAFETENSORS_MODEL_INDEX_FILENAME_JSON)
+        with open(index_path, "w") as fin:
+            json.dump(index, fin, indent=4)
+
+    filename_to_tensors = sharded_state_dict.filename_to_tensors
+    for filename, shard in filename_to_tensors.items():
+        file_path = os.path.join(state_dict_dir, filename)
+        save_file(shard, file_path)
+
+
+def prune_state_dict(state_dict):
+    """
+    A helper function that deletes None values in the state_dict before saving
+    as torch.save does not like None values in the state dict.
+    """
+    keys_to_delete = []
+    for key in state_dict:
+        if state_dict[key] is None:
+            keys_to_delete.append(key)
+
+    print(f"Will be deleting following keys as its Value is None: {keys_to_delete}")
+
+    pruned_state_dict = {k: v for k, v in state_dict.items() if v is not None}
+    return pruned_state_dict

--- a/optimum/neuron/models/inference/nxd/backend/modules/checkpoint.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/checkpoint.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/checkpoint.py
 import json
 import os
 from typing import Callable, Dict, List

--- a/optimum/neuron/models/inference/nxd/backend/modules/custom_calls.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/custom_calls.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from torch import nn, ones
+from torch_neuronx.xla_impl.ops import RmsNorm
+
+
+class CustomRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        Use this RMSNorm to perform customized rmsnorm on Neuron
+        Note: CustomRMSNorm forward method calls target="AwsNeuronRmsNorm"
+        """
+        super().__init__()
+        self.weight = nn.Parameter(ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        original_dtype = hidden_states.dtype
+
+        hidden_states = hidden_states.to(torch.float32)
+        result = RmsNorm.apply(hidden_states, self.weight, self.variance_epsilon, len(hidden_states.shape) - 1)
+
+        return result.to(original_dtype)

--- a/optimum/neuron/models/inference/nxd/backend/modules/custom_calls.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/custom_calls.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/custom_calls.py
 import torch
 from torch import nn, ones
 from torch_neuronx.xla_impl.ops import RmsNorm

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/__init__.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/__init__.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .modeling_decoder import NxDDecoderModel, NxDModelForCausalLM

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/decoder_wrapper.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/decoder_wrapper.py
@@ -1,0 +1,311 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+from typing import List
+
+import torch
+import torch.nn.functional as F
+from neuronx_distributed.trace.model_builder import BaseModelInstance
+from torch_neuronx import BucketModelConfig
+from transformers import PretrainedConfig
+
+from ...config import NxDNeuronConfig
+from ...model_wrapper import NxDModelWrapper
+from ..autobucketing import (
+    get_context_encoder_bk,
+    get_generation_model_bk,
+)
+from ..generation.sampling import prepare_sampling_params
+
+
+CONTEXT_ENCODING_MODEL_TAG = "context_encoding_model"
+TOKEN_GENERATION_MODEL_TAG = "token_generation_model"
+SPECULATION_MODEL_TAG = "speculation_model"
+
+
+def get_bucket_model_config_from_tag(
+    tag, config: PretrainedConfig, neuron_config: NxDNeuronConfig, buckets: List[int]
+):
+    bucket_degree = len(buckets)
+    if bucket_degree == 1:
+        return None
+
+    pad_token = config.pad_token_id
+
+    # NOTE: KV Cache preprocessing is done within the model and not the
+    # shared buffer preprocessor due to lack of support of non-contiguous
+    # slicing of nrt tensors via the NRT API.
+    if tag == CONTEXT_ENCODING_MODEL_TAG:
+        return BucketModelConfig(
+            bucket_kernel=get_context_encoder_bk,
+            bucket_kernel_constant_args=(
+                torch.tensor(buckets),
+                neuron_config.padding_side,
+                pad_token,
+            ),
+            shared_state_buffer=None,
+            func_kwargs=[{"bucket_rank": i} for i in range(bucket_degree)],
+        )
+    elif tag == TOKEN_GENERATION_MODEL_TAG or tag == SPECULATION_MODEL_TAG:
+        return BucketModelConfig(
+            bucket_kernel=get_generation_model_bk,
+            bucket_kernel_constant_args=(
+                torch.tensor(buckets),
+                neuron_config.padding_side,
+                0,
+            ),
+            shared_state_buffer=None,
+            func_kwargs=[{"bucket_rank": i} for i in range(bucket_degree)],
+        )
+    else:
+        raise ValueError(
+            f"The supplied tag: {tag} is not supported for Bucketing. Only {CONTEXT_ENCODING_MODEL_TAG} and {TOKEN_GENERATION_MODEL_TAG} are supported"
+        )
+
+
+class NxDDecoderWrapper(NxDModelWrapper):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        neuron_config: NxDNeuronConfig,
+        buckets: List[int],
+        bucket_n_active_tokens: bool,
+        model_cls,
+        tag="",
+        priority_model_idx: int = None,
+        model_init_kwargs={},
+    ) -> None:
+        super().__init__(tag, priority_model_idx)
+        self.config = config
+        self.neuron_config = neuron_config
+        self.buckets = buckets
+        self.bucket_n_active_tokens = bucket_n_active_tokens
+
+        if not self.neuron_config.torch_dtype:
+            self.neuron_config.torch_dtype = torch.float32
+
+        if config.pad_token_id is None:
+            config.pad_token_id = 0
+
+        self.model_cls = model_cls
+        self.model = None
+        self.is_compiled = False
+        self.serialize_base_path = None
+
+        base_compile_work_dir = os.environ.get("BASE_COMPILE_WORK_DIR", "/tmp/nxd_model/")
+        self.compiler_workdir = os.path.join(base_compile_work_dir, self.tag)
+
+        self.model_init_kwargs = model_init_kwargs
+        self.async_mode = self.neuron_config.async_mode
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        self.model = self.model_cls(self.config, self.neuron_config)
+        self.model.load_state_dict(state_dict, strict=strict, assign=assign)
+
+    def input_generator(
+        self,
+    ):
+        inputs = []
+        for bucket in self.buckets:
+            n_active_tokens = bucket if self.bucket_n_active_tokens else self.neuron_config.n_active_tokens
+
+            input_ids = torch.zeros((self.neuron_config.batch_size, n_active_tokens), dtype=torch.int32)
+            attention_mask = torch.zeros((self.neuron_config.batch_size, bucket), dtype=torch.int32)
+            position_ids = torch.zeros((self.neuron_config.batch_size, n_active_tokens), dtype=torch.int32)
+            seq_ids = torch.zeros((self.neuron_config.batch_size), dtype=torch.int32)
+            # Get the count of sampling params currently supported.
+            sampling_params_len = prepare_sampling_params(1).shape[1]
+            sampling_params = torch.zeros((self.neuron_config.batch_size, sampling_params_len), dtype=torch.float32)
+
+            inputs.append((input_ids, attention_mask, position_ids, seq_ids, sampling_params))
+
+        return inputs
+
+    def get_model_instance(self):
+        return DecoderModelInstance(
+            model_cls=self.model_cls,
+            config=self.config,
+            neuron_config=self.neuron_config,
+            buckets=self.buckets,
+            **self.model_init_kwargs,
+        )
+
+    def get_bucket_config(self):
+        return get_bucket_model_config_from_tag(self.tag, self.config, self.neuron_config, self.buckets)
+
+    def _forward_with_pad(self, input_ids, attention_mask, position_ids, seq_ids, sampling_params):
+        # pad the inputs up to the compiled batch size in the end
+        def pad_helper(tensor, pad_type="zeros"):
+            VALID_PAD_TYPES = {"zeros", "ones", "repeat_first_batchline"}
+            assert pad_type in VALID_PAD_TYPES, f"Found {pad_type=}, but valid pad types are {VALID_PAD_TYPES}"
+            if tensor is None or tensor.shape[0] == self.neuron_config.batch_size:
+                return tensor
+
+            padded_shape = list(tensor.shape)
+            padded_shape[0] = self.neuron_config.batch_size
+            if pad_type == "repeat_first_batchline":
+                # pad with first batch line values instead of zeros, to reduce chances of NaN
+                padded_tensor = tensor[0].unsqueeze(0).repeat(padded_shape[0], 1).to(tensor.dtype)
+            else:
+                fill_value = 0 if pad_type == "zeros" else 1
+                padded_tensor = torch.full(padded_shape, fill_value=fill_value, dtype=tensor.dtype)
+            padded_tensor[: tensor.shape[0]] = tensor
+            return padded_tensor
+
+        padded_args = []
+        for arg in (input_ids, attention_mask, position_ids):
+            padded_args.append(pad_helper(arg, pad_type="repeat_first_batchline"))
+
+        # need to handle seq_ids separately, when compiled batch is 4, if we pad seq_ids from [0,2,1] to [0,2,1,
+        # 0]. then the kv cache of padded input could be written into the first cache line, so we need to pad as [0,
+        # 2, 1, 3] instead
+
+        seq_ids_list = seq_ids.tolist()
+        padded_seq_ids = torch.tensor(
+            seq_ids_list + [x for x in range(self.neuron_config.max_batch_size) if x not in seq_ids_list],
+            dtype=seq_ids.dtype,
+        )
+        padded_args.append(padded_seq_ids)
+
+        # pad sampling params by repeating first batchline
+        padded_sampling_params = pad_helper(sampling_params, pad_type="repeat_first_batchline")
+        padded_args.append(padded_sampling_params)
+
+        outputs = self._forward(*padded_args)
+
+        # note that we don't do index select here as it should already be handled, simply sliced out padding here
+        logits = outputs
+        return logits[: seq_ids.shape[0]]
+
+    def _forward(self, input_ids, attention_mask, position_ids, seq_ids, sampling_params):
+        return self.model(input_ids, attention_mask, position_ids, seq_ids, sampling_params)
+
+    def convert_int64_to_int32(self, *args):
+        """
+        Convert int64 args to int32 to match compiled input types.
+        Neuron compiler handles int32 better than int64. Context: P165494809
+        """
+        return [t.to(torch.int32) if t.dtype == torch.int64 else t for t in args]
+
+    def pad_to_max_compiled_seq(self, *args):
+        if self.tag == CONTEXT_ENCODING_MODEL_TAG:
+            to_pad = args[:3]
+            pad_lengths = [self.neuron_config.max_context_length - arg.shape[1] for arg in to_pad]
+            tensor_pad_vals = [self.config.pad_token_id, 0, 1]
+            padded_args = [
+                F.pad(arg, (0, pad_len), "constant", pad_val)
+                for arg, pad_val, pad_len in zip(to_pad, tensor_pad_vals, pad_lengths)
+            ]
+            args = (*padded_args, *args[3:])
+        else:
+            input_ids, attention_mask, *rest_of_args = args
+            pad_len = self.neuron_config.sequence_length - attention_mask.shape[1]
+            padded_attention_mask = F.pad(attention_mask, (0, pad_len), "constant", 0)
+            args = (input_ids, padded_attention_mask, *rest_of_args)
+
+        return args
+
+    def _get_async_output(self, ranked_async_tensor):
+        outputs = [[async_tensor[0].cpu()] for async_tensor in ranked_async_tensor]
+        return outputs[0][0]
+
+    def forward(self, input_ids, attention_mask, position_ids, seq_ids, sampling_params):
+        input_ids, attention_mask, position_ids, seq_ids = self.convert_int64_to_int32(
+            input_ids, attention_mask, position_ids, seq_ids
+        )
+        input_ids, attention_mask, position_ids, seq_ids = self.pad_to_max_compiled_seq(
+            input_ids, attention_mask, position_ids, seq_ids
+        )
+
+        input_batch_size = seq_ids.shape[0]
+
+        if input_batch_size == self.neuron_config.batch_size:
+            return self._forward(input_ids, attention_mask, position_ids, seq_ids, sampling_params)
+
+        cur_batch = 0
+        output_logits = []
+
+        logging.debug(
+            f"get input_batch_size as {input_batch_size} but compiled batch_size as {self.neuron_config.batch_size}"
+        )
+        args = (input_ids, attention_mask, position_ids, seq_ids, sampling_params)
+        while cur_batch < input_batch_size:
+            if cur_batch + self.neuron_config.batch_size <= input_batch_size:
+                # we only process part of the input to run
+                logging.debug(f"running foward on batch {cur_batch}:{cur_batch + self.neuron_config.batch_size}")
+                outputs = self._forward(*[arg[cur_batch : cur_batch + self.neuron_config.batch_size] for arg in args])
+            else:
+                # we need to pad the input to run
+                logging.debug(
+                    f"running forward on batch {cur_batch}:{input_batch_size}, padded up to {self.neuron_config.batch_size}"
+                )
+                outputs = self._forward_with_pad(*[arg[cur_batch:input_batch_size] for arg in args])
+
+            output_logits.append(outputs)
+            cur_batch += self.neuron_config.batch_size
+
+        if self.async_mode:
+            # block on all requests here, since this is output manipulation
+            output_logits = [self._get_async_output(ranked_logits) for ranked_logits in output_logits]
+
+        return torch.cat(output_logits, dim=0)
+
+
+class DecoderModelInstance(BaseModelInstance):
+    def __init__(
+        self, model_cls, config: PretrainedConfig, neuron_config: NxDNeuronConfig, buckets: List[int], **kwargs
+    ):
+        self.model_cls = model_cls
+        self.module = None
+        self.input_output_aliases = None
+        self.config = config
+        self.neuron_config = neuron_config
+        self.buckets = buckets
+        self.kwargs = kwargs if kwargs is not None else {}
+
+    def initialize_process_group(self, world_size):
+        self.model_cls.initialize_process_group(world_size)
+
+    def load_module(self):
+        float_model = self.model_cls(self.config, self.neuron_config, **self.kwargs)
+        float_model.eval()
+
+        if self.neuron_config.torch_dtype != torch.float32:
+            float_model._apply(
+                lambda t: t.to(self.neuron_config.torch_dtype)
+                if t.is_floating_point() and t.dtype not in [torch.float8_e4m3fn, torch.float8_e5m2]
+                else t
+            )
+        self.module = float_model
+
+    def get(self, bucket_rank, **kwargs):
+        if bucket_rank is not None:
+            self.module.n_positions = self.buckets[bucket_rank]
+
+        # Currently we have to init an input_output_aliases map for
+        # each buckets, otherwise it will fail the aliasing setup when
+        # generating HLO
+        self.input_output_aliases = {}
+        num_output_from_trace = 1 if not self.neuron_config.output_logits else 2
+        # TODO: This else block is a short-term fix for Llava/ViT models to use DecoderModelInstance.
+        #       Long-term, these models should use a different implementation of BaseModelInstance.
+        if self.module.kv_mgr is not None:
+            past_key_values = self.module.kv_mgr.past_key_values
+        else:
+            past_key_values = self.module.past_key_values
+        for i in range(len(past_key_values)):
+            self.input_output_aliases[past_key_values[i]] = num_output_from_trace + i
+        return self.module, self.input_output_aliases

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -1,0 +1,896 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import logging
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List, Optional, Tuple, Union
+
+import neuronx_distributed as nxd
+import torch
+import torch_xla.core.xla_model as xm
+from huggingface_hub import snapshot_download
+from neuronx_distributed.operators.argmax import argmax as nxd_argmax
+from neuronx_distributed.parallel_layers.layers import SPMDRank
+from neuronx_distributed.parallel_layers.mappings import (
+    _gather_along_dim,
+    _reduce_scatter_along_dim,
+    gather_from_sequence_parallel_region,
+)
+from torch import nn
+from transformers import AutoConfig, PretrainedConfig
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+from optimum.neuron import NeuronModelForCausalLM
+
+from ...config import NxDNeuronConfig
+from ...pretrained_model import NxDPreTrainedModel
+from ...utils.random import set_random_seed
+from ..attention import utils as attn_utils
+from ..autobucketing import generate_buckets
+from ..flashdecode.utils import (
+    get_cache_size,
+    mask_util,
+    turn_2d_mask_to_4d,
+)
+from ..generation.generation_utils import NxDGenerationMixin
+from ..generation.sampling import (
+    Sampler,
+    prepare_sampling_params,
+    validate_sampling_params,
+)
+from ..kvcache.kv_cache_manager import (
+    KVCacheManager,
+    _slice_kv_cacheline,
+)
+from .decoder_wrapper import (
+    CONTEXT_ENCODING_MODEL_TAG,
+    SPECULATION_MODEL_TAG,
+    TOKEN_GENERATION_MODEL_TAG,
+    NxDDecoderWrapper,
+)
+
+
+logger = logging.getLogger("Neuron")
+
+
+class NxDDecoderModel(nn.Module):
+    """
+    Base model that NeuronXXXModel classes inherit from.
+
+    The forward() function will be traced and compiled by NxD.
+    """
+
+    def __init__(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig):
+        super().__init__()
+
+        self.config = config
+        self.sampler = None
+        self.kv_mgr = None
+        self.neuron_config = neuron_config
+        self.batch_size = neuron_config.batch_size
+        self.n_positions = neuron_config.sequence_length
+        self.vocab_size = config.vocab_size
+        self.speculation_length = neuron_config.speculation_length
+        self.padding_side = neuron_config.padding_side
+        self.max_length = neuron_config.sequence_length
+        self.sequence_parallel_enabled = neuron_config.sequence_parallel_enabled
+        self.sequence_dimension = 1 if self.sequence_parallel_enabled else None
+        self.rank_util = SPMDRank(world_size=neuron_config.tp_degree)
+        self.num_cores_per_group = neuron_config.num_cores_per_group
+        if neuron_config.on_device_sampling:
+            # Instantiate a multinomial Sampler (it can still be used for greedy by passing topk=1)
+            self.sampler = Sampler(do_sample=True, max_topk=neuron_config.max_topk)
+        self.kv_mgr = KVCacheManager(config, neuron_config, num_kv_head=config.num_key_value_heads)
+
+    def initialize_process_group(self, seed: int = 0):
+        if not torch.dist.is_initialized():
+            torch.dist.init_process_group(backend="xla")
+        else:
+            logging.warning("torch.distributed was already initialized, skipping...")
+
+        if not nxd.parallel_layers.parallel_state.model_parallel_is_initialized():
+            nxd.parallel_layers.initialize_model_parallel(
+                tensor_model_parallel_size=self.neuron_config.tp_degree,
+                pipeline_model_parallel_size=self.neuron_config.pp_degree,
+                expert_model_parallel_size=self.neuron_config.ep_degree,
+            )
+        else:
+            logging.warning("NxD was already initialized, skipping...")
+
+        # set seed
+        set_random_seed(seed)
+
+    def _create_context_attn_mask(self, attention_mask, **kwargs):
+        # Block diagonal causal mask for chunked prefill
+        if self.neuron_config.is_chunked_prefill:
+            return self._create_chunked_prefill_attn_mask(**kwargs)
+
+        # Lower triangle causal mask for classic attention
+        mask = torch.full((self.n_positions, self.n_positions), True, device=attention_mask.device).tril(diagonal=0)
+        mask = mask[None, None, :, :].expand(self.batch_size, 1, self.n_positions, self.n_positions)
+
+        if self.padding_side == "right":
+            return mask
+        else:
+            expanded_mask = (
+                attention_mask[:, None, None, :]
+                .expand(self.batch_size, 1, self.n_positions, self.n_positions)
+                .to(torch.bool)
+            )
+            return torch.logical_and(mask, expanded_mask)
+
+    def _create_chunked_prefill_attn_mask(
+        self,
+        query_lens: torch.Tensor,
+        key_lens: torch.Tensor,
+        max_query_len: int,
+        max_key_len: int,
+        **kwargs,
+    ) -> torch.Tensor:
+        return attn_utils.create_block_diagonal_attn_mask(query_lens, key_lens, max_query_len, max_key_len, **kwargs)
+
+    def _create_spec_attn_mask(self, attention_mask):
+        return (
+            attention_mask[:, None, None, :]
+            .expand(self.batch_size, 1, self.speculation_length, self.n_positions)
+            .to(torch.bool)
+        )
+
+    def _create_simple_attn_mask(self, attention_mask):
+        return attention_mask[:, None, None, :].expand(self.batch_size, 1, 1, self.n_positions).to(torch.bool)
+
+    def create_attn_mask(self, attention_mask, is_for_context_encoding, is_for_speculation, **kwargs):
+        if is_for_context_encoding:
+            return self._create_context_attn_mask(attention_mask, **kwargs)
+        elif is_for_speculation:
+            return self._create_spec_attn_mask(attention_mask)
+        else:
+            return self._create_simple_attn_mask(attention_mask)
+
+    def _reorder_helper(self, inp, ids):
+        # alternative, torch_xla compatible version of index_select for 0th (batch) dimension
+        sorted_inp = inp[ids.flatten()]
+
+        return sorted_inp
+
+    def _slice_kv_cache(self, kv_cache, n_positions):
+        past_key_values = []
+        for idx in range(len(kv_cache)):
+            k_cache = _slice_kv_cacheline(self.neuron_config.padding_side, n_positions, kv_cache[idx][0])
+            v_cache = _slice_kv_cacheline(self.neuron_config.padding_side, n_positions, kv_cache[idx][1])
+            past_key_values.append([k_cache, v_cache])
+        return past_key_values
+
+    def _is_reorder_needed(self, is_for_context_encoding, is_for_speculation):
+        return not is_for_context_encoding and not is_for_speculation and self.neuron_config.is_continuous_batching
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask,
+        position_ids,
+        seq_ids,
+        sampling_params,
+        scatter_index=None,
+        # In llava context encoding model, input_embeds is precomputed
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        kv_cache: Optional[torch.Tensor] = None,
+    ):
+        # TODO: This will not work for a context encoding model with bucket size
+        # equal to the speculation length
+        is_for_context_encoding = input_ids.shape[-1] > 1 and input_ids.shape[-1] != self.speculation_length
+        is_for_speculation = input_ids.shape[-1] == self.speculation_length
+
+        cache_size = (
+            get_cache_size(self.n_positions, self.num_cores_per_group)
+            if self.neuron_config.flash_decoding_enabled
+            else self.n_positions
+        )
+
+        orig_seq_ids = seq_ids
+
+        if self._is_reorder_needed(is_for_context_encoding, is_for_speculation):
+            seq_ids = torch.argsort(seq_ids)
+            input_ids = self._reorder_helper(input_ids, seq_ids)
+            attention_mask = self._reorder_helper(attention_mask, seq_ids)
+            position_ids = self._reorder_helper(position_ids, seq_ids)
+            sampling_params = self._reorder_helper(sampling_params, seq_ids)
+
+        # It is either for context encoding or for token generation
+        if is_for_context_encoding:
+            past_key_values = None
+        else:
+            if kv_cache is None:
+                past_key_values = self.kv_mgr.get_cache(cache_size)
+            else:
+                past_key_values = self._slice_kv_cache(kv_cache, cache_size)
+
+        # Prepare attention mask(s)
+        attention_mask = self.create_attn_mask(
+            attention_mask,
+            is_for_context_encoding,
+            is_for_speculation,
+        )
+        active_mask = None
+        if is_for_speculation:
+            active_mask = torch.full(
+                (self.speculation_length, self.speculation_length),
+                True,
+                device=attention_mask.device,
+            ).tril(diagonal=0)
+            active_mask = active_mask[None, None, :, :].expand(
+                self.batch_size, 1, self.speculation_length, self.speculation_length
+            )
+
+        # FD masks
+        active_mask_2d = None
+        if self.neuron_config.flash_decoding_enabled and not is_for_context_encoding:
+            rank_id = self.rank_util.get_rank()
+            active_mask_2d, attention_mask_2d = mask_util(
+                pos_ids=position_ids,
+                rank_id=rank_id,
+                num_cores_per_group=self.num_cores_per_group,
+                cache_size=cache_size,
+            )
+            active_mask = turn_2d_mask_to_4d(active_mask_2d, n_positions=1, batch_size=self.batch_size)
+            attention_mask = turn_2d_mask_to_4d(attention_mask_2d, n_positions=cache_size, batch_size=self.batch_size)
+
+        hidden_states, past_key_values = self.get_model_output(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            active_mask=active_mask,
+            inputs_embeds=inputs_embeds,
+        )
+
+        if kv_cache is None:
+            updated_kv_cache = self.kv_mgr.update_cache(
+                is_for_context_encoding=is_for_context_encoding,
+                seq_ids=seq_ids,
+                position_ids=position_ids,
+                new_key_values=past_key_values,
+                seq_len=cache_size,
+                scatter_index=scatter_index,
+                active_mask=active_mask_2d,
+            )
+        else:
+            updated_kv_cache = self.kv_mgr.update_cache(
+                is_for_context_encoding=is_for_context_encoding,
+                seq_ids=seq_ids,
+                position_ids=position_ids,
+                new_key_values=past_key_values,
+                seq_len=cache_size,
+                scatter_index=scatter_index,
+                active_mask=active_mask_2d,
+                kvcache_buffer=kv_cache,
+            )
+
+        batch_size, num_tokens, hidden_size = hidden_states.shape
+        if self.padding_side == "left":
+            index = torch.tensor([num_tokens - 1], device=hidden_states.device)
+            index = index.unsqueeze(1).expand(batch_size, 1, hidden_size)
+            hidden_states = torch.gather(hidden_states, dim=1, index=index)
+        else:
+            # speculative decoding case; only batch_size=1
+            # will need to extend the logic to support multi-batch later
+            # maybe just use position_ids for index?
+            if position_ids.shape[-1] == self.speculation_length:
+                index = torch.min(position_ids)
+                index = torch.arange(index, index + self.speculation_length, device=hidden_states.device)
+                index = index.unsqueeze(0).unsqueeze(2).expand(batch_size, self.speculation_length, hidden_size)
+                hidden_states = torch.gather(hidden_states, dim=1, index=index)
+            else:
+                # simple token generation
+                index = torch.max(position_ids, dim=1, keepdim=True).indices
+                index = index.unsqueeze(1).expand(batch_size, 1, hidden_size)
+                hidden_states = torch.gather(hidden_states, dim=1, index=index)
+
+        logits = self.lm_head(hidden_states)
+        logits = logits.float()
+
+        res = logits
+        if self.neuron_config.on_device_sampling:
+            # perform sampling on Neuron to get tokens
+            # FIXME, logits[:, -1, :] is not correct for speculation model, this is a tempory fix.
+            if is_for_speculation and not self.neuron_config.on_device_sampling_config.do_sample:
+                res = nxd_argmax(tensor=logits, dim=2, gather_dim=2, keepdim=False)
+            else:
+                res = self.sampler(logits[:, -1, :], sampling_params)
+
+        if self._is_reorder_needed(is_for_context_encoding, is_for_speculation):
+            res = self._reorder_helper(res, orig_seq_ids)
+
+        outputs = [res]
+        if self.neuron_config.output_logits:
+            logits = _gather_along_dim(
+                logits,
+                partition_dim=2,
+            )
+            outputs += [logits]
+        outputs += updated_kv_cache
+
+        return outputs
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def get_model_output(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        active_mask: Optional[List[torch.FloatTensor]] = None,
+        # In llava context encoding model, input_embeds is precomputed
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ):
+        batch_size, seq_length = input_ids.shape[:2]
+
+        past_key_values_length = 0
+        if past_key_values is not None:
+            past_key_values_length = past_key_values[0][0].shape[2]
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if position_ids is None:
+            device = input_ids.device if input_ids is not None else inputs_embeds.device  # noqa
+            position_ids = torch.arange(
+                past_key_values_length,
+                seq_length + past_key_values_length,
+                dtype=torch.long,
+                device=device,
+            )
+            position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
+        else:
+            position_ids = position_ids.view(-1, seq_length).long()
+
+        # NeuronLlamaModel class manages the KV cache. So the attention_mask will be generated and passed
+        # through to LlamaModel. We override the HF's code that generates attention mask because HF does
+        # not support left aligned RHS padding. This enables Neuron to achieve higher performance and
+        # extensibility.
+        #
+        # 4d mask is passed through the layers
+        # attention_mask = _prepare_4d_causal_attention_mask(
+        #     attention_mask, (batch_size, seq_length), inputs_embeds, past_key_values_length
+        # )
+
+        # embed positions
+        if self.sequence_parallel_enabled:
+            # TODO: Replace this with rankid + scatter call once supported
+            hidden_states = _reduce_scatter_along_dim(
+                inputs_embeds,
+                self.sequence_dimension,
+                xm.REDUCE_MAX,
+            )
+        else:
+            hidden_states = inputs_embeds
+
+        # decoder layers
+        next_decoder_cache = ()
+        cos_cache = None
+        sin_cache = None
+        for idx, decoder_layer in enumerate(self.layers):
+            past_key_value = past_key_values[idx] if past_key_values is not None else None
+
+            layer_outputs = decoder_layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                active_mask=active_mask,
+                cos_cache=cos_cache,
+                sin_cache=sin_cache,
+            )
+
+            hidden_states = layer_outputs[0]
+            next_decoder_cache += (layer_outputs[1],)
+            cos_cache, sin_cache = layer_outputs[2:]
+
+        hidden_states = self.norm(hidden_states)
+
+        if self.sequence_parallel_enabled:
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                self.sequence_dimension,
+            )
+
+        return (hidden_states, next_decoder_cache)
+
+
+class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelForCausalLM):
+    _model_cls = None
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        neuron_config: NxDNeuronConfig,
+        traced_model: torch.jit.ScriptModule,
+        context_encoding_model: NxDDecoderWrapper,
+        token_generation_model: NxDDecoderWrapper = None,
+        speculation_model: NxDDecoderWrapper = None,
+    ):
+        self.context_encoding_model = context_encoding_model
+        self.token_generation_model = token_generation_model
+        self.speculation_model = speculation_model
+        # Model wrappers are used by the parent class to assign weights to the model.
+        model_wrappers = [self.context_encoding_model]
+        if self.token_generation_model is not None:
+            model_wrappers.append(self.token_generation_model)
+        if self.speculation_model is not None:
+            model_wrappers.append(self.speculation_model)
+        super().__init__(
+            config=config, neuron_config=neuron_config, traced_model=traced_model, model_wrappers=model_wrappers
+        )
+
+        self.text_config = self.config.get_text_config()
+        self.vocab_size = self.text_config.vocab_size
+        self.padding_side = self.neuron_config.padding_side
+        self.kv_cache_populated = False
+
+        # async related
+        self.async_mode = self.neuron_config.async_mode
+        self.next_cpu_inputs = None
+        self.prior_outputs = None
+        self.unequal_batching = self.neuron_config.ctx_batch_size != self.neuron_config.tkg_batch_size
+        if self.async_mode:
+            os.environ["NEURON_RT_ASYNC_EXEC_MAX_INFLIGHT_REQUESTS"] = "2"
+
+        self.sampler = None
+        self.default_sampling_params = prepare_sampling_params(
+            batch_size=self.neuron_config.batch_size, top_k=[1], top_p=[1.0], temperature=[1.0]
+        )
+
+    @staticmethod
+    def create_context_encoding_wrapper(model_cls, config, neuron_config, **model_init_kwargs):
+        new_neuron_config = copy.deepcopy(neuron_config)
+        new_neuron_config.batch_size = neuron_config.ctx_batch_size
+        new_neuron_config.n_active_tokens = neuron_config.max_context_length
+
+        if new_neuron_config.enable_bucketing:
+            buckets = generate_buckets(128, new_neuron_config.max_context_length)
+        else:
+            buckets = generate_buckets(
+                new_neuron_config.max_context_length,
+                new_neuron_config.max_context_length,
+            )
+
+        return NxDDecoderWrapper(
+            config=config,
+            neuron_config=new_neuron_config,
+            buckets=buckets,
+            bucket_n_active_tokens=True,
+            model_cls=model_cls,
+            tag=CONTEXT_ENCODING_MODEL_TAG,
+            model_init_kwargs=model_init_kwargs,
+        )
+
+    @staticmethod
+    def create_token_generation_wrapper(
+        model_cls, config, neuron_config, enable_wlt_optimization: bool = True, **model_init_kwargs
+    ):
+        new_neuron_config = copy.deepcopy(neuron_config)
+        new_neuron_config.batch_size = neuron_config.tkg_batch_size
+        new_neuron_config.n_active_tokens = 1
+        new_neuron_config.sequence_parallel_enabled = False
+
+        if new_neuron_config.enable_bucketing:
+            buckets = generate_buckets(128, neuron_config.sequence_length)
+        else:
+            buckets = generate_buckets(neuron_config.sequence_length, neuron_config.sequence_length)
+
+        # shouldn't be used in token gen models
+        new_neuron_config.sequence_parallel_enabled = False
+
+        return NxDDecoderWrapper(
+            config=config,
+            neuron_config=new_neuron_config,
+            buckets=buckets,
+            bucket_n_active_tokens=False,
+            model_cls=model_cls,
+            tag=TOKEN_GENERATION_MODEL_TAG,
+            priority_model_idx=0 if enable_wlt_optimization else None,  # to turn on weight layout optimization
+            model_init_kwargs=model_init_kwargs,
+        )
+
+    @staticmethod
+    def create_speculation_wrapper(model_cls, config, neuron_config, **model_init_kwargs):
+        new_neuron_config = copy.deepcopy(neuron_config)
+        new_neuron_config.batch_size = neuron_config.tkg_batch_size
+        new_neuron_config.n_active_tokens = neuron_config.speculation_length
+
+        new_neuron_config.sequence_parallel_enabled = False
+
+        if new_neuron_config.enable_bucketing:
+            buckets = generate_buckets(128, neuron_config.sequence_length)
+        else:
+            buckets = generate_buckets(neuron_config.sequence_length, neuron_config.sequence_length)
+
+        return NxDDecoderWrapper(
+            config=config,
+            neuron_config=new_neuron_config,
+            buckets=buckets,
+            bucket_n_active_tokens=False,
+            model_cls=model_cls,
+            tag=SPECULATION_MODEL_TAG,
+            priority_model_idx=0,  # to turn on weight layout optimization
+            model_init_kwargs=model_init_kwargs,
+        )
+
+    @staticmethod
+    def create_model_wrappers(model_cls, config, neuron_config, **model_init_kwargs):
+        context_encoding_model = NxDModelForCausalLM.create_context_encoding_wrapper(
+            model_cls,
+            config,
+            neuron_config,
+            **model_init_kwargs,
+        )
+        token_generation_model = NxDModelForCausalLM.create_token_generation_wrapper(
+            model_cls,
+            config,
+            neuron_config,
+            **model_init_kwargs,
+        )
+        speculation_model = (
+            NxDModelForCausalLM.create_speculation_wrapper(
+                model_cls,
+                config,
+                neuron_config,
+                **model_init_kwargs,
+            )
+            if neuron_config.speculation_length > 0
+            else None
+        )
+        return context_encoding_model, token_generation_model, speculation_model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: Optional[torch.LongTensor],
+        seq_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        sampling_params: Optional[torch.FloatTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        if self.async_mode:
+            # derive future cpu inputs from current cpu inputs
+            if position_ids.shape[1] == input_ids.shape[1]:
+                next_position_ids = torch.amax(position_ids, 1, keepdim=True)
+            else:
+                next_position_ids = position_ids
+
+            next_position_ids = next_position_ids + 1
+            next_attention_mask = self._infer_attention_mask(next_position_ids)
+            self.next_cpu_inputs = {
+                "attention_mask": next_attention_mask,
+                "position_ids": next_position_ids,
+            }
+
+        sampling_params = self.default_sampling_params if sampling_params is None else sampling_params
+        if self.neuron_config.on_device_sampling:
+            validate_sampling_params(sampling_params, self.neuron_config.max_topk)
+
+        self.sampling_params = sampling_params
+
+        output_attentions, output_hidden_states, return_dict = self._setup_func_config(
+            output_attentions, output_hidden_states, return_dict
+        )
+
+        # infer attention_mask from position_ids if not provided
+        if attention_mask is None:
+            attention_mask = self._infer_attention_mask(position_ids)
+
+        if seq_ids is None:
+            seq_ids = torch.arange(input_ids.shape[0])
+
+        logits_or_next_tokens = self._get_model_outputs(
+            input_ids,
+            attention_mask,
+            position_ids,
+            seq_ids,
+            sampling_params,
+        )
+
+        logging.debug("---output---")
+        logging.debug(
+            f"{'tokens' if self.neuron_config.on_device_sampling else 'logits'} = %s, ",
+            logits_or_next_tokens,
+        )
+
+        return self._construct_output(logits_or_next_tokens)
+
+    def _setup_func_config(self, output_attentions, output_hidden_states, return_dict):
+        output_attentions = output_attentions if output_attentions is not None else self.text_config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.text_config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else getattr(self.config, "use_return_dict", None)
+        return output_attentions, output_hidden_states, return_dict
+
+    def _infer_attention_mask(self, position_ids):
+        assert position_ids is not None, "need to call forward with position_ids if attention_mask is not provided"
+        batch_size, seq_len = position_ids.shape
+        if position_ids.shape[-1] == 1:
+            seq_len = self.neuron_config.sequence_length
+            position_ids_to_compare = position_ids.expand(batch_size, seq_len) - 1
+        else:
+            seq_len = position_ids.shape[-1]
+            position_ids_to_compare = position_ids
+        mask = torch.arange(seq_len).view(1, -1).expand(batch_size, seq_len)
+        attention_mask = (position_ids_to_compare >= mask).to(dtype=position_ids.dtype)
+        return attention_mask
+
+    def _get_async_output(
+        self,
+        ranked_async_tensor,
+    ):
+        outputs = [[async_tensor[0].cpu()] for async_tensor in ranked_async_tensor]
+        return outputs[0][0]
+
+    def _get_model_outputs(
+        self,
+        input_ids,
+        attention_mask,
+        position_ids,
+        seq_ids,
+        sampling_params,
+    ):
+        # casting inputs to int32
+        input_ids = input_ids.to(torch.int32)
+        attention_mask = attention_mask.to(torch.int32)
+        position_ids = position_ids.to(torch.int32)
+        seq_ids = seq_ids.to(torch.int32)
+
+        if input_ids.shape[-1] > 1 and not position_ids.min().item():
+            outputs = self.context_encoding_model(
+                input_ids,
+                attention_mask,
+                position_ids,
+                seq_ids,
+                sampling_params,
+            )
+
+            self.kv_cache_populated = True
+            if self.async_mode:
+                if not self.unequal_batching:
+                    # for now only cte + tkg flow is supported with async (this will be enforced at config level)
+                    next_outputs = self.token_generation_model(
+                        outputs,
+                        self.next_cpu_inputs["attention_mask"],
+                        self.next_cpu_inputs["position_ids"],
+                        seq_ids,
+                        sampling_params,
+                    )
+                    outputs = self._get_async_output(outputs)  # block on cte call
+                    self.prior_outputs = next_outputs
+                else:
+                    if isinstance(
+                        outputs, list
+                    ):  # in case the outputs weren't passed through `torch.cat` in model_wrapper.py
+                        outputs = self._get_async_output(outputs)  # block on cte call
+
+                    self.prior_outputs = None
+
+        elif input_ids.shape[-1] == self.neuron_config.speculation_length:
+            outputs = self.speculation_model(
+                input_ids,
+                attention_mask,
+                position_ids,
+                seq_ids,
+                sampling_params,
+            )
+        else:
+            if (
+                self.next_cpu_inputs is not None and self.prior_outputs is not None
+            ):  # this is never not None and not in async mode
+                _input_ids = self.prior_outputs
+                _attention_mask = self.next_cpu_inputs["attention_mask"]
+                _position_ids = self.next_cpu_inputs["position_ids"]
+            else:
+                _input_ids = input_ids
+                _attention_mask = attention_mask
+                _position_ids = position_ids
+
+            next_outputs = self.token_generation_model(
+                _input_ids,
+                _attention_mask,
+                _position_ids,
+                seq_ids,
+                sampling_params,
+            )
+            if self.async_mode:
+                if self.prior_outputs is None:  # this means that next_outputs is processing token to be returned
+                    self.prior_outputs = next_outputs
+                    next_outputs = self.token_generation_model(  # submit future token request
+                        next_outputs,
+                        self.next_cpu_inputs["attention_mask"],
+                        self.next_cpu_inputs["position_ids"],
+                        seq_ids,
+                        sampling_params,
+                    )
+                outputs = self.prior_outputs
+                if isinstance(outputs, list):
+                    outputs = self._get_async_output(
+                        self.prior_outputs
+                    )  # block on prior (sometimes current) token gen request
+
+                self.prior_outputs = next_outputs
+            else:
+                outputs = next_outputs
+
+        return outputs
+
+    def _construct_output(self, logits_or_next_tokens):
+        next_tokens = logits_or_next_tokens
+
+        OutputParams = CausalLMOutputWithPast(
+            logits=None if self.neuron_config.on_device_sampling else logits_or_next_tokens,
+            hidden_states=logits_or_next_tokens,
+            attentions=None,
+        )
+
+        OutputParams.tokens = next_tokens
+
+        return OutputParams
+
+    def reset(self):
+        # We need to reset the KV cache flag for a new batch of inference.
+        # When the flag is reset, the subsequent run will invoke the
+        # context encoding model.
+        self.kv_cache_populated = False
+
+    def get_required_kwargs(self) -> List[str]:
+        """The list of required kwargs to the model's forward"""
+        return []
+
+    @classmethod
+    def get_compiler_args(cls, neuron_config: NxDNeuronConfig) -> str:
+        tensorizer_options = (
+            "--enable-ccop-compute-overlap "
+            f"--cc-pipeline-tiling-factor={neuron_config.cc_pipeline_tiling_factor} "
+            "--vectorize-dge-dma "
+            "--vectorize-strided-dma "
+        )
+
+        compiler_args = (
+            "--auto-cast=none --model-type=transformer "
+            f"--tensorizer-options='{tensorizer_options}'"
+            " -O1 "
+            f" --internal-num-neuroncores-per-sengine={neuron_config.logical_nc_config}"
+        )
+
+        if neuron_config.target:
+            compiler_args += f" --target {neuron_config.target}"
+
+        logging.info(f"neuronx-cc compiler_args are: {compiler_args}")
+        return compiler_args
+
+    # NeuronModelForCausalLM methods
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, "Path"],
+        config: "PretrainedConfig",
+        revision: Optional[str] = None,
+        token: Optional[Union[bool, str]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: Optional[bool] = False,
+        subfolder: Optional[str] = "",
+        local_files_only: Optional[bool] = False,
+        trust_remote_code: Optional[bool] = False,
+        **kwargs,
+    ) -> "NeuronModelForCausalLM":
+        neuron_config = cls.get_neuron_config_cls().from_pretrained(model_id)
+        context_encoding_model, token_generation_model, speculation_model = cls.create_model_wrappers(
+            model_cls=cls._model_cls,
+            config=config,
+            neuron_config=neuron_config,
+            **kwargs,
+        )
+        traced_model = torch.jit.load(os.path.join(model_id, cls.COMPILED_MODEL_FILE_NAME))
+        model = cls(
+            config=config,
+            neuron_config=neuron_config,
+            traced_model=traced_model,
+            context_encoding_model=context_encoding_model,
+            token_generation_model=token_generation_model,
+            speculation_model=speculation_model,
+        )
+        checkpoint_path = os.path.join(model_id, cls.CHECKPOINT_DIR)
+        if os.path.exists(checkpoint_path):
+            model._load_weights(checkpoint_path)
+        elif neuron_config.checkpoint_id is not None:
+            # Fetch weights from the checkpoint
+            checkpoint_dir = TemporaryDirectory()
+            os.chmod(checkpoint_dir.name, 0o775)
+            snapshot_download(
+                repo_id=neuron_config.checkpoint_id,
+                revision=neuron_config.checkpoint_revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+                token=token,
+                local_dir=checkpoint_dir.name,
+                allow_patterns=["*.safetensors*"],
+            )
+            model._load_weights(checkpoint_dir.name)
+            checkpoint_dir.cleanup()
+        else:
+            logger.warning(f"Checkpoint file {checkpoint_path} not found. Weights will not be loaded.")
+        return model
+
+    @classmethod
+    def export(
+        cls,
+        model_id: str,
+        config: "PretrainedConfig",
+        neuron_config: "NxDNeuronConfig",
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        force_download: Optional[bool] = False,
+        subfolder: Optional[str] = "",
+        local_files_only: Optional[bool] = False,
+        trust_remote_code: Optional[bool] = False,
+        **kwargs,
+    ) -> "NeuronModelForCausalLM":
+        config = AutoConfig.from_pretrained(
+            model_id,
+            token=token,
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            trust_remote_code=trust_remote_code,
+        )
+        # Override torch_dtype in config as it is used by the neuronx_distributed code to cast weights to the correct type
+        config.torch_dtype = neuron_config.torch_dtype
+        context_encoding_model, token_generation_model, speculation_model = cls.create_model_wrappers(
+            model_cls=cls._model_cls,
+            config=config,
+            neuron_config=neuron_config,
+            **kwargs,
+        )
+        model_wrappers = []
+        for wrapper in context_encoding_model, token_generation_model, speculation_model:
+            if wrapper is not None:
+                model_wrappers.append(wrapper)
+        traced_model = NxDPreTrainedModel.compile(
+            neuron_config=neuron_config,
+            model_wrappers=model_wrappers,
+            compiler_args=cls.get_compiler_args(neuron_config),
+        )
+        model = cls(
+            config=config,
+            neuron_config=neuron_config,
+            traced_model=traced_model,
+            context_encoding_model=context_encoding_model,
+            token_generation_model=token_generation_model,
+            speculation_model=speculation_model,
+        )
+        return model
+
+    def _save_pretrained(self, save_directory: Union[str, Path]):
+        model_name_or_path = getattr(self.config, "_name_or_path")
+        # If the model was exported from a local path, we need to save the checkpoint (not that we also shard it)
+        weight_path = model_name_or_path if os.path.isdir(model_name_or_path) else None
+        self.save(save_directory, weight_path=weight_path)

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -800,12 +800,13 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         trust_remote_code: Optional[bool] = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
+        if len(kwargs) > 0:
+            logger.warning("Ignoring the following kwargs as they are not supported by neuron: %s", kwargs.keys())
         neuron_config = cls.get_neuron_config_cls().from_pretrained(model_id)
         context_encoding_model, token_generation_model, speculation_model = cls.create_model_wrappers(
             model_cls=cls._model_cls,
             config=config,
             neuron_config=neuron_config,
-            **kwargs,
         )
         traced_model = torch.jit.load(os.path.join(model_id, cls.COMPILED_MODEL_FILE_NAME))
         model = cls(
@@ -854,6 +855,8 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         trust_remote_code: Optional[bool] = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
+        if len(kwargs) > 0:
+            logger.warning("Ignoring the following kwargs as they are not supported by neuron: %s", kwargs.keys())
         config = AutoConfig.from_pretrained(
             model_id,
             token=token,
@@ -868,7 +871,6 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
             model_cls=cls._model_cls,
             config=config,
             neuron_config=neuron_config,
-            **kwargs,
         )
         model_wrappers = []
         for wrapper in context_encoding_model, token_generation_model, speculation_model:

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple, Union
 import neuronx_distributed as nxd
 import torch
 import torch_xla.core.xla_model as xm
-from huggingface_hub import snapshot_download
+from huggingface_hub import HfApi, snapshot_download
 from neuronx_distributed.operators.argmax import argmax as nxd_argmax
 from neuronx_distributed.parallel_layers.layers import SPMDRank
 from neuronx_distributed.parallel_layers.mappings import (
@@ -921,3 +921,33 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         # If the model was exported from a local path, we need to save the checkpoint (not that we also shard it)
         weight_path = model_name_or_path if os.path.isdir(model_name_or_path) else None
         self.save(save_directory, weight_path=weight_path)
+
+    def push_to_hub(
+        self,
+        save_directory: str,
+        repository_id: str,
+        private: Optional[bool] = None,
+        revision: Optional[str] = None,
+        token: Union[bool, str] = True,
+        endpoint: Optional[str] = None,
+    ) -> str:
+        api = HfApi(endpoint=endpoint)
+
+        api.create_repo(
+            token=token,
+            repo_id=repository_id,
+            exist_ok=True,
+            private=private,
+        )
+        ignore_patterns = []
+        checkpoint_id = self.neuron_config.checkpoint_id
+        if checkpoint_id is not None:
+            # Avoid uploading checkpoints when the original model is available on the hub
+            ignore_patterns = [self.CHECKPOINT_DIR + "/*"]
+        api.upload_folder(
+            repo_id=repository_id,
+            folder_path=save_directory,
+            token=token,
+            revision=revision,
+            ignore_patterns=ignore_patterns,
+        )

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -177,7 +177,7 @@ class NxDDecoderModel(nn.Module):
         return past_key_values
 
     def _is_reorder_needed(self, is_for_context_encoding, is_for_speculation):
-        return not is_for_context_encoding and not is_for_speculation and self.neuron_config.is_continuous_batching
+        return not is_for_context_encoding and not is_for_speculation and self.neuron_config.continuous_batching
 
     def forward(
         self,

--- a/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/README.md
+++ b/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/README.md
@@ -1,0 +1,25 @@
+# Flash Decoding
+
+Flash decoding supports long context inference by reducing KV cache memory. This is done by sharding and distributing 
+cache storage instead of replicating it on multiple devices (cores).
+
+Flash decoding lives in context of GQA (group query attention). This means it is a feature on top of GQA and not 
+traditional MHA (multi-head attention). In GQA we replicate the KV cache in the devices within the same KV group. 
+Now instead of replicating, we shard the KV and distribute them in each device of the group. To accommodate this setup, 
+we modify the attention computation as below:
+1) Gather all query heads in the group, 
+2) Compute partial softmax on each device, 
+3) Reduce-scatter in the end to get the complete result.
+
+## User guide
+Simply add `flash_decoding_enabled` to be True.
+- `generation_demo`: set it inside `examples/generation_demo.py` when constructing `NeuronConfig`.
+- `inference_demo`: add the flag `--flash-decoding-enabled`.
+
+## Development
+
+We onboarded LLAMA onto this feature and use it for reference. To enable flash decoding for a new model (dense LLM for now), you need modify below:
+- Override `add_derived_config` to set `num_cores_per_group` based on model configuration. See LLAMA example in `src/neuronx_distributed_inference/models/llama/modeling_llama.py`
+- Modify `convert_hf_to_neuron_state_dict` to facilitate rank usage in base model. See LLAMA example in `src/neuronx_distributed_inference/models/llama/modeling_llama.py`
+
+

--- a/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/README.md
+++ b/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/README.md
@@ -3,10 +3,9 @@
 Flash decoding supports long context inference by reducing KV cache memory. This is done by sharding and distributing 
 cache storage instead of replicating it on multiple devices (cores).
 
-Flash decoding lives in context of GQA (group query attention). This means it is a feature on top of GQA and not 
-traditional MHA (multi-head attention). In GQA we replicate the KV cache in the devices within the same KV group. 
-Now instead of replicating, we shard the KV and distribute them in each device of the group. To accommodate this setup, 
-we modify the attention computation as below:
+Flash decoding lives in the context of GQA (group query attention). This means it is a feature on top of GQA and not 
+traditional MHA (multi-head attention). In GQA, we replicate the KV cache in the devices within the same KV group. 
+Now, instead of replicating, we shard the KV and distribute them to each device in the group. To accommodate this setup, we modify the attention computation as follows:
 1) Gather all query heads in the group, 
 2) Compute partial softmax on each device, 
 3) Reduce-scatter in the end to get the complete result.

--- a/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/flashdecode/utils.py
 from typing import Tuple
 
 import torch

--- a/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/flashdecode/utils.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Tuple
+
+import torch
+from neuronx_distributed.parallel_layers.utils import divide
+
+
+# Theoretically one should enough to avoid writing true value to garbage pos (last pos of the cache),
+# pick 128 as is more compatible with compiler
+EXTRA_RESERVED_SPACE = 128
+
+
+def get_cache_size(seq_len, num_cores_per_group):
+    return divide(seq_len, num_cores_per_group) + EXTRA_RESERVED_SPACE
+
+
+def turn_2d_mask_to_4d(attention_mask, n_positions, batch_size):
+    return attention_mask[:, None, None, :].expand(batch_size, 1, 1, n_positions).to(torch.bool)
+
+
+def calculate_num_cores_per_group(num_attn_heads, num_kv_heads, tp_degree):
+    assert num_attn_heads % tp_degree == 0, (
+        f"expect num attention heads is multiples of tp degree but got {num_attn_heads} and {tp_degree}"
+    )
+    num_cores_per_group = divide(min(tp_degree, num_attn_heads), num_kv_heads)
+    return num_cores_per_group
+
+
+def mask_util(
+    pos_ids: torch.Tensor, rank_id: torch.Tensor, num_cores_per_group: int, cache_size: int
+) -> (Tuple)[torch.Tensor, torch.Tensor]:
+    """
+    @:param pos_ids: 2d [bsz x n_active_tokens] tensor represents position ids for all sequences in a batch
+    @:param rank_id: current rank of the device
+    @:return num_cores_per_group: number of cores per kv group
+    @:param cache_size: size of the cache per core
+    """
+    assert pos_ids.dim() == 2, f"position ids have to be 2D for shape {pos_ids.shape}"
+    batch_sz, n_active_tokens = pos_ids.shape
+
+    # Core layout: 32 cores on 8 kv group (col) and 4 cores in each group
+    #     0, 1, 2, 3, 4, 5, 6, 7
+    # -------------------------------
+    # 0 | 0, 4, 8, 12, 16, 20, 24, 28
+    # 1 | 1, 5, 9, 13, 17, 21, 25, 29
+    # 2 | 2, 6, 10, 14, 18, 22, 26, 30
+    # 3 | 3, 7, 11, 15, 19, 23, 27, 31
+    # -------------------------------
+    # for rank id == 19:
+    # the rank_id_in_kv_group (row index) is 3, derived by 19 % 4
+
+    rank_id = torch.remainder(rank_id, num_cores_per_group)
+
+    # active masks: select only one core to update active KV
+    selected_core_idx = torch.remainder(pos_ids, num_cores_per_group)
+    active_masks = torch.where(selected_core_idx == rank_id, 1, 0).to(dtype=pos_ids.dtype)
+    if n_active_tokens > 1:  # speculation
+        active_masks_causal = torch.full(
+            (n_active_tokens, n_active_tokens),
+            1,
+            device=pos_ids.device,
+        ).tril(diagonal=0)
+        active_masks_causal = active_masks_causal[None, :, :].expand(batch_sz, n_active_tokens, n_active_tokens)
+        active_masks = active_masks[:, None, :].expand(batch_sz, n_active_tokens, n_active_tokens)
+        active_masks = torch.logical_and(active_masks, active_masks_causal).to(dtype=pos_ids.dtype)
+
+    # prior masks: infer and update it
+
+    # Cache layout within 1 kv group: 4 cores (row) and each has 8 positions (col), that is cache_size=8
+    # Note num of positions = bucket_sz//num_cores_per_kv_group
+    #     0, 1, 2, 3, 4, 5, 6, 7
+    # -------------------------------
+    # 0 | 0, 4, 8, 12, 16, 20, 24, 28
+    # 1 | 1, 5, 9, 13, 17, 21, 25, 29
+    # 2 | 2, 6, 10, 14, 18, 22, 26, 30
+    # 3 | 3, 7, 11, 15, 19, 23, 27, 31
+    # -------------------------------
+    # for pos_id = 19:
+    # the selected_pos for prior masks to be updated (col index) is 4, derived by 19 // 4
+
+    # selected_pos = torch.div(pos_ids, num_cores_per_group, rounding_mode="floor")
+    num_processed_tokens = pos_ids.min(dim=-1, keepdim=True).values if n_active_tokens > 1 else pos_ids
+    selected_pos = torch.div(
+        torch.subtract(torch.add(num_processed_tokens, num_cores_per_group - 1), rank_id),
+        num_cores_per_group,
+        rounding_mode="floor",
+    )
+    mask_shape = (batch_sz, n_active_tokens, cache_size) if n_active_tokens > 1 else (batch_sz, cache_size)
+    # init prior mask: set True from the start to the selected_pos, and the rest False
+    position_ids_to_compare = (
+        selected_pos.unsqueeze(-1).expand(mask_shape) if n_active_tokens > 1 else selected_pos.expand(mask_shape)
+    )
+    mask = torch.arange(cache_size, device=pos_ids.device).expand(mask_shape)
+    prior_masks = torch.where(position_ids_to_compare > mask, 1, 0).to(dtype=pos_ids.dtype)
+
+    return active_masks, prior_masks

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/__init__.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -1,0 +1,377 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+from typing import Any, Dict, Optional, Union
+
+import torch
+from transformers import GenerationConfig
+from transformers.generation import GenerationMixin, SampleDecoderOnlyOutput
+from transformers.generation.logits_process import LogitsProcessorList
+from transformers.generation.stopping_criteria import StoppingCriteriaList
+from transformers.modeling_outputs import ModelOutput
+
+from .sampling import (
+    Sampler,
+    prepare_sampling_params,
+)
+
+
+class NxDGenerationMixin(GenerationMixin):
+    """A generation Mixin that can be used to extend NxDPreTrainedModel based classes"""
+
+    # These are expected to be set by the GenerationMixin code
+    main_input_name = "input_ids"
+    _is_stateful = False
+    _supports_cache_class = False
+
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        assert hasattr(self, "neuron_config")  # Must be set by the super class
+        # Initialize default generation config
+        self.generation_config = GenerationConfig.from_model_config(config)
+        self.sampler = None
+
+    def can_generate(self):
+        # Still required in transformers <= 4.50
+        return True
+
+    def generate(self, *args, **kwargs):
+        # Keep generation stateless.
+        self.reset()
+        return super().generate(*args, **kwargs)
+
+    # TODO: Remove _sample and define separate flow for on-device sampling that doesn't use HF.
+    def _sample(
+        self,
+        input_ids: torch.LongTensor,
+        logits_processor: LogitsProcessorList,
+        stopping_criteria: StoppingCriteriaList,
+        generation_config: GenerationConfig,
+        logits_warper: Optional[LogitsProcessorList] = None,
+        **model_kwargs,
+    ) -> Union[SampleDecoderOnlyOutput, torch.LongTensor]:
+        r"""
+        We override the GenerationMixin sample function (_sample for transformers>=4.39.0) to add support for right side padding.
+        """
+
+        # init values
+        logits_warper = logits_warper if logits_warper is not None else LogitsProcessorList()
+        pad_token_id = generation_config._pad_token_tensor
+        output_scores = generation_config.output_scores
+        output_logits = generation_config.output_logits
+        return_dict_in_generate = generation_config.return_dict_in_generate
+        has_eos_stopping_criteria = any(hasattr(criteria, "eos_token_id") for criteria in stopping_criteria)
+        do_sample = generation_config.do_sample
+
+        batch_size = model_kwargs["attention_mask"].shape[0]
+        sampling_params = prepare_sampling_params(
+            batch_size=batch_size,
+            top_k=generation_config.top_k,
+            top_p=generation_config.top_p,
+            temperature=generation_config.temperature,
+        )
+        model_kwargs["sampling_params"] = sampling_params
+
+        # init scores / logits tuples
+        scores = () if (return_dict_in_generate and output_scores) else None
+        raw_logits = () if (return_dict_in_generate and output_logits) else None
+
+        # keep track of which sequences are already finished
+        unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
+
+        this_peer_finished = False
+        is_for_token_generation = False
+        # auto-regressive generation
+        while not this_peer_finished:
+            # prepare model inputs
+            model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+            model_kwargs["attention_mask"] = model_inputs.get("attention_mask")
+
+            # forward pass to get next token
+            outputs = self.forward(**model_inputs, return_dict=True)
+
+            if self.neuron_config.on_device_sampling:
+                next_tokens = outputs.tokens
+            else:
+                next_token_logits = outputs.logits[:, -1, :].clone()
+
+                # pre-process distribution
+                next_token_scores = logits_processor(input_ids, next_token_logits)
+                if do_sample:
+                    next_token_scores = logits_warper(input_ids, next_token_scores)
+
+                if return_dict_in_generate:
+                    if output_scores:
+                        scores += (next_token_scores,)
+                    if output_logits:
+                        raw_logits += (next_token_logits,)
+
+                if self.sampler is None:
+                    self.sampler = Sampler(do_sample=True, max_topk=self.neuron_config.max_topk, on_cpu=True)
+
+                next_tokens = self.sampler(next_token_scores, sampling_params)
+
+            # finished sentences should have their next token be a padding token
+            if has_eos_stopping_criteria:
+                next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
+
+            # update generated ids, model inputs, and length for next step
+            input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
+
+            model_kwargs = self._update_model_kwargs_for_generation(
+                outputs, model_kwargs, is_for_token_generation=is_for_token_generation
+            )
+            is_for_token_generation = True
+
+            unfinished_sequences = unfinished_sequences & ~stopping_criteria(input_ids, None)
+            this_peer_finished = unfinished_sequences.max() == 0
+
+        if return_dict_in_generate:
+            return SampleDecoderOnlyOutput(
+                sequences=input_ids,
+                scores=scores,
+                logits=raw_logits,
+            )
+        else:
+            return input_ids
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        attention_mask=None,
+        sampling_params=None,
+        **kwargs,
+    ):
+        if self.kv_cache_populated:
+            input_ids = input_ids[:, -1:]
+
+        position_ids = kwargs.get("position_ids", None)
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if self.kv_cache_populated:
+                position_ids = torch.amax(position_ids, 1, keepdim=True)
+                position_ids = position_ids + 1
+
+        model_inputs = {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "attention_mask": attention_mask,
+            "sampling_params": sampling_params,
+        }
+
+        # WARNING: This is needed for propagating additional kwargs to the neuron model
+        additional_kwargs = self.get_required_kwargs()
+        for arg in additional_kwargs:
+            model_inputs.update({arg: kwargs.get(arg, None)})
+
+        return model_inputs
+
+    # We override this function because we want to change the way attention_mask
+    # is updated each iteration.
+    def _update_model_kwargs_for_generation(
+        self,
+        outputs: ModelOutput,
+        model_kwargs: Dict[str, Any],
+        is_for_token_generation: bool,
+    ) -> Dict[str, Any]:
+        if getattr(outputs, "state", None) is not None:
+            model_kwargs["state"] = outputs.state
+
+        # update token_type_ids with last value
+        if "token_type_ids" in model_kwargs:
+            token_type_ids = model_kwargs["token_type_ids"]
+            model_kwargs["token_type_ids"] = torch.cat([token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
+
+        # update attention mask
+        if "attention_mask" in model_kwargs:
+            attention_mask = model_kwargs["attention_mask"]
+            if is_for_token_generation:
+                if self.neuron_config.padding_side == "left":
+                    attention_mask = torch.cat(
+                        [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))],
+                        dim=-1,
+                    )
+                    attention_mask = attention_mask[:, 1:]
+                else:
+                    attention_mask = torch.cat(
+                        [attention_mask.new_ones((attention_mask.shape[0], 1)), attention_mask],
+                        dim=-1,
+                    )
+            model_kwargs["attention_mask"] = attention_mask
+        return model_kwargs
+
+    def _assisted_decoding(
+        self,
+        input_ids: torch.LongTensor,
+        candidate_generator: "CandidateGenerator",  # noqa
+        stopping_criteria: StoppingCriteriaList,
+        generation_config: GenerationConfig,
+        **model_kwargs,
+    ):
+        pad_token_id = generation_config.pad_token_id
+        eos_token_id = generation_config.eos_token_id
+        assistant_model = candidate_generator.assistant_model
+
+        # Initialize the num_assistant_tokens used for speculation.
+        if hasattr(assistant_model, "num_assistant_tokens"):
+            num_assistant_tokens = assistant_model.num_assistant_tokens
+        else:
+            num_assistant_tokens = assistant_model.generation_config.num_assistant_tokens
+
+        # Init values
+        if eos_token_id is not None and pad_token_id is None:
+            raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
+        if isinstance(eos_token_id, int):
+            eos_token_id = [eos_token_id]
+        eos_token_id_tensor = torch.tensor(eos_token_id).to(input_ids.device) if eos_token_id is not None else None
+
+        # Prepare assistant model's keys of inputs
+        assistant_kwargs = copy.deepcopy(model_kwargs)
+
+        # Other auxiliary variables
+        max_len = stopping_criteria[0].max_length
+        cur_len = input_ids.shape[-1]
+        spec_len = self.neuron_config.speculation_length
+
+        # Run the target model once and get the first generated token
+        model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+        outputs = self.forward(**model_inputs)
+
+        curr_pos = model_inputs["position_ids"][0].argmax(dim=-1)
+        new_token = outputs.logits[:, 0].argmax(dim=-1, keepdim=True)
+
+        # Prepare the input ids and attention mask for the draft model
+        candidate_input_ids = input_ids
+
+        # This is the finally return outputs; append the first generated token
+        returned_ids = torch.cat((input_ids[:, : curr_pos + 1], new_token), dim=1)
+
+        # Speculation loop
+        while True:
+            # 1 Token generation using draft model
+            for _ in range(int(num_assistant_tokens)):
+                # 1.1 Prepare assistant model inputs
+                assistant_inputs = assistant_model.prepare_inputs_for_generation(
+                    candidate_input_ids,
+                    **assistant_kwargs,
+                )
+                is_for_token_generation = assistant_model.kv_cache_populated
+
+                # 1.2 Use the assistant model to obtain the next candidate logits
+                assistant_model_outputs = assistant_model.forward(**assistant_inputs)
+                assistant_new_token = assistant_model_outputs.logits[:, 0, :].argmax(dim=-1)
+
+                # 1.3 Update inputs and args for next iteration
+                candidate_input_ids = torch.cat((candidate_input_ids, assistant_new_token[:, None]), dim=-1)
+                assistant_kwargs = assistant_model._update_model_kwargs_for_generation(
+                    assistant_model_outputs,
+                    assistant_kwargs,
+                    is_for_token_generation,
+                )
+
+                # 1.4 Stop assistant generation on EOS
+                if eos_token_id_tensor is not None:
+                    last_assistant_token_is_eos = assistant_new_token.tile(eos_token_id_tensor.shape[0], 1)
+                    last_assistant_token_is_eos = (
+                        ~last_assistant_token_is_eos.ne(eos_token_id_tensor.unsqueeze(1)).prod(dim=0).bool()
+                    )
+                    if last_assistant_token_is_eos:
+                        break
+                else:
+                    last_assistant_token_is_eos = False
+
+            # 2 Validation of draft model output using the original model
+            #   The length could be shorter if the draft loop ends earlier
+            candidate_length = candidate_input_ids.shape[1] - input_ids.shape[1]
+
+            # 2.1 Prepare the input arguments
+            input_ids = torch.cat((new_token, candidate_input_ids[:, -candidate_length:-1]), dim=-1)
+            attention_mask = model_inputs["attention_mask"]
+            pos = curr_pos + 1
+            position_ids = torch.arange(pos, pos + spec_len).expand(1, spec_len)
+            # Pad the input_ids if needed
+            if input_ids.shape[-1] < spec_len:
+                input_ids = torch.cat(
+                    (input_ids, torch.full((1, spec_len - input_ids.shape[-1]), pad_token_id)),
+                    dim=-1,
+                )
+
+            # 2.2. Run a forward pass on the candidate sequence
+            outputs = self.forward(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+            )
+
+            # 2.3. Process the new logits
+            new_tokens = outputs.logits.argmax(dim=-1)
+            selected_tokens = outputs.logits[:, : candidate_length - 1].argmax(dim=-1)
+
+            # 3. Compare the argmax from the original model logits with the assistant forecasted tokens. We can keep
+            # the assistant forecasted tokens until the first mismatch, or until the max length is reached.
+            candidate_new_tokens = candidate_input_ids[:, -candidate_length:-1]
+            n_matches = ((~(candidate_new_tokens == selected_tokens)).cumsum(dim=-1) < 1).sum()
+
+            # 4. Ensure we don't generate beyond max_len or an EOS token
+            if last_assistant_token_is_eos and n_matches == candidate_length:
+                n_matches -= 1
+            n_matches = min(n_matches, max_len - cur_len - 1)
+            # n_matches = 4
+
+            # 5. Get the valid continuation, after the matching tokens. We also consider the extra token
+            # generated by the original model. Update the return ids accordingly
+            valid_tokens = new_tokens[:, : n_matches + 1]
+            returned_ids = torch.cat((returned_ids, valid_tokens), dim=1)
+            # if last_assistant_token_is_eos and n_matches == candidate_length-1:
+            #    break;
+
+            # 6. Update the args for the next iteration.
+            #    Feed the last correct token to the next loop
+            new_token = valid_tokens[:, -1:]
+            if new_token[0] in torch.tensor(eos_token_id):
+                break
+            input_ids = valid_tokens[:, -1:]
+            candidate_input_ids = valid_tokens[:, -1:]
+            model_inputs_attn_mask = model_inputs["attention_mask"]
+            n_matches_concat_tensor = torch.zeros(1, n_matches + 1, dtype=model_inputs_attn_mask.dtype)
+            model_inputs_attn_mask = torch.cat([model_inputs_attn_mask, n_matches_concat_tensor], dim=-1)
+            model_inputs["attention_mask"] = model_inputs_attn_mask.index_fill(
+                1, torch.arange(curr_pos + 1, curr_pos + 1 + n_matches + 1), 1
+            )
+
+            curr_pos = curr_pos + n_matches + 1
+            assistant_kwargs["attention_mask"] = copy.deepcopy(model_inputs["attention_mask"])
+
+            # 7. Update with the generated token length and check for stopping condition.
+            cur_len = cur_len + n_matches + 1
+            if cur_len >= max_len:
+                break
+            # 8. If the rest length is smaller than speculation length, we directly run the target model to finish
+            if max_len - cur_len < spec_len:
+                # @yihsian: TODO: complete with using target tokengen model
+                break
+
+        return returned_ids
+
+    @property
+    def device(self) -> torch.device:
+        """
+        `torch.device`: The device on which the module is (assuming that all the module parameters are on the same
+        device).
+        """
+        # We dont want HF to move parameters to device
+        return torch.device("cpu")

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/generation/sampling.py
 import logging
 from typing import Optional, Union
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
@@ -1,0 +1,266 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Optional, Union
+
+import torch
+from neuronx_distributed.operators.argmax import argmax as nxd_argmax
+from neuronx_distributed.operators.topk import topk as nxd_topk
+from neuronx_distributed.parallel_layers import parallel_state
+from torch_neuronx.xla_impl.ops import xla_hlo_call
+
+
+logger = logging.getLogger("Neuron")
+
+
+@xla_hlo_call
+def rand_like(tensor):
+    dtype = tensor.dtype
+    shape = tensor.sizes
+    minimum = dtype.Constant(constant_value=0)
+    maximum = dtype.Constant(constant_value=1)
+    return dtype[shape].Rng(minimum, maximum, distribution=1)  # Uniform distribution
+
+
+def validate_sampling_params(params: torch.Tensor, max_topk: int) -> None:
+    """
+    Validates sampling parameters for language models.
+
+    Args:
+    params (torch.Tensor): Tensor of shape (batch_size, 3) containing sampling parameters
+                           in the order: top-k, top-p, temperature.
+    max_topk (int): The maximum number of top tokens to sample from.
+
+    Raises:
+    ValueError: If any of the parameters are invalid.
+    """
+    if params.shape[1] != 3:
+        raise ValueError(f"Expected tensor of shape (batch_size, 3), but got {params.shape}")
+
+    # autocast params tensor to float32
+    params = params.to(torch.float32)
+
+    # Unpack parameters
+    top_k, top_p, temperature = params[:, 0], params[:, 1], params[:, 2]
+
+    # Validate top-k value range
+    valid_top_k = (top_k == -1) | ((top_k > 0) & (top_k <= max_topk))
+    if not torch.all(valid_top_k):
+        raise ValueError(
+            f"Invalid top-k values found. top-k must be -1 or greater than 0 but less than or equal to {max_topk}. Found {top_k}."
+        )
+
+    # checks if top-k values can be represented as integers
+    if not torch.equal(top_k, top_k.floor()):
+        raise ValueError(
+            f"Invalid top-k values found. top-k values should be able to be represented as integer values, but found decimal parts. Found {top_k=}."
+        )
+
+    # Validate top-p
+    valid_top_p = (top_p > 0.0) & (top_p <= 1.0)
+    if not torch.all(valid_top_p):
+        raise ValueError(f"Invalid top-p values found. top-p must be in the range (0.0, 1.0]. Found {top_p=}.")
+
+    # Validate temperature
+    valid_temp = temperature > 0.0
+    if not torch.all(valid_temp):
+        raise ValueError(
+            f"Invalid temperature values found. Temperature must be strictly greater than 0.0. Found {temperature=}."
+        )
+
+
+def prepare_sampling_params(batch_size, top_k=[1], top_p=[1.0], temperature=[1.0]):
+    top_k = prepare_tensor(top_k)
+    top_p = prepare_tensor(top_p)
+    temperature = prepare_tensor(temperature)
+
+    assert top_k.shape[0] == top_p.shape[0] == temperature.shape[0], (
+        f"sampling params shapes don't match. \
+        Got top_k shape: {top_k.shape}, top_p shape: {top_p.shape}, temperature shape: {temperature.shape}"
+    )
+
+    if top_k.shape[0] == 1:
+        top_k = top_k.broadcast_to(batch_size)
+        top_p = top_p.broadcast_to(batch_size)
+        temperature = temperature.broadcast_to(batch_size)
+    stacked = torch.stack([top_k, top_p, temperature], dim=1)
+    return stacked
+
+
+def prepare_tensor(val: Union[torch.Tensor, list, float]):
+    if not torch.is_tensor(val):
+        if not isinstance(val, list):
+            val = [val]
+        val = torch.tensor(val)
+    return val
+
+
+class Sampler(torch.nn.Module):
+    """Add sampling code to the model graph.
+
+    The sampling method is set when compiling the model, and cannot be changed at runtime.
+    If the model was compiled for multinomial sampling, it is still possible
+    to perform greedy sampling by passing top_k=1 and top_p=1.0.
+    On the other hand, if the model was compiled for greedy sampling, it is not
+    possible to perform multinomial sampling at runtime.
+    For that reason, multinomial sampling is the default sampling method.
+
+    Args:
+        do_sample(`Optional[bool]`): whether to use sampling or not. If False, argmax sampling is used, whatever sampling parameters are passed at runtime.
+        max_topk(`Optional[int]`): the maximum number of top tokens to sample from. It is used to optimize calculations
+        by performing a single topk operation on all logits in a batch then apply a mask by sequence instead of
+        applying top_k on each sequence in the batch individually. Defaults to 0, which means no optimization.
+        on_cpu(`Optional[bool]`): whether to run on CPU or not
+    """
+
+    def __init__(self, do_sample: Optional[bool] = True, max_topk: Optional[int] = 0, on_cpu=False):
+        super().__init__()
+        if not do_sample:
+            logger.warning("Greedy sampling is used. Sampling parameters will be ignored at runtime.")
+        self.do_sample = do_sample
+        if max_topk < 0:
+            logger.warning("max_topk optimization is disabled: this can lead to extremely long compilation times.")
+        self.max_topk = max_topk
+        self.IGNORED_LOGITS_VALUE = -3000  # large negative values will be transformed to ~0 in softmax, this is to ignore tokens that are beyond topk range
+
+        self.on_cpu = on_cpu
+        if on_cpu:
+            self.process_group = None
+        else:
+            self.process_group = parallel_state.get_tensor_model_parallel_group()
+
+    def _soft_max(self, logits, dim):
+        return torch.nn.functional.softmax(input=logits, dim=dim)
+
+    def _top_k_masked(self, logits, top_k, dim):
+        if self.max_topk > 0:
+            if self.on_cpu:
+                sorted_logits, indeces = torch.topk(input=logits, k=self.max_topk, dim=dim)
+            else:
+                sorted_logits, indeces = nxd_topk(
+                    tensor=logits,
+                    k=self.max_topk,
+                    dim=dim,
+                    gather_dim=dim,
+                    process_group=self.process_group,
+                )
+        else:
+            sorted_logits, indeces = torch.sort(input=logits, dim=dim, descending=True)
+
+        vocab_size = sorted_logits.shape[-1]
+        mask = torch.arange(vocab_size, device=logits.device)
+        mask = mask.broadcast_to(*sorted_logits.shape)
+
+        mask = torch.greater_equal(mask, top_k)
+        sorted_logits = sorted_logits.masked_fill_(mask, self.IGNORED_LOGITS_VALUE)
+        return sorted_logits, indeces
+
+    def _top_p(self, top_k_logits_values, probs_cumsum, top_p, dim):
+        top_p_mask = torch.greater(probs_cumsum, top_p)
+        top_k_logits_values = top_k_logits_values.masked_fill_(top_p_mask, self.IGNORED_LOGITS_VALUE)
+        probs_soft_max = self._soft_max(top_k_logits_values, dim)  # custom call
+        probs_cumsum = torch.cumsum(input=probs_soft_max, dim=dim)
+        return probs_cumsum
+
+    def _rand_selector(self, probs_cumsum, num_samples=1):
+        return torch.full((probs_cumsum.shape[0], num_samples), 0.5, device=probs_cumsum.device)
+
+    def _multinomial(self, probs, dim, num_samples=1):
+        probs_cumsum = torch.cumsum(input=probs, dim=dim)
+        rand_selector = self._rand_selector(probs_cumsum, num_samples)
+        greater_than_rand = torch.greater(rand_selector, probs_cumsum)
+        counts = torch.sum(greater_than_rand, dim=dim).unsqueeze(dim)
+        return counts
+
+    def _argmax_sample(self, token_logits, return_values, dim):
+        if self.on_cpu:
+            return torch.argmax(token_logits, dim=dim)
+        else:
+            # distributed argmax
+            tokens = nxd_argmax(
+                tensor=token_logits,
+                dim=dim,
+                gather_dim=dim,
+                keepdim=False,
+                process_group=self.process_group,
+            )
+            values = torch.ones(tokens.shape, dtype=token_logits.dtype, device=tokens.device)
+            if return_values:
+                return tokens, values
+            return tokens
+
+    def _multinomial_sample(self, token_logits, sampling_params, return_values, dim):
+        batch_size = token_logits.shape[0]
+        top_k = sampling_params[:, 0].reshape(batch_size, 1)
+        top_p = sampling_params[:, 1].reshape(batch_size, 1)
+        temperature = sampling_params[:, 2].reshape(batch_size, 1)
+
+        # Apply top_k first
+        top_k_logits_values, top_k_logits_indices = self._top_k_masked(token_logits, top_k, dim)
+
+        # Apply temperature
+        top_k_logits_values = torch.divide(top_k_logits_values, temperature)
+
+        # Apply top_p
+        probs_soft_max = self._soft_max(top_k_logits_values, dim)
+        probs_cumsum = torch.cumsum(input=probs_soft_max, dim=dim)
+        top_p = torch.max(torch.min(probs_cumsum), top_p)
+        top_p_mask = torch.greater(probs_cumsum, top_p).index_fill_(
+            dim, torch.tensor([0], device=top_p.device), False
+        )  # need to keep at least one token
+        top_k_logits_values = top_k_logits_values.masked_fill_(top_p_mask, self.IGNORED_LOGITS_VALUE)
+
+        probs_soft_max = self._soft_max(top_k_logits_values, dim)  # custom call
+        if return_values:
+            return top_k_logits_indices, probs_soft_max
+
+        counts = self._multinomial(probs_soft_max, dim)
+        return torch.gather(input=top_k_logits_indices, dim=dim, index=counts).flatten()
+
+    def forward(self, token_logits, sampling_params, return_values=False):
+        """
+        forward to perform topk, topp, temperature and multinomial sampling.
+
+        This method is only used when compiling the model, which means that the
+        decision to use multinomial sampling cannot be made at runtime.
+        If the model was compiled for multinomial sampling, it is still possible
+        to perform greedy sampling by passing top_k=1 and top_p=1.0.
+        On the other hand, if the model was compiled for greedy sampling, it is not
+        possible to perform multinomial sampling at runtime.
+        For that reason, multinomial sampling is the default sampling method.
+
+        Inputs:
+            token_logits: tensor whose first dimension is Batch Size
+                and whose final dimension is Vocabulary Size
+            sampling_params: a 2D tensor of size (Batch Size, 3)
+            containing the following sampling params:
+                * top_k: value to use for top_k sampling
+                * top_p: value to use for top_p sampling
+                * temperature: value to use for temperature sampling
+
+        Output:
+            Tensor containing 1 sampled token id per batch size.
+            Output size is (1, Batch Size)
+
+        Note: Using torch.multinomial on device causes trace to hang.
+        This is because torch.multinomial performs a number of distribution
+        validation steps, which is content dependent. Hence we implement multinomial
+        distribution here instead.
+        """
+        dim = len(token_logits.shape) - 1  # vocab_size dimension
+        if self.do_sample:
+            return self._multinomial_sample(token_logits, sampling_params, return_values, dim)
+        else:
+            return self._argmax_sample(token_logits, return_values, dim)

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/kvcache/kv_cache_manager.py
 import logging
 from typing import List
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
@@ -63,7 +63,7 @@ class KVCacheManager(nn.Module):
     def __init__(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig, **kwargs):
         super().__init__()
         self.padding_side = neuron_config.padding_side
-        self.is_continuous_batching = neuron_config.is_continuous_batching
+        self.is_continuous_batching = neuron_config.continuous_batching
         self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
         self.num_cores_per_group = neuron_config.num_cores_per_group
         self.num_kv_head = kwargs["num_kv_head"]

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/kv_cache_manager.py
@@ -1,0 +1,292 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import List
+
+import torch
+from neuronx_distributed.parallel_layers import parallel_state, utils
+from torch import Tensor, nn
+from torch_neuronx.xla_impl.ops import ConcatenateOp
+from transformers import PretrainedConfig
+
+from ...config import NxDNeuronConfig
+from ..attention.gqa import (
+    determine_sharding_strategy,
+    get_shardable_head_counts,
+)
+from ..autobucketing import slice_lhs, slice_rhs
+from ..flashdecode.utils import get_cache_size
+from .utils import fill_prefix
+
+
+def _slice_kv_cacheline(padding_side, seq_len: int, cache: Tensor):
+    if padding_side == "right":
+        return slice_lhs(cache, seq_len, 2)
+    else:
+        max_idx = cache.shape[2]
+        return slice_rhs(cache, seq_len, max_idx, 2)
+
+
+def _gather_slice_into_kv_cacheline(cache, padding_side, seq_len: int, bucket_slice: Tensor):
+    max_idx = cache.shape[2]
+    if padding_side == "right":
+        remaining = slice_rhs(cache, max_idx - seq_len, max_idx, dim=2)
+        if remaining.dtype == torch.float8_e4m3fn:
+            return ConcatenateOp.apply(bucket_slice, remaining, dim=2)
+        return torch.cat([bucket_slice, remaining], dim=2)
+    else:
+        remaining = slice_lhs(cache, max_idx - seq_len, dim=2)
+        if remaining.dtype == torch.float8_e4m3fn:
+            return ConcatenateOp.apply(bucket_slice, remaining, dim=2)
+        return torch.cat([remaining, bucket_slice], dim=2)
+
+
+class KVCacheManager(nn.Module):
+    """
+    Key Value Cache Management.
+    It stores KV cache as a parameter list of the shape (batch_sz, num_kv_head_per_rank, max_len, head_dim),
+    and vends out read and write operations.
+    """
+
+    def __init__(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig, **kwargs):
+        super().__init__()
+        self.padding_side = neuron_config.padding_side
+        self.is_continuous_batching = neuron_config.is_continuous_batching
+        self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
+        self.num_cores_per_group = neuron_config.num_cores_per_group
+        self.num_kv_head = kwargs["num_kv_head"]
+
+        # NOTE: Tiling the sequence dimension of the KV cache enables specific compiler optimizations like cascaded reductions
+        self.is_kv_cache_tiled = False  # TODO: enable this when compiler fixes CR 158191111 (as per NxDI comment)
+        self._init_kv_shape(config, neuron_config)
+
+        num_layer = config.num_hidden_layers
+        dtype = neuron_config.torch_dtype
+        self.past_key_values = nn.ParameterList(
+            [nn.Parameter(torch.zeros(self.kv_shape, dtype=dtype), requires_grad=False) for _ in range(num_layer * 2)]
+        )
+
+    def _get_num_kv_heads_per_rank(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig):
+        tp_degree = neuron_config.tp_degree
+        num_kv_head = self.num_kv_head
+        num_atten_head = config.num_attention_heads
+
+        gqa_sharding_strategy = determine_sharding_strategy(tp_degree, num_kv_head)
+        _, num_key_value_heads = get_shardable_head_counts(
+            tp_degree, num_atten_head, num_kv_head, gqa_sharding_strategy
+        )
+
+        if parallel_state.model_parallel_is_initialized():
+            num_kv_heads_per_rank = utils.divide(num_key_value_heads, tp_degree)
+        else:
+            num_kv_heads_per_rank = num_key_value_heads
+        return num_kv_heads_per_rank
+
+    def _get_hidden_dim_per_head(self, config: PretrainedConfig):
+        hidden_size = config.hidden_size
+        num_atten_head = config.num_attention_heads
+        hidden_dim_per_head = hidden_size // num_atten_head
+        return hidden_dim_per_head
+
+    def _init_kv_shape(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig):
+        max_batch_size = neuron_config.max_batch_size
+        max_len = neuron_config.sequence_length
+        num_kv_heads_per_rank = self._get_num_kv_heads_per_rank(config, neuron_config)
+        hidden_dim_per_head = self._get_hidden_dim_per_head(config)
+
+        if self.flash_decoding_enabled:
+            padded_max_len = max_len
+            if max_len % self.num_cores_per_group != 0:
+                padded_max_len += self.num_cores_per_group - max_len % self.num_cores_per_group
+                logging.warning(
+                    f"Max length needs to be multiples of num_cores_per_group {self.num_cores_per_group}"
+                    f" but got {max_len}. Padding it to {padded_max_len} meet the requirement."
+                )
+            max_len = get_cache_size(padded_max_len, self.num_cores_per_group)
+
+        if self.is_kv_cache_tiled:
+            num_tiles = int(max_len / 128)
+            # KV cache layout : BHS(128 tiled)D
+            self.kv_shape = (
+                max_batch_size,
+                num_kv_heads_per_rank,
+                128,  # Sequence dim is tiled
+                num_tiles,  # max_len = 128 * num_tiles
+                hidden_dim_per_head,
+            )
+        else:
+            # KV cache layout : BHSD
+            self.kv_shape = (
+                max_batch_size,
+                num_kv_heads_per_rank,
+                max_len,
+                hidden_dim_per_head,
+            )
+
+    def get_kv_by_layer_id(self, key_layer_idx, gather_index=None, slice_index=None):
+        k_cache = self.past_key_values[key_layer_idx]
+        v_cache = self.past_key_values[key_layer_idx + 1]
+        return k_cache, v_cache
+
+    def get_cache(self, seq_len: int, skip_slice=False, **kwargs):
+        """
+        Return network (all layers)'s previously cached K and V, up to seq_len.
+
+        :param seq_len: sequence length (or bucket size from auto-bucketing e.g. 128, 512, 1024 etc.)
+        :return: list of tuple of (K, V)
+        """
+        slice_index, gather_index = None, None
+        past_key_values = []
+        for key_layer_idx in range(0, len(self.past_key_values), 2):
+            # get kv per layer
+            k_cache, v_cache = self.get_kv_by_layer_id(
+                key_layer_idx, gather_index=gather_index, slice_index=slice_index
+            )
+
+            if self.is_kv_cache_tiled:
+                # We merge the tiles BHS(128 tiled)D ->  BHSD
+                k_cache = k_cache.reshape(
+                    self.kv_shape[0],
+                    self.kv_shape[1],
+                    self.kv_shape[2] * self.kv_shape[3],
+                    self.kv_shape[4],
+                )
+                v_cache = v_cache.reshape(
+                    self.kv_shape[0],
+                    self.kv_shape[1],
+                    self.kv_shape[2] * self.kv_shape[3],
+                    self.kv_shape[4],
+                )
+
+            # slice for partial view
+            if not skip_slice:
+                k_cache = _slice_kv_cacheline(self.padding_side, seq_len, k_cache)
+                v_cache = _slice_kv_cacheline(self.padding_side, seq_len, v_cache)
+
+            past_key_values.append([k_cache, v_cache])
+        return past_key_values
+
+    def update_cache(
+        self,
+        is_for_context_encoding: bool,
+        seq_ids: Tensor,
+        position_ids: Tensor,
+        new_key_values: List[Tensor],
+        seq_len: int,
+        scatter_index=None,
+        active_mask=None,
+        kvcache_buffer=None,
+    ):
+        """
+        Given the passed-in new_key_values, update the cache
+
+        :param scatter_index: tensor representing index to update
+        :param is_for_context_encoding: bool
+        :param seq_ids: tensor of size (batch_sz)
+        :param position_ids: tensor of size (batch_sz, bucket_sz)
+        :param new_key_values: list of tuple, the latest kv obtained at the end of the network from forward pass
+        :param seq_len: sequence length (or bucket size from auto-bucketing e.g. 128, 512, 1024 etc.)
+        :param scatter_index: tensor representing index to update
+        :param active_mask: tensor representing index to update
+        :param kvcache_buffer: if passed key states are updates to this buffer.
+               kvcache_buffer is 2D list where, 1st dim for layer and the second denotes K and V.
+               For example,
+                    kvcache_buffer[1][0] is the K cache of the 1st layer
+                    kvcache_buffer[4][1] is the V cache of the 4th layer
+        :return: list of tuple of (K, V)
+        """
+        updated_kv_cache = []
+        for idx, kv_per_layer in enumerate(new_key_values):
+            latest_k, latest_v = kv_per_layer[0], kv_per_layer[1]
+
+            if kvcache_buffer is None:
+                cache_shape = self.past_key_values[idx * 2].shape
+                if self.is_kv_cache_tiled:
+                    k_cache_buffer = self.past_key_values[idx * 2].reshape(
+                        cache_shape[0],
+                        cache_shape[1],
+                        cache_shape[2] * cache_shape[3],
+                        cache_shape[4],
+                    )
+                    v_cache_buffer = self.past_key_values[idx * 2 + 1].reshape(
+                        cache_shape[0],
+                        cache_shape[1],
+                        cache_shape[2] * cache_shape[3],
+                        cache_shape[4],
+                    )
+                    k_cache = k_cache_buffer
+                    v_cache = v_cache_buffer
+                else:
+                    k_cache = self.past_key_values[idx * 2]
+                    v_cache = self.past_key_values[idx * 2 + 1]
+
+            else:
+                cache_shape = kvcache_buffer[idx][0].shape
+                k_cache = kvcache_buffer[idx][0]
+                v_cache = kvcache_buffer[idx][1]
+
+            if is_for_context_encoding:
+                if self.is_continuous_batching:
+                    # scatter back to the desired seq_ids
+                    sliced_k_cache = _slice_kv_cacheline(self.padding_side, seq_len, k_cache)
+                    sliced_v_cache = _slice_kv_cacheline(self.padding_side, seq_len, v_cache)
+
+                    seq_id_index_shape = seq_ids.shape[:1] + sliced_k_cache.shape[1:]
+                    seq_id_index = seq_ids.view(-1, 1, 1, 1).expand(seq_id_index_shape)
+
+                    sliced_k_cache = torch.scatter(input=sliced_k_cache, dim=0, index=seq_id_index, src=latest_k)
+                    sliced_v_cache = torch.scatter(input=sliced_v_cache, dim=0, index=seq_id_index, src=latest_v)
+
+                    read_len = sliced_k_cache.shape[2]
+                    k_cache = _gather_slice_into_kv_cacheline(k_cache, self.padding_side, read_len, sliced_k_cache)
+                    v_cache = _gather_slice_into_kv_cacheline(v_cache, self.padding_side, read_len, sliced_v_cache)
+                else:
+                    k_cache = fill_prefix(k_cache, latest_k)
+                    v_cache = fill_prefix(v_cache, latest_v)
+            else:
+                if self.padding_side == "left":
+                    k_cache = k_cache[:, :, 1:, :]
+                    v_cache = v_cache[:, :, 1:, :]
+                    k_cache = torch.cat([k_cache, latest_k], dim=2)
+                    v_cache = torch.cat([v_cache, latest_v], dim=2)
+                else:
+                    # copy the tensor of the new position into kv cache
+                    if self.flash_decoding_enabled:
+                        assert active_mask is not None, "active_mask should be specified for flash decoding!"
+                        garbage_pos = seq_len - 1  # treat last pos as garbage
+                        updated_pos_ids = position_ids // self.num_cores_per_group
+                        scatter_index = torch.where(active_mask == 1, updated_pos_ids, garbage_pos)
+                        scatter_index_new = scatter_index.view(-1, 1, scatter_index.shape[-1], 1).expand_as(latest_k)
+                    else:
+                        scatter_index_new = self._get_index_to_update_new_position(
+                            scatter_index, position_ids, latest_k
+                        )
+                    k_cache = torch.scatter(input=k_cache, dim=2, index=scatter_index_new, src=latest_k)
+                    v_cache = torch.scatter(input=v_cache, dim=2, index=scatter_index_new, src=latest_v)
+
+            # Retiling
+            # TODO once compiler fixes CR 158191111 we can turn back output tiling on
+            # k_cache = k_cache.view(cache_shape)
+            # v_cache = v_cache.view(cache_shape)
+
+            updated_kv_cache.append(k_cache)
+            updated_kv_cache.append(v_cache)
+
+        # return updated kv cache to NxD runtime
+        return updated_kv_cache
+
+    def _get_index_to_update_new_position(self, scatter_index, position_ids, full_k):
+        scatter_index = position_ids.view(-1, 1, position_ids.shape[-1], 1).expand_as(full_k)
+        return scatter_index

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/kvcache/utils.py
 from torch_neuronx.xla_impl.ops import xla_hlo_call
 
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
@@ -1,0 +1,10 @@
+from torch_neuronx.xla_impl.ops import xla_hlo_call
+
+
+@xla_hlo_call
+def fill_prefix(tensor, update):
+    scribe = tensor.scribe
+    dtype = tensor.dtype
+    shape = tensor.sizes
+    start_indices = [scribe.u32.Constant(constant_value=0)] * len(shape)
+    return dtype[shape].DynamicUpdateSlice(tensor, update, *start_indices)

--- a/optimum/neuron/models/inference/nxd/backend/modules/moe.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/moe.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from neuronx_distributed.modules.moe.expert_mlps import ExpertMLPs
+from neuronx_distributed.modules.moe.model import MoE
+from neuronx_distributed.modules.moe.routing import RouterTopK
+
+
+def initialize_moe_module(
+    neuron_config,
+    num_experts,
+    top_k,
+    hidden_size,
+    intermediate_size,
+    hidden_act,
+    normalize_top_k_affinities=True,
+):
+    """
+    Initializes and returns an MoE module corresponding to the given configuration.
+    """
+    router = RouterTopK(
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        sequence_parallel_enabled=neuron_config.sequence_parallel_enabled,
+        sequence_dimension=1,
+    )
+    expert_mlps = ExpertMLPs(
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        hidden_act=hidden_act,
+        capacity_factor=neuron_config.capacity_factor,
+        glu_mlp=neuron_config.glu_mlp,
+        normalize_top_k_affinities=normalize_top_k_affinities,
+    )
+    moe = MoE(
+        router=router,
+        expert_mlps=expert_mlps,
+        sequence_parallel_enabled=neuron_config.sequence_parallel_enabled,
+        sequence_dimension=1,
+    )
+    # Set MoE module in eval mode
+    moe.eval()
+    return moe

--- a/optimum/neuron/models/inference/nxd/backend/modules/moe.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/moe.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/moe.py
 from neuronx_distributed.modules.moe.expert_mlps import ExpertMLPs
 from neuronx_distributed.modules.moe.model import MoE
 from neuronx_distributed.modules.moe.routing import RouterTopK

--- a/optimum/neuron/models/inference/nxd/backend/pretrained_model.py
+++ b/optimum/neuron/models/inference/nxd/backend/pretrained_model.py
@@ -24,6 +24,7 @@ from neuronx_distributed.trace.model_builder import ModelBuilder
 from safetensors.torch import load_file
 from transformers import AutoModelForCausalLM, PretrainedConfig
 
+from .cache import neff_cache
 from .config import NxDNeuronConfig
 from .model_wrapper import NxDModelWrapper
 from .modules.checkpoint import (
@@ -147,7 +148,8 @@ class NxDPreTrainedModel:
     @staticmethod
     def compile(neuron_config, model_wrappers: List[NxDModelWrapper], compiler_args: str, debug: bool = False):
         builder = get_builder(neuron_config, model_wrappers, debug=debug, compiler_args=compiler_args)
-        return builder.trace(initialize_model_weights=False)
+        with neff_cache():
+            return builder.trace(initialize_model_weights=False)
 
     def save(self, dest_path, weight_path: Optional[str] = None):
         if self._traced_model is None:

--- a/optimum/neuron/models/inference/nxd/backend/pretrained_model.py
+++ b/optimum/neuron/models/inference/nxd/backend/pretrained_model.py
@@ -1,0 +1,281 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import logging
+import os
+from functools import partial
+from typing import List, Optional
+
+import neuronx_distributed.trace.hlo_utils as hlo_utils
+import torch
+from neuronx_distributed.trace.model_builder import ModelBuilder
+from safetensors.torch import load_file
+from transformers import AutoModelForCausalLM, PretrainedConfig
+
+from .config import NxDNeuronConfig
+from .model_wrapper import NxDModelWrapper
+from .modules.checkpoint import (
+    load_state_dict,
+)
+from .modules.flashdecode.utils import calculate_num_cores_per_group
+
+
+logger = logging.getLogger("Neuron")
+
+
+def normalize_path(path):
+    """Normalize path separators and ensure path ends with a trailing slash"""
+    normalized = os.path.normpath(path)
+    return os.path.join(normalized, "")
+
+
+def get_shards_path(dest_path):
+    return os.path.join(dest_path, "weights")
+
+
+def get_builder(
+    neuron_config: NxDNeuronConfig,
+    model_wrappers: List[NxDModelWrapper],
+    debug: bool = False,
+    checkpoint_loader=None,
+    compiler_args: str = None,
+):
+    """Creates a ModelBuilder instance for the given model wrappers.
+
+    This function initializes a ModelBuilder with the specified Neuron configuration and model wrappers.
+    It exists to provide a convenient way to create a ModelBuilder instance, and is called by the
+    `NxDPreTrainedModel` class every time a model is compiled or loaded.
+    The returned ModelBuilder instances are typically discarded after having been used to save memory.
+
+    Args:
+        neuron_config (NxDNeuronConfig): The Neuron configuration.
+        model_wrappers (List[NxDModelWrapper]): The model wrappers to be added to the builder.
+        debug (bool): Whether to enable debug mode.
+        checkpoint_loader (callable): A function to load the model's state dictionary and weights.
+        compiler_args (str): Compiler arguments to be passed to the builder.
+    Returns:
+        ModelBuilder: The ModelBuilder instance.
+    """
+    base_compile_work_dir = os.environ.get("BASE_COMPILE_WORK_DIR", "/tmp/nxd_model/")
+
+    builder = ModelBuilder(
+        router=None,
+        tp_degree=neuron_config.tp_degree,
+        pp_degree=neuron_config.pp_degree,
+        ep_degree=neuron_config.ep_degree,
+        world_size=neuron_config.world_size,
+        start_rank_id=neuron_config.start_rank_id,
+        local_ranks_size=neuron_config.local_ranks_size,
+        checkpoint_loader=checkpoint_loader,
+        compiler_workdir=base_compile_work_dir,
+        debug=debug,
+        num_cores_per_group=neuron_config.num_cores_per_group,
+        logical_nc_config=neuron_config.logical_nc_config,
+        weights_to_skip_layout_optimization=neuron_config.weights_to_skip_layout_optimization,
+    )
+    for model in model_wrappers:
+        builder.add(
+            key=model.tag,
+            model_instance=model.get_model_instance(),
+            example_inputs=model.input_generator(),
+            compiler_args=compiler_args,
+            bucket_config=model.get_bucket_config(),
+            priority_model_idx=model.priority_model_idx,
+        )
+    return builder
+
+
+class NxDPreTrainedModel:
+    _STATE_DICT_MODEL_PREFIX = "model."
+    _NEW_STATE_DICT_MODEL_PREFIX = ""
+    _FUSED_PREFIX = ""
+    COMPILED_MODEL_FILE_NAME = "model.pt"
+    CHECKPOINT_DIR = "checkpoint"
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        neuron_config: NxDNeuronConfig,
+        traced_model: torch.jit.ScriptModule,
+        model_wrappers: List[NxDModelWrapper],
+    ):
+        self.config = copy.deepcopy(config)
+        self.neuron_config = copy.deepcopy(neuron_config)
+        # Override torch_dtype in config as it is used by the neuronx_distributed code to cast weights to the correct type
+        self.config.torch_dtype = self.neuron_config.torch_dtype
+        if neuron_config.flash_decoding_enabled:
+            # FIXME: this should not be part of neuron_config but is used in downstream classes
+            # Could it be deduced from tensor shapes ?
+            self.neuron_config.num_cores_per_group = calculate_num_cores_per_group(
+                config.num_attention_heads, config.num_key_value_heads, neuron_config.tp_degree
+            )
+        self._traced_model = traced_model
+        self.model_wrappers = model_wrappers  # Required for loading weights
+        for model_wrapper in self.model_wrappers:
+            model_wrapper.model = self._traced_model
+
+    def forward(self, **kwargs):
+        """Forward pass for this model."""
+        raise NotImplementedError("forward is not implemented")
+
+    @classmethod
+    def get_config_cls(cls) -> PretrainedConfig:
+        """Gets the config class for this model."""
+        raise NotImplementedError("get_config_cls is not implemented")
+
+    @classmethod
+    def get_neuron_config_cls(cls) -> NxDNeuronConfig:
+        raise NotImplementedError("get_neuron_config_cls is not implemented")
+
+    @classmethod
+    def get_compiler_args(cls, neuron_config) -> str:
+        """Gets the Neuron compiler arguments to use when compiling this model."""
+        return None
+
+    @staticmethod
+    def compile(neuron_config, model_wrappers: List[NxDModelWrapper], compiler_args: str, debug: bool = False):
+        builder = get_builder(neuron_config, model_wrappers, debug=debug, compiler_args=compiler_args)
+        return builder.trace(initialize_model_weights=False)
+
+    def save(self, dest_path, weight_path: Optional[str] = None):
+        if self._traced_model is None:
+            raise ValueError("Model has not been compiled or loaded")
+        dest_path = normalize_path(dest_path)
+        self.config.save_pretrained(dest_path)
+        self.neuron_config.save_pretrained(dest_path)
+        torch.jit.save(self._traced_model, dest_path + self.COMPILED_MODEL_FILE_NAME)
+        if weight_path is not None:
+            self.shard_checkpoint(
+                src_path=weight_path,
+                dest_path=os.path.join(dest_path, self.CHECKPOINT_DIR),
+            )
+
+    def shard_checkpoint(self, src_path, dest_path, debug: bool = False):
+        shards_path = get_shards_path(dest_path)
+        checkpoint_loader = partial(self.checkpoint_loader_fn, src_path, self.config, self.neuron_config)
+        sharder = get_builder(
+            self.neuron_config,
+            self.model_wrappers,
+            debug=debug,
+            checkpoint_loader=checkpoint_loader,
+            compiler_args=self.get_compiler_args(self.neuron_config),
+        )
+        sharder.shard_checkpoint(serialize_path=shards_path)
+
+        if hlo_utils.NXD_LAYOUT_TRANSFORMATION_OPTIONS in os.environ:
+            sharder.transform_weight_layout_with_overriden_option(sharded_checkpoint_dir=shards_path)
+
+    def _load_weights(self, weights_path):
+        weights_path = normalize_path(weights_path)
+
+        """Loads the model weights to the Neuron device."""
+        if self._traced_model is None:
+            raise ValueError("Model is not loaded")
+
+        start_rank_id = self.neuron_config.start_rank_id
+        local_ranks_size = self.neuron_config.local_ranks_size
+
+        logging.info(f"loading models for ranks {start_rank_id}...{start_rank_id + local_ranks_size - 1}")
+        weights = []
+        shards_path = get_shards_path(weights_path)
+
+        def get_shard_name(rank):
+            return os.path.join(shards_path, f"tp{rank}_sharded_checkpoint.safetensors")
+
+        if os.path.exists(get_shard_name(start_rank_id)):
+            # If sharded checkpoints exist, load them
+            print(f"Loading sharded checkpoint from {shards_path}")
+            for rank in range(start_rank_id, start_rank_id + local_ranks_size):
+                ckpt = load_file(get_shard_name(rank))
+                weights.append(ckpt)
+        else:
+            print("There are no saved sharded checkpoints.")
+            checkpoint_loader = partial(self.checkpoint_loader_fn, weights_path, self.config, self.neuron_config)
+            sharder = get_builder(
+                self.neuron_config,
+                self.model_wrappers,
+                debug=False,
+                checkpoint_loader=checkpoint_loader,
+                compiler_args=self.get_compiler_args(self.neuron_config),
+            )
+            source_model_key = list(sharder.model_collection.keys())[0]
+            for rank in range(start_rank_id, start_rank_id + local_ranks_size):
+                print(f"Sharding and loading rank {rank}")
+                ckpt = sharder.shard_weights(rank, sharder.model_collection[source_model_key])
+                weights.append(ckpt)
+        start_rank_tensor = torch.tensor([start_rank_id], dtype=torch.int32, device="cpu")
+        self._traced_model.nxd_model.initialize(weights, start_rank_tensor)
+
+    def checkpoint_loader_fn(self, checkpoint_path, config, neuron_config):
+        """This function loads the model's state dictionary and weights from the hf model"""
+
+        model_sd = self.get_state_dict(checkpoint_path, config, neuron_config)
+        if neuron_config.torch_dtype != torch.float32:
+            for name, param in model_sd.items():
+                if torch.is_floating_point(param) and param.dtype is not neuron_config.torch_dtype:
+                    logger.info(f"Converting {name} to {neuron_config.torch_dtype}")
+                    model_sd[name] = param.to(neuron_config.torch_dtype)
+        return model_sd
+
+    @classmethod
+    def get_state_dict(cls, model_path: str, config: PretrainedConfig, neuron_config: NxDNeuronConfig) -> dict:
+        """Gets the state dict for this model."""
+        model_sd = load_state_dict(model_path)
+        param_name_list = list(model_sd.keys())
+        for param_name in param_name_list:
+            if param_name.startswith(cls._STATE_DICT_MODEL_PREFIX):
+                updated_param_name = param_name.replace(
+                    cls._STATE_DICT_MODEL_PREFIX, cls._NEW_STATE_DICT_MODEL_PREFIX, 1
+                )
+                model_sd[updated_param_name] = model_sd[param_name]
+                del model_sd[param_name]
+        model_sd = cls.convert_hf_to_neuron_state_dict(model_sd, config, neuron_config)
+        if getattr(config, "tie_word_embeddings", False):
+            cls.update_state_dict_for_tied_weights(model_sd)
+
+        param_name_list = list(model_sd.keys())
+        if cls._FUSED_PREFIX != "":
+            for param_name in param_name_list:
+                model_sd[f"{cls._FUSED_PREFIX}.{param_name}"] = model_sd[param_name]
+                del model_sd[param_name]
+        return model_sd
+
+    @staticmethod
+    def convert_hf_to_neuron_state_dict(state_dict: dict, config: PretrainedConfig) -> dict:
+        """This function should be over-ridden in child classes as needed"""
+        return state_dict
+
+    @staticmethod
+    def load_hf_model(model_path):
+        """Loads the HuggingFace model from the given checkpoint path."""
+        return AutoModelForCausalLM.from_pretrained(model_path)
+
+    @staticmethod
+    def update_state_dict_for_tied_weights(state_dict):
+        """Implement state_dict update for each model class with tied weights"""
+        raise NotImplementedError("State-dict update not implemented")
+
+    @property
+    def device(self) -> torch.device:
+        """
+        `torch.device`: The device on which the module is (assuming that all the module parameters are on the same
+        device).
+        """
+        # We dont want HF to move parameters to device
+        return torch.device("cpu")
+
+    def reset(self):
+        """Resets the model state. Can be implemented by subclasses."""
+        pass

--- a/optimum/neuron/models/inference/nxd/backend/utils/__init__.py
+++ b/optimum/neuron/models/inference/nxd/backend/utils/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/optimum/neuron/models/inference/nxd/backend/utils/distributed.py
+++ b/optimum/neuron/models/inference/nxd/backend/utils/distributed.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/utils/distributed.py
 import os
 
 

--- a/optimum/neuron/models/inference/nxd/backend/utils/distributed.py
+++ b/optimum/neuron/models/inference/nxd/backend/utils/distributed.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+
+def get_init_world_size() -> int:
+    """Get world size set by distributed launcher (torchrun or mpirun)"""
+    for var in ["WORLD_SIZE", "OMPI_COMM_WORLD_SIZE"]:
+        if var in os.environ and os.environ[var] != "":
+            return int(os.environ[var])
+    return -1
+
+
+def get_init_rank() -> int:
+    """Get rank set by distributed launcher (torchrun or mpirun)"""
+    for var in ["RANK", "OMPI_COMM_WORLD_RANK"]:
+        if var in os.environ and os.environ[var] != "":
+            return int(os.environ[var])
+    return -1

--- a/optimum/neuron/models/inference/nxd/backend/utils/random.py
+++ b/optimum/neuron/models/inference/nxd/backend/utils/random.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+
+import neuronx_distributed as nxd
+import numpy as np
+import torch
+
+
+def set_random_seed(seed):
+    """Set random seed for reproducability."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if nxd.parallel_layers.parallel_state.model_parallel_is_initialized():
+        nxd.parallel_layers.random.model_parallel_xla_manual_seed(seed)

--- a/optimum/neuron/models/inference/nxd/backend/utils/random.py
+++ b/optimum/neuron/models/inference/nxd/backend/utils/random.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/utils/random.py
 import random
 
 import neuronx_distributed as nxd

--- a/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
@@ -541,4 +541,6 @@ class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
             sequence_length=sequence_length,
             tp_degree=tensor_parallel_size,
             torch_dtype=auto_cast_type,
+            on_device_sampling=True,
+            fused_qkv=True,
         )

--- a/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/models/llama/modeling_llama.py
 """PyTorch LLaMA model for NXD inference."""
 
 import gc

--- a/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
@@ -1,0 +1,544 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch LLaMA model for NXD inference."""
+
+import gc
+import logging
+import math
+from typing import Optional, Tuple, Type
+
+import torch
+from neuronx_distributed.parallel_layers import parallel_state
+from neuronx_distributed.parallel_layers.layers import (
+    ColumnParallelLinear,
+    ParallelEmbedding,
+    RowParallelLinear,
+)
+from neuronx_distributed.parallel_layers.mappings import (
+    gather_from_sequence_parallel_region,
+    reduce_from_tensor_model_parallel_region,
+    reduce_scatter_to_sequence_parallel_region,
+)
+from neuronxcc.nki._private_kernels.mlp import (
+    mlp_fused_add_isa_kernel,
+    mlp_isa_kernel,
+)
+from neuronxcc.nki.language import nc
+from torch import nn
+from torch_neuronx.xla_impl.ops import nki_jit
+from transformers.activations import ACT2FN
+from transformers.models.llama.modeling_llama import LlamaConfig, LlamaRMSNorm, LlamaRotaryEmbedding
+
+from ..backend.config import NxDNeuronConfig  # noqa: E402
+from ..backend.modules.attention.attention_base import NeuronAttentionBase
+from ..backend.modules.attention.utils import (
+    RotaryEmbedding,
+    transpose_parallel_linear_layer,
+)
+from ..backend.modules.custom_calls import CustomRMSNorm
+from ..backend.modules.decoder import NxDDecoderModel, NxDModelForCausalLM
+
+
+logger = logging.getLogger("Neuron")
+
+
+def get_rmsnorm_cls():
+    # Initialize to the appropriate implementation of RMSNorm
+    # If infer on NXD -> CustomRMSNorm
+    # If infer on CPU -> HF_RMSNorm (CustomRMSNorm does not work on CPU)
+    return CustomRMSNorm if parallel_state.model_parallel_is_initialized() else LlamaRMSNorm
+
+
+def convert_state_dict_to_fused_qkv(llama_state_dict, cfg: LlamaConfig):
+    """
+    This function concats the qkv weights to a Wqkv weight for fusedqkv, and deletes the qkv weights.
+    """
+    for l in range(cfg.num_hidden_layers):  # noqa: E741
+        llama_state_dict[f"layers.{l}.self_attn.Wqkv.weight"] = torch.cat(
+            [
+                llama_state_dict[f"layers.{l}.self_attn.q_proj.weight"],
+                llama_state_dict[f"layers.{l}.self_attn.k_proj.weight"],
+                llama_state_dict[f"layers.{l}.self_attn.v_proj.weight"],
+            ],
+        )
+        del llama_state_dict[f"layers.{l}.self_attn.q_proj.weight"]
+        del llama_state_dict[f"layers.{l}.self_attn.k_proj.weight"]
+        del llama_state_dict[f"layers.{l}.self_attn.v_proj.weight"]
+
+    gc.collect()
+
+    return llama_state_dict
+
+
+class NeuronLlamaMLP(nn.Module):
+    """
+    This class just replace the linear layers (gate_proj, up_proj and down_proj) with column and row parallel layers
+    """
+
+    def __init__(self, config: LlamaConfig, neuron_config: NxDNeuronConfig):
+        super().__init__()
+        self.tp_degree = neuron_config.tp_degree
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.act_fn = ACT2FN[config.hidden_act]
+
+        self.sequence_parallel_enabled = getattr(neuron_config, "sequence_parallel_enabled", False)
+        self.sequence_dimension = 1 if self.sequence_parallel_enabled else None
+        self.rms_norm_eps = config.rms_norm_eps
+        self.mlp_kernel_enabled = neuron_config.mlp_kernel_enabled
+        self.logical_nc_config = neuron_config.logical_nc_config
+        mlp_bias = getattr(config, "mlp_bias", False)
+        if parallel_state.model_parallel_is_initialized():
+            self.gate_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.intermediate_size,
+                bias=mlp_bias,
+                gather_output=False,
+                dtype=neuron_config.torch_dtype,
+                pad=True,
+                sequence_parallel_enabled=False,
+                sequence_dimension=None,
+            )
+            self.up_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.intermediate_size,
+                bias=mlp_bias,
+                gather_output=False,
+                dtype=neuron_config.torch_dtype,
+                pad=True,
+                sequence_parallel_enabled=False,
+                sequence_dimension=None,
+            )
+            self.down_proj = RowParallelLinear(
+                self.intermediate_size,
+                self.hidden_size,
+                bias=mlp_bias,
+                input_is_parallel=True,
+                dtype=neuron_config.torch_dtype,
+                pad=True,
+                sequence_parallel_enabled=self.sequence_parallel_enabled,
+                sequence_dimension=self.sequence_dimension,
+                reduce_dtype=neuron_config.rpl_reduce_dtype,
+            )
+
+            if self.mlp_kernel_enabled:
+                # Transpose the weights to the layout expected by kernels
+                self.gate_proj.weight = transpose_parallel_linear_layer(self.gate_proj.weight)
+                self.up_proj.weight = transpose_parallel_linear_layer(self.up_proj.weight)
+                self.down_proj.weight = transpose_parallel_linear_layer(self.down_proj.weight)
+
+        else:
+            self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=mlp_bias)
+            self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=mlp_bias)
+            self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=mlp_bias)
+
+    def _kernel_enabled_mlp(self, x, fused_rmsnorm, rmsnorm, residual):
+        fused_residual = residual is not None
+        logger.debug(
+            f"MLP: kernel, fused_residual={fused_residual}, fused_rmsnorm={fused_rmsnorm}, logical_nc_config={self.logical_nc_config}"
+        )
+
+        # Choose which kernel to call
+        if fused_residual:
+            assert not self.sequence_parallel_enabled, (
+                "MLP kernel cannot have both fused residual add and sequence parallel RMSnorm!"
+            )
+            # Using fused residual add
+            _mlp_fwd_call = nki_jit()(mlp_fused_add_isa_kernel)
+        else:
+            _mlp_fwd_call = nki_jit()(mlp_isa_kernel)
+
+        if self.sequence_parallel_enabled:
+            x = gather_from_sequence_parallel_region(x, self.sequence_dimension)
+
+        # Build output tensor
+        output_tensor_seqlen = x.shape[1]
+        if fused_residual:
+            # seqlen dim is doubled to store the residual add output
+            output_tensor_seqlen *= 2
+
+        output_tensor = torch.zeros(
+            size=(
+                x.shape[0],  # batch size
+                output_tensor_seqlen,
+                self.hidden_size,  # hidden size
+            ),
+            dtype=x.dtype,
+            device=x.device,
+        )
+
+        # Grab weights
+        # all weights of the layers are stored in (out, in) shape
+        # unsqueeze so that shape of RMS gamma weight is [1, hidden] instead of [hidden]
+        ln_w = rmsnorm.weight.unsqueeze(0)
+        gate_w = self.gate_proj.weight.data
+        up_w = self.up_proj.weight.data
+        down_w = self.down_proj.weight.data
+
+        grid = (nc(self.logical_nc_config),)
+
+        if fused_residual:
+            _mlp_fwd_call[grid](
+                x,  # attn_output
+                residual,  # hidden
+                ln_w,  # ln_w
+                gate_w,  # gate_w
+                up_w,  # up_w
+                down_w,  # down_w
+                output_tensor,  # out
+                fused_rmsnorm=fused_rmsnorm,
+                eps=self.rms_norm_eps,
+                kernel_name="MLP",
+                store_add=True,
+            )
+            original_seqlen = x.shape[1]
+            residual = output_tensor[:, original_seqlen:, :]
+            output_tensor = output_tensor[:, :original_seqlen, :]
+        else:
+            _mlp_fwd_call[grid](
+                x,  # hidden
+                # should be fine to pass gamma is as a dummy even if not using fused rmsnorm
+                ln_w,
+                gate_w,
+                up_w,
+                down_w,
+                output_tensor,  # out
+                # Run RMSNorm inside the kernel if NOT using SP rmsnorm
+                fused_rmsnorm=fused_rmsnorm,
+                eps=self.rms_norm_eps,
+                kernel_name="MLP",
+            )
+            residual = None
+
+        # All-reduce or reduce-scatter, depending on whether SP is enabled
+        if self.sequence_parallel_enabled:
+            output_tensor = reduce_scatter_to_sequence_parallel_region(output_tensor, self.sequence_dimension)
+        else:
+            output_tensor = reduce_from_tensor_model_parallel_region(output_tensor)
+
+        logger.debug(f"MLP output shape {output_tensor.shape}")
+        return (output_tensor, residual)
+
+    def _native_mlp(self, x, rmsnorm):
+        logger.debug("MLP: native compiler")
+        # all-gather is done here instead of CPL layers to
+        # avoid 2 all-gathers from up and gate projections
+        if self.sequence_parallel_enabled:
+            x = gather_from_sequence_parallel_region(x, self.sequence_dimension)
+
+        gate_proj_output = self.gate_proj(x)
+        up_proj_output = self.up_proj(x)
+        down_proj_input = self.act_fn(gate_proj_output) * up_proj_output
+        output = self.down_proj(down_proj_input)
+        logger.debug(f"MLP output shape {output.shape}")
+        return output
+
+    def forward(self, x, rmsnorm=None, residual=None):
+        """
+        If residual is passed in, will fuse its add into the MLP kernel
+
+        Returns a tuple of (output, residual), where residual is the output of the residual add
+        """
+        if self.mlp_kernel_enabled:
+            fused_rmsnorm = not self.sequence_parallel_enabled
+            # MLP kernel
+            return self._kernel_enabled_mlp(x, fused_rmsnorm, rmsnorm, residual)
+        else:
+            # No kernel
+            return (self._native_mlp(x, rmsnorm), None)
+
+
+class NeuronLlamaAttention(NeuronAttentionBase):
+    """
+    Compared with LlamaAttention, this class just
+    1. replaces the q_proj, k_proj, v_proj with column parallel layer
+    2. replaces the o_proj with row parallel layer
+    3. update self.num_head to be self.num_head / tp_degree
+    4. update self.num_key_value_heads to be self.num_key_value_heads / tp_degree
+    5. update forward() method to adjust to changes from self.num_head
+    """
+
+    def __init__(self, config: LlamaConfig, neuron_config: NxDNeuronConfig):
+        super().__init__(config, neuron_config)
+        head_dim = config.hidden_size // config.num_attention_heads
+        if not hasattr(config, "rope_scaling") or config.rope_scaling is None:
+            self.rotary_emb = RotaryEmbedding(
+                head_dim,
+                max_position_embeddings=config.max_position_embeddings,
+                base=config.rope_theta,
+            )
+        else:
+            rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type", None))
+            if rope_type == "llama3":
+                self.rotary_emb = Llama3RotaryEmbedding(
+                    dim=head_dim,
+                    max_position_embeddings=config.max_position_embeddings,
+                    base=config.rope_theta,
+                    factor=config.rope_scaling["factor"],
+                    low_freq_factor=config.rope_scaling["low_freq_factor"],
+                    high_freq_factor=config.rope_scaling["high_freq_factor"],
+                    original_max_position_embeddings=config.rope_scaling["original_max_position_embeddings"],
+                )
+            else:
+                # LlamaRotaryEmbedding automatically chooses the correct scaling type from config.
+                # Warning: The HF implementation may have precision issues when run on Neuron.
+                # We include it here for compatibility with other scaling types.
+                self.rotary_emb = LlamaRotaryEmbedding(config)
+
+
+# TODO: Modularize RotaryEmbedding. See how HF transformers does it in 4.43.
+class Llama3RotaryEmbedding(nn.Module):
+    """
+    Adapted from Llama 4.43 impl
+    * https://github.com/huggingface/transformers/blob/v4.43.4/src/transformers/models/llama/modeling_llama.py#L78
+    * https://github.com/huggingface/transformers/blob/v4.43.4/src/transformers/modeling_rope_utils.py#L345
+
+    This implementation ensures inv_freq is calculated and stored in fp32.
+    """
+
+    def __init__(
+        self,
+        dim,
+        max_position_embeddings=131072,
+        base=500000.0,
+        factor=8.0,
+        low_freq_factor=1.0,
+        high_freq_factor=4.0,
+        original_max_position_embeddings=8192,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        self.factor = factor
+        self.low_freq_factor = low_freq_factor
+        self.high_freq_factor = high_freq_factor
+        self.old_context_len = original_max_position_embeddings
+        self.register_buffer("inv_freq", None, persistent=False)
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        if self.inv_freq is None:
+            inv_freq = 1.0 / (
+                self.base ** (torch.arange(0, self.dim, 2, dtype=torch.int64).float().to(x.device) / self.dim)
+            )
+
+            low_freq_wavelen = self.old_context_len / self.low_freq_factor
+            high_freq_wavelen = self.old_context_len / self.high_freq_factor
+            new_freqs = []
+            for freq in inv_freq:
+                wavelen = 2 * math.pi / freq
+                if wavelen < high_freq_wavelen:
+                    new_freqs.append(freq)
+                elif wavelen > low_freq_wavelen:
+                    new_freqs.append(freq / self.factor)
+                else:
+                    assert low_freq_wavelen != high_freq_wavelen
+                    smooth = (self.old_context_len / wavelen - self.low_freq_factor) / (
+                        self.high_freq_factor - self.low_freq_factor
+                    )
+                    new_freqs.append((1 - smooth) * freq / self.factor + smooth * freq)
+            self.inv_freq = torch.tensor(new_freqs, dtype=inv_freq.dtype, device=inv_freq.device)
+
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        position_ids_expanded = position_ids[:, None, :].float()
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class NeuronLlamaDecoderLayer(nn.Module):
+    """
+    Just replace the attention with the NXD version, and MLP with the NXD version
+    """
+
+    def __init__(self, config: LlamaConfig, neuron_config: NxDNeuronConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = NeuronLlamaAttention(config, neuron_config)
+        self.mlp = NeuronLlamaMLP(config, neuron_config)
+        logger.debug(
+            f"Instantiating RMSNorm modules with hidden size {config.hidden_size} and EPS {config.rms_norm_eps}"
+        )
+        self.input_layernorm = get_rmsnorm_cls()(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = get_rmsnorm_cls()(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.qkv_kernel_enabled = neuron_config.qkv_kernel_enabled
+        self.mlp_kernel_enabled = neuron_config.mlp_kernel_enabled
+        self.mlp_kernel_fuse_residual_add = neuron_config.mlp_kernel_fuse_residual_add
+        self.sequence_parallel_enabled = neuron_config.sequence_parallel_enabled
+        self.config = config
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        **kwargs,
+    ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        residual = hidden_states
+
+        # RMSNorm (fused with QKV kernel when SP is disabled)
+        if (not self.qkv_kernel_enabled or self.sequence_parallel_enabled) and self.input_layernorm:
+            hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, present_key_value, cos_cache, sin_cache = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            rmsnorm=self.input_layernorm,
+            **kwargs,
+        )
+
+        if self.mlp_kernel_enabled and self.mlp_kernel_fuse_residual_add:
+            assert not self.sequence_parallel_enabled, (
+                "mlp_kernel_fuse_residual_add should be off when sequence parallelism is enabled"
+            )
+            # First residual add handled in the MLP kernel
+            hidden_states, residual = self.mlp(
+                hidden_states,
+                rmsnorm=self.post_attention_layernorm,
+                residual=residual,
+            )
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            # RMSNorm (fused with QKV kernel when SP is disabled)
+            if not self.mlp_kernel_enabled or self.sequence_parallel_enabled:
+                hidden_states = self.post_attention_layernorm(hidden_states)
+            hidden_states, _ = self.mlp(
+                hidden_states,
+                rmsnorm=self.post_attention_layernorm,
+            )
+
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, present_key_value, cos_cache, sin_cache)
+        return outputs
+
+
+class NxDLlamaModel(NxDDecoderModel):
+    """
+    The neuron version of the LlamaModel
+    """
+
+    def __init__(self, config: LlamaConfig, neuron_config: NxDNeuronConfig):
+        super().__init__(config, neuron_config)
+
+        if parallel_state.model_parallel_is_initialized():
+            self.embed_tokens = ParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                config.pad_token_id,
+                dtype=neuron_config.torch_dtype,
+                shard_across_embedding=not neuron_config.vocab_parallel,
+                sequence_parallel_enabled=False,
+                pad=True,
+                use_spmd_rank=neuron_config.vocab_parallel,
+            )
+
+            self.lm_head = ColumnParallelLinear(
+                config.hidden_size,
+                config.vocab_size,
+                gather_output=not neuron_config.on_device_sampling,
+                bias=False,
+                pad=True,
+            )
+        else:
+            self.embed_tokens = nn.Embedding(
+                config.vocab_size,
+                config.hidden_size,
+                config.pad_token_id,
+            )
+            self.lm_head = nn.Linear(
+                config.hidden_size,
+                config.vocab_size,
+                bias=False,
+            )
+
+        self.layers = nn.ModuleList(
+            [NeuronLlamaDecoderLayer(config, neuron_config) for _ in range(config.num_hidden_layers)]
+        )
+        self.norm = get_rmsnorm_cls()(config.hidden_size, eps=config.rms_norm_eps)
+
+
+class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
+    """
+    This class extends LlamaForCausalLM create traceable
+    blocks for Neuron.
+
+    Args:
+        LlamaForCausalLM (_type_): _description_
+    """
+
+    _model_cls = NxDLlamaModel
+
+    @staticmethod
+    def convert_hf_to_neuron_state_dict(state_dict: dict, config: LlamaConfig, neuron_config: NxDNeuronConfig) -> dict:
+        """This function should be over-ridden in child classes as needed"""
+        if neuron_config.fused_qkv:
+            state_dict = convert_state_dict_to_fused_qkv(state_dict, config)
+
+        if neuron_config.vocab_parallel:
+            # TODO: this hack can be removed after replication_id is ready to use
+            state_dict["embed_tokens.rank_util.rank"] = torch.arange(0, neuron_config.local_ranks_size)
+
+        # to facilitate rank usage in attention
+        num_layers = config.num_hidden_layers
+        tp_degree = neuron_config.tp_degree
+        for i in range(num_layers):
+            state_dict[f"layers.{i}.self_attn.rank_util.rank"] = torch.arange(0, tp_degree, dtype=torch.int32)
+        # to facilitate rank usage in base model
+        state_dict["rank_util.rank"] = torch.arange(0, tp_degree, dtype=torch.int32)
+        return state_dict
+
+    @staticmethod
+    def update_state_dict_for_tied_weights(state_dict):
+        state_dict["lm_head.weight"] = state_dict["embed_tokens.weight"].clone()
+
+    @classmethod
+    def get_neuron_config_cls(cls) -> Type[NxDNeuronConfig]:
+        return NxDNeuronConfig
+
+    @classmethod
+    def _get_neuron_config(
+        cls,
+        checkpoint_id: str,
+        checkpoint_revision: str,
+        batch_size: int,
+        sequence_length: int,
+        tensor_parallel_size: int,
+        auto_cast_type: str,
+    ):
+        return NxDNeuronConfig(
+            checkpoint_id=checkpoint_id,
+            checkpoint_revision=checkpoint_revision,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            tp_degree=tensor_parallel_size,
+            torch_dtype=auto_cast_type,
+        )

--- a/optimum/neuron/models/inference/nxd/mixtral/modeling_mixtral.py
+++ b/optimum/neuron/models/inference/nxd/mixtral/modeling_mixtral.py
@@ -1,0 +1,285 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch Mixtral model for NXD inference."""
+
+import gc
+import warnings
+from typing import Optional, Tuple, Union
+
+import torch
+
+# Try except for the compatibility with older compiler version
+from neuronx_distributed.parallel_layers import parallel_state
+from neuronx_distributed.parallel_layers.layers import ColumnParallelLinear, ParallelEmbedding
+from torch import nn
+from transformers.generation import SampleDecoderOnlyOutput, SampleEncoderDecoderOutput
+from transformers.models.mixtral.modeling_mixtral import MixtralConfig
+
+from ..backend.config import NxDNeuronConfig
+from ..backend.modules.attention.attention_base import NeuronAttentionBase
+from ..backend.modules.attention.utils import RotaryEmbedding
+from ..backend.modules.custom_calls import CustomRMSNorm
+from ..backend.modules.decoder import NxDDecoderModel, NxDModelForCausalLM
+from ..backend.modules.moe import initialize_moe_module
+
+
+SampleOutput = Union[SampleEncoderDecoderOutput, SampleDecoderOnlyOutput]
+
+
+def convert_mixtral_to_neuron_state_dict(neuron_state_dict, config, neuron_config):
+    """
+    Helper function which returns the model weights from the mixtral model in a state dictionary compatible with the stucture of the neuron MoE model.
+    """
+    assert neuron_config.glu_mlp is True, "Only GLU MLP is supported for Mixtral Top-K model"
+
+    for l in range(config.num_hidden_layers):  # noqa: E741
+        # Copy router weights
+        neuron_state_dict[f"layers.{l}.mlp.router.linear_router.weight"] = (
+            neuron_state_dict[f"layers.{l}.block_sparse_moe.gate.weight"].detach().clone()
+        )
+        del neuron_state_dict[f"layers.{l}.block_sparse_moe.gate.weight"]
+
+        intermediate_size, hidden_size = neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.0.w1.weight"].shape
+        device = neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.0.w1.weight"].device
+        dtype = neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.0.w1.weight"].dtype
+
+        # copy the MLP parameters
+        gate_up_proj = torch.empty(
+            config.num_local_experts,
+            hidden_size,
+            2 * intermediate_size,
+            dtype=dtype,
+            device=device,
+        )
+        for e in range(config.num_local_experts):
+            # Copy gate_proj and up_proj after concatenation
+            gate_proj_weights = (
+                neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w1.weight"].T.detach().clone()
+            )
+            up_proj_weights = (
+                neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w3.weight"].T.detach().clone()
+            )
+
+            gate_up_proj_slice = torch.narrow(gate_up_proj, 0, e, 1)
+            gate_proj_slice = torch.narrow(gate_up_proj_slice, 2, 0, intermediate_size)
+            gate_proj_slice.copy_(gate_proj_weights)
+            up_proj_slice = torch.narrow(gate_up_proj_slice, 2, intermediate_size, intermediate_size)
+            up_proj_slice.copy_(up_proj_weights)
+
+            del neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w1.weight"]
+            del neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w3.weight"]
+        neuron_state_dict[f"layers.{l}.mlp.expert_mlps.mlp_op.gate_up_proj.weight"] = gate_up_proj
+
+        down_proj = torch.empty(
+            config.num_local_experts,
+            intermediate_size,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+        )
+        for e in range(config.num_local_experts):
+            # Copy down_proj
+            down_proj_weights = (
+                neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w2.weight"].T.detach().clone()
+            )
+            down_proj_slice = torch.narrow(down_proj, 0, e, 1)
+            down_proj_slice.copy_(down_proj_weights)
+            del neuron_state_dict[f"layers.{l}.block_sparse_moe.experts.{e}.w2.weight"]
+        neuron_state_dict[f"layers.{l}.mlp.expert_mlps.mlp_op.down_proj.weight"] = down_proj
+
+        gc.collect()
+
+    return neuron_state_dict
+
+
+def get_rmsnorm_cls(neuron_config):
+    # Initialize to the appropriate implementation of RMSNorm
+    # If infer on NXD -> CustomRMSNorm
+    # If infer on CPU -> HF_RMSNorm (CustomRMSNorm does not work on CPU)
+    return CustomRMSNorm
+
+
+class NeuronMixtralAttention(NeuronAttentionBase):
+    def __init__(self, config: MixtralConfig, neuron_config: NxDNeuronConfig):
+        if not parallel_state.model_parallel_is_initialized():
+            raise ValueError(
+                "NeuronMixtralAttention has to be initialized in a distributed env. Please use neuronx_distributed"
+                " module to initialize a distributed env."
+            )
+        super().__init__(config, neuron_config)
+        self.tp_degree = parallel_state.get_tensor_model_parallel_size()
+
+        head_dim = config.hidden_size // config.num_attention_heads
+        self.rotary_emb = RotaryEmbedding(
+            head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            base=config.rope_theta,
+        )
+
+
+class NeuronMixtralDecoderLayer(nn.Module):
+    """
+    Just replace the attention with the NXD version, and MLP with the NXD version
+    """
+
+    def __init__(self, config: MixtralConfig, neuron_config: NxDNeuronConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = NeuronMixtralAttention(config, neuron_config)
+
+        self.mlp = initialize_moe_module(
+            neuron_config=neuron_config,
+            num_experts=config.num_local_experts,
+            top_k=config.num_experts_per_tok,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+        )
+
+        self.input_layernorm = get_rmsnorm_cls(neuron_config)(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = get_rmsnorm_cls(neuron_config)(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        **kwargs,
+    ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*):
+                attention mask of size `(batch_size, sequence_length)` if flash attention is used or `(batch_size, 1,
+                query_sequence_length, key_sequence_length)` if default attention is used.
+            position_ids (`torch.FloatTensor`, *optional*):
+                position ids of size `(batch_size, sequence_length)`.
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+        """
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, present_key_value, cos_cache, sin_cache = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # MoE
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)[0]
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, present_key_value, cos_cache, sin_cache)
+
+        return outputs
+
+
+class NxDMixtralModel(NxDDecoderModel):
+    """
+    NeuronMixtralModel extends the MixtralModel to be traceable.
+    The forward function of this class is traced.
+    """
+
+    def __init__(self, config: MixtralConfig, neuron_config: NxDNeuronConfig):
+        super().__init__(config, neuron_config)
+
+        self.embed_tokens = ParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            config.pad_token_id,
+            dtype=neuron_config.torch_dtype,
+            shard_across_embedding=True,
+        )
+        self.layers = nn.ModuleList(
+            [
+                NeuronMixtralDecoderLayer(config, neuron_config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = get_rmsnorm_cls(neuron_config)(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = ColumnParallelLinear(
+            config.hidden_size,
+            config.vocab_size,
+            gather_output=not neuron_config.on_device_sampling,
+            bias=False,
+        )
+
+
+class MixtralNxDModelForCausalLM(NxDModelForCausalLM):
+    """
+    This class can be used as MixtralForCausalLM
+    """
+
+    _model_cls = NxDMixtralModel
+
+    @classmethod
+    def get_neuron_config_cls(cls):
+        return NxDNeuronConfig
+
+    @staticmethod
+    def convert_hf_to_neuron_state_dict(
+        state_dict: dict, config: MixtralConfig, neuron_config: NxDNeuronConfig
+    ) -> dict:
+        return convert_mixtral_to_neuron_state_dict(state_dict, config, neuron_config)
+
+    @classmethod
+    def get_compiler_args(cls, neuron_config: NxDNeuronConfig) -> str:
+        compiler_args = "--enable-saturate-infinity --enable-mixed-precision-accumulation --model-type transformer -O1"
+        # Add flags for cc-overlap
+        compiler_args += " --tensorizer-options='--enable-ccop-compute-overlap --cc-pipeline-tiling-factor=2'"
+        # Prevent auto-down casting when running with fp32
+        if neuron_config.torch_dtype == torch.float32:
+            compiler_args += " --auto-cast=none"
+        # Enable vector-offset DGE
+        compiler_args += " --internal-enable-dge-levels vector_dynamic_offsets"
+        return compiler_args
+
+    @classmethod
+    def _get_neuron_config(
+        cls,
+        checkpoint_id: str,
+        checkpoint_revision: str,
+        batch_size: int,
+        sequence_length: int,
+        tensor_parallel_size: int,
+        auto_cast_type: str,
+    ):
+        return NxDNeuronConfig(
+            checkpoint_id=checkpoint_id,
+            checkpoint_revision=checkpoint_revision,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            tp_degree=tensor_parallel_size,
+            torch_dtype=auto_cast_type,
+        )

--- a/optimum/neuron/models/inference/nxd/mixtral/modeling_mixtral.py
+++ b/optimum/neuron/models/inference/nxd/mixtral/modeling_mixtral.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/models/mixtral/modeling_mixtral.py
 """PyTorch Mixtral model for NXD inference."""
 
 import gc

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -631,6 +631,9 @@ def map_torch_dtype(dtype: Union[str, torch.dtype]):
         "float64": torch.float64,
         "int32": torch.int32,
         "int64": torch.int64,
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
     }
 
     if isinstance(dtype, str) and dtype in dtype_mapping:

--- a/tests/decoder/test_decoder_export.py
+++ b/tests/decoder/test_decoder_export.py
@@ -19,8 +19,8 @@ import pytest
 from transformers import AutoModelForCausalLM
 
 from optimum.neuron import NeuronModelForCausalLM
-from optimum.neuron.models.inference.nxd.backend.config import to_torch_dtype
 from optimum.neuron.models.inference.nxd.llama.modeling_llama import LlamaNxDModelForCausalLM
+from optimum.neuron.utils import map_torch_dtype
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
@@ -53,7 +53,7 @@ def check_neuron_model(neuron_model, batch_size=None, sequence_length=None, num_
         if hasattr(neuron_config, "auto_cast_type"):
             assert neuron_config.auto_cast_type == auto_cast_type
         elif hasattr(neuron_config, "torch_dtype"):
-            assert neuron_config.torch_dtype == to_torch_dtype(auto_cast_type)
+            assert neuron_config.torch_dtype == map_torch_dtype(auto_cast_type)
 
 
 def _test_decoder_export_save_reload(

--- a/tests/decoder/test_decoder_export.py
+++ b/tests/decoder/test_decoder_export.py
@@ -19,15 +19,18 @@ import pytest
 from transformers import AutoModelForCausalLM
 
 from optimum.neuron import NeuronModelForCausalLM
+from optimum.neuron.models.inference.nxd.backend.config import to_torch_dtype
+from optimum.neuron.models.inference.nxd.llama.modeling_llama import LlamaNxDModelForCausalLM
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
-DECODER_MODEL_ARCHITECTURES = ["llama", "granite", "qwen2", "phi3"]
+DECODER_MODEL_ARCHITECTURES = ["llama", "granite", "qwen2", "phi3", "mixtral"]
 DECODER_MODEL_NAMES = {
     "llama": "llamafactory/tiny-random-Llama-3",
     "qwen2": "yujiepan/qwen2.5-128k-tiny-random",
     "granite": "hf-internal-testing/tiny-random-GraniteForCausalLM",
     "phi3": "yujiepan/phi-4-tiny-random",
+    "mixtral": "dacorvo/Mixtral-tiny",
 }
 
 
@@ -47,21 +50,21 @@ def check_neuron_model(neuron_model, batch_size=None, sequence_length=None, num_
     if num_cores:
         assert neuron_config.tp_degree == num_cores
     if auto_cast_type:
-        assert neuron_config.auto_cast_type == auto_cast_type
+        if hasattr(neuron_config, "auto_cast_type"):
+            assert neuron_config.auto_cast_type == auto_cast_type
+        elif hasattr(neuron_config, "torch_dtype"):
+            assert neuron_config.torch_dtype == to_torch_dtype(auto_cast_type)
 
 
-@pytest.mark.parametrize(
-    "batch_size, sequence_length, num_cores, auto_cast_type",
-    [
-        [1, 100, 2, "fp32"],
-        [1, 100, 2, "fp16"],
-        [2, 100, 2, "fp16"],
-    ],
-)
-@is_inferentia_test
-@requires_neuronx
-@pytest.mark.parametrize("local", [True, False], ids=["local", "from_hub"])
-def test_decoder_export_save_reload(local, export_decoder_id, batch_size, sequence_length, num_cores, auto_cast_type):
+def _test_decoder_export_save_reload(
+    model_cls,
+    is_local: bool,
+    model_id: str,
+    batch_size: int,
+    sequence_length: int,
+    num_cores: int,
+    auto_cast_type: str,
+):
     export_kwargs = {
         "batch_size": batch_size,
         "sequence_length": sequence_length,
@@ -69,16 +72,64 @@ def test_decoder_export_save_reload(local, export_decoder_id, batch_size, sequen
         "auto_cast_type": auto_cast_type,
     }
     with TemporaryDirectory() as model_path:
-        if local:
+        if is_local:
             with TemporaryDirectory() as tmpdir:
-                model = AutoModelForCausalLM.from_pretrained(export_decoder_id)
+                model = AutoModelForCausalLM.from_pretrained(model_id)
                 model.save_pretrained(tmpdir)
-                model = NeuronModelForCausalLM.from_pretrained(tmpdir, export=True, **export_kwargs)
+                model = model_cls.from_pretrained(tmpdir, export=True, **export_kwargs)
                 model.save_pretrained(model_path)
         else:
-            model = NeuronModelForCausalLM.from_pretrained(export_decoder_id, export=True, **export_kwargs)
+            model = model_cls.from_pretrained(model_id, export=True, **export_kwargs)
             model.save_pretrained(model_path)
         check_neuron_model(model, **export_kwargs)
         del model
-        model = NeuronModelForCausalLM.from_pretrained(model_path)
+        model = model_cls.from_pretrained(model_path)
         check_neuron_model(model, **export_kwargs)
+
+
+@pytest.mark.parametrize(
+    "batch_size, sequence_length, num_cores, auto_cast_type",
+    [
+        [1, 100, 2, "bf16"],
+        [1, 100, 2, "fp16"],
+        [2, 100, 2, "fp16"],
+    ],
+)
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.parametrize("is_local", [True, False], ids=["local", "from_hub"])
+def test_decoder_export_save_reload(
+    is_local, export_decoder_id, batch_size, sequence_length, num_cores, auto_cast_type
+):
+    _test_decoder_export_save_reload(
+        NeuronModelForCausalLM,
+        is_local=is_local,
+        model_id=export_decoder_id,
+        batch_size=batch_size,
+        sequence_length=sequence_length,
+        num_cores=num_cores,
+        auto_cast_type=auto_cast_type,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch_size, sequence_length, num_cores, auto_cast_type",
+    [
+        [1, 100, 2, "bf16"],
+        [1, 100, 2, "fp16"],
+        [2, 100, 2, "fp16"],
+    ],
+)
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.parametrize("is_local", [True, False], ids=["local", "from_hub"])
+def test_nxd_llama_export_save_reload(is_local, batch_size, sequence_length, num_cores, auto_cast_type):
+    _test_decoder_export_save_reload(
+        LlamaNxDModelForCausalLM,
+        is_local=is_local,
+        model_id=DECODER_MODEL_NAMES["llama"],
+        batch_size=batch_size,
+        sequence_length=sequence_length,
+        num_cores=num_cores,
+        auto_cast_type=auto_cast_type,
+    )

--- a/tests/decoder/test_decoder_generation.py
+++ b/tests/decoder/test_decoder_generation.py
@@ -51,21 +51,23 @@ def _test_generation(model, batch_size, input_length, **gen_kwargs):
 @requires_neuronx
 def test_decoder_generation_base(model_and_tokenizer, gen_kwargs):
     model = model_and_tokenizer[0]
-    _test_generation(model, model.batch_size, 10, **gen_kwargs)
+    _test_generation(model, model.neuron_config.batch_size, 10, **gen_kwargs)
 
 
 @is_inferentia_test
 @requires_neuronx
 def test_decoder_generation_input_dimensions(model_and_tokenizer):
     model, tokenizer = model_and_tokenizer
+    batch_size = model.neuron_config.batch_size
+    sequence_length = model.neuron_config.sequence_length
     # Using valid input dimensions
-    _test_generation(model, model.batch_size, model.max_length // 2)
+    _test_generation(model, batch_size, sequence_length // 2)
     # Using an incompatible batch_size
     with pytest.raises(ValueError, match="The specified batch_size"):
-        _test_generation(model, model.batch_size + 1, model.max_length)
+        _test_generation(model, batch_size + 1, sequence_length)
     # Using an incompatible input length
     with pytest.raises(ValueError, match="The input sequence length"):
-        _test_generation(model, model.batch_size, input_length=model.max_length * 2)
+        _test_generation(model, batch_size, input_length=sequence_length * 2)
 
 
 @is_inferentia_test
@@ -153,7 +155,7 @@ def test_decoder_generation_stop_strings(model_and_tokenizer):
     prompt = "Name three fruits:"
     tokens = tokenizer(prompt, return_tensors="pt")
     generation_config = copy.deepcopy(model.generation_config)
-    generation_config.max_new_tokens = model.max_length - tokens["input_ids"].shape[-1]
+    generation_config.max_new_tokens = model.neuron_config.sequence_length - tokens["input_ids"].shape[-1]
     # Generate once
     outputs = model.generate(**tokens, do_sample=False, generation_config=generation_config)
     output_string = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
@@ -181,7 +183,7 @@ def test_continuous_batching_two_requests(model_and_tokenizer):
     Both generated tokens must match since we are using greedy.
     """
     model, tokenizer = model_and_tokenizer
-    if not model.model.neuron_config.continuous_batching:
+    if not model.neuron_config.continuous_batching:
         pytest.skip("Model does not support continuous batching")
 
     # We need at least three inputs

--- a/tests/decoder/test_decoder_generation.py
+++ b/tests/decoder/test_decoder_generation.py
@@ -21,6 +21,7 @@ from transformers import AutoTokenizer
 from transformers.generation import StoppingCriteria
 
 from optimum.neuron import NeuronModelForCausalLM
+from optimum.neuron.models.inference.nxd.backend.modules.decoder import NxDModelForCausalLM
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
@@ -119,12 +120,20 @@ def test_decoder_generation_greedy_expectations(neuron_decoder_config):
     prompt = "What is Deep Learning?"
     inputs = tokenizer(prompt, return_tensors="pt")
     outputs = model.generate(**inputs, do_sample=False, max_new_tokens=17)
-    expectations = {
-        "llama": " and How Does it Work?\nDeep learning is a subset of machine learning that uses artificial",
-        "qwen2": " - Part 1\n\nDeep Learning is a subset of Machine Learning that is based on",
-        "granite": "\n\nDeep Learning is a subset of Machine Learning, which is a branch of Art",
-        "phi": "\n\nDeep learning is a subset of machine learning that uses neural networks with many",
-    }
+    if isinstance(model, NxDModelForCausalLM):
+        expectations = {
+            "llama": " And how does it differ from other Machine Learning approaches?\n\n**What is Deep Learning?",
+            "qwen2": " - Part 1\n\nDeep Learning is a subset of Machine Learning that is based on",
+            "granite": "\n\nDeep Learning is a subset of Machine Learning, which is a branch of Art",
+            "phi": "\n\nDeep learning is a subset of machine learning that uses neural networks with many",
+        }
+    else:
+        expectations = {
+            "llama": " and How Does it Work?\nDeep learning is a subset of machine learning that uses artificial",
+            "qwen2": " - Part 1\n\nDeep Learning is a subset of Machine Learning that is based on",
+            "granite": "\n\nDeep Learning is a subset of Machine Learning, which is a branch of Art",
+            "phi": "\n\nDeep learning is a subset of machine learning that uses neural networks with many",
+        }
     config_name = neuron_decoder_config["name"]
     assert tokenizer.decode(outputs[0]).endswith(expectations[config_name])
 

--- a/tests/decoder/test_decoder_hub.py
+++ b/tests/decoder/test_decoder_hub.py
@@ -27,7 +27,7 @@ from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neur
 
 @is_inferentia_test
 @requires_neuronx
-@pytest.mark.parametrize("from_local", [False, True], ids=["from_hub", "from_local"])
+@pytest.mark.parametrize("from_local", [False, True], ids=["llama_from_hub", "llama_from_local"])
 def test_decoder_push_to_hub(from_local):
     model_id = "llamafactory/tiny-random-Llama-3"
     with TemporaryDirectory() as model_path:


### PR DESCRIPTION
# What does this PR do?

This adds support for the export and inference of decoder models on top of `neuronx-distributed`.

For now only two model architectures are supported: `llama` and `mixtral`.

Note that the existing custom modeling for llama on top of TnX is still chosen by default when using `NeuronModelForCausalLM`.

To export or instantiate a llama model on top of NxD instead, either:

- use directly `LlamaNxDModelForCausalLM`,
- export OPTIMUM_PRIORITIZE_NXD_BACKEND=1, then use `NeuronModelForCausalLM`.

The basic features are all implemented:

- export/save/reload,
- generate with multinomial sampling or greedy,
- transparent local cache,
- transparent hub cache.

A new cool feature has been added: assisted/speculative decoding.

What's missing:

- support for continuous batching,
- integration in TGI,
- several modeling optimizations are not working (yet): they will be fixed in individual pull-requests or removed. 

Performance:
- inference time seems in line with the numbers obtained using the direct HLO modeling,
- device memory usage is much higher, quickly leading to a saturation when increasing the batch size. It might be because some outputs/cached vales are stored with a higher precision.
