### PR TITLE
training dlc doc

### DIFF
--- a/docs/source/containers.mdx
+++ b/docs/source/containers.mdx
@@ -32,7 +32,7 @@ print(f"llm image uri: {llm_image}")
 
 | Type                       | Optimum Version | Image URI                                   |
 |-----------------------------|-----------------|---------------------------------------------|
-| Training  | 0.0.25           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training-neuronx:2.1.2-transformers4.43.2-neuronx-py310-sdk2.20.0-ubuntu20.04`   |
+| Training  | 0.0.25           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training-neuronx:2.1.2-transformers4.48.1-neuronx-py310-sdk2.20.0-ubuntu20.04`   |
 | Inference      | 0.0.25           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference-neuronx:2.1.2-transformers4.43.2-neuronx-py310-sdk2.20.0-ubuntu20.04`      |
 | Text Generation Inference        | 0.0.28           | `763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.2-optimum0.0.28-neuronx-py310-ubuntu22.04`        |
 


### PR DESCRIPTION
I was checking if we were up to date on the doc and we missed this one:
https://github.com/aws/deep-learning-containers/releases/tag/v2.2-hf-4.48.1-pt-2.1.2-tr-neuronx-sdk2.20.0-py310