### PR TITLE
Activate continuous batching for Llama on NxD

### DIFF
--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -158,8 +158,11 @@ class NxDNeuronConfig(NeuronConfig):
 
         # Speculative decoding
         self.speculation_length = speculation_length
-        if self.speculation_length > 0 and self.async_mode:
-            raise IncompatibleConfigError("Speculative Decoding is not yet supported with async.")
+        if self.speculation_length > 0:
+            if self.async_mode:
+                raise IncompatibleConfigError("Speculative Decoding is not yet supported with async.")
+            if self.on_device_sampling:
+                raise IncompatibleConfigError("Speculative decoding is incompatible with on-device sampling")
 
         # Distributed config
         self.pp_degree = pp_degree

--- a/optimum/neuron/models/inference/nxd/backend/config.py
+++ b/optimum/neuron/models/inference/nxd/backend/config.py
@@ -57,8 +57,6 @@ class NxDNeuronConfig(NeuronConfig):
         checkpoint_id: str = None,
         checkpoint_revision: str = None,
         batch_size: Optional[int] = 1,
-        ctx_batch_size: Optional[int] = None,
-        tkg_batch_size: Optional[int] = None,
         max_batch_size: Optional[int] = None,
         continuous_batching: Optional[bool] = False,
         speculation_length: Optional[int] = 0,
@@ -145,10 +143,8 @@ class NxDNeuronConfig(NeuronConfig):
         # Continuous batching
         # TODO: Check if we really need different batch size for CTE and TKG, given
         # that we anyway provide two different config instance for them.
-        self.ctx_batch_size = batch_size if ctx_batch_size is None else ctx_batch_size
-        self.tkg_batch_size = batch_size if tkg_batch_size is None else tkg_batch_size
-        self.max_batch_size = batch_size if max_batch_size is None else max_batch_size
         self.continuous_batching = continuous_batching
+        self.max_batch_size = batch_size if max_batch_size is None else max_batch_size
 
         # On-device sampling
         self.on_device_sampling = on_device_sampling
@@ -198,6 +194,14 @@ class NxDNeuronConfig(NeuronConfig):
         # MoE specific
         self.capacity_factor = float(capacity_factor) if capacity_factor is not None else None
         self.glu_mlp = glu_mlp
+
+    @property
+    def ctx_batch_size(self) -> int:
+        return 1 if self.continuous_batching else self.batch_size
+
+    @property
+    def tkg_batch_size(self) -> int:
+        return self.batch_size
 
     @property
     def world_size(self) -> int:

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -94,7 +94,7 @@ class NxDDecoderModel(nn.Module):
         self.num_cores_per_group = neuron_config.num_cores_per_group
         if neuron_config.on_device_sampling:
             # Instantiate a multinomial Sampler (it can still be used for greedy by passing topk=1)
-            self.sampler = Sampler(do_sample=True, max_topk=neuron_config.max_topk)
+            self.sampler = Sampler(neuron_config, do_sample=True)
         self.kv_mgr = KVCacheManager(config, neuron_config, num_kv_head=config.num_key_value_heads)
 
     def initialize_process_group(self, seed: int = 0):

--- a/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/decoder/modeling_decoder.py
@@ -761,7 +761,7 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         compiler_args = (
             "--auto-cast=none --model-type=transformer "
             f"--tensorizer-options='{tensorizer_options}'"
-            " -O1 "
+            " -O2 "
             f" --internal-num-neuroncores-per-sengine={neuron_config.logical_nc_config}"
         )
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -281,6 +281,9 @@ class NxDGenerationMixin(GenerationMixin):
         eos_token_id = generation_config.eos_token_id
         assistant_model = candidate_generator.assistant_model
 
+        if assistant_model.neuron_config.on_device_sampling:
+            raise ValueError("Assistant model must not use on-device sampling")
+
         # Initialize the num_assistant_tokens used for speculation.
         if hasattr(assistant_model, "num_assistant_tokens"):
             num_assistant_tokens = assistant_model.num_assistant_tokens

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -173,6 +173,7 @@ class NxDGenerationMixin(GenerationMixin):
         is_decode,
         attention_mask=None,
         sampling_params=None,
+        seq_ids=None,
         **kwargs,
     ):
         if is_decode:
@@ -187,11 +188,15 @@ class NxDGenerationMixin(GenerationMixin):
                 position_ids = torch.amax(position_ids, 1, keepdim=True)
                 position_ids = position_ids + 1
 
+        if seq_ids is None:
+            seq_ids = torch.arange(input_ids.shape[0])
+
         model_inputs = {
             "input_ids": input_ids,
             "position_ids": position_ids,
             "attention_mask": attention_mask,
             "sampling_params": sampling_params,
+            "seq_ids": seq_ids,
         }
 
         # WARNING: This is needed for propagating additional kwargs to the neuron model

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -150,10 +150,10 @@ class NxDGenerationMixin(GenerationMixin):
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
 
+            is_for_token_generation = True
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_for_token_generation=is_for_token_generation
             )
-            is_for_token_generation = True
 
             unfinished_sequences = unfinished_sequences & ~stopping_criteria(input_ids, None)
             this_peer_finished = unfinished_sequences.max() == 0
@@ -186,7 +186,6 @@ class NxDGenerationMixin(GenerationMixin):
             position_ids.masked_fill_(attention_mask == 0, 1)
             if is_decode:
                 position_ids = torch.amax(position_ids, 1, keepdim=True)
-                position_ids = position_ids + 1
 
         if seq_ids is None:
             seq_ids = torch.arange(input_ids.shape[0])

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -139,7 +139,7 @@ class NxDGenerationMixin(GenerationMixin):
                         raw_logits += (next_token_logits,)
 
                 if self.sampler is None:
-                    self.sampler = Sampler(do_sample=True, max_topk=self.neuron_config.max_topk, on_cpu=True)
+                    self.sampler = Sampler(self.neuron_config, do_sample=True, on_cpu=True)
 
                 next_tokens = self.sampler(next_token_scores, sampling_params)
 

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/generation_utils.py
@@ -284,12 +284,6 @@ class NxDGenerationMixin(GenerationMixin):
         if assistant_model.neuron_config.on_device_sampling:
             raise ValueError("Assistant model must not use on-device sampling")
 
-        # Initialize the num_assistant_tokens used for speculation.
-        if hasattr(assistant_model, "num_assistant_tokens"):
-            num_assistant_tokens = assistant_model.num_assistant_tokens
-        else:
-            num_assistant_tokens = assistant_model.generation_config.num_assistant_tokens
-
         # Init values
         if eos_token_id is not None and pad_token_id is None:
             raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
@@ -322,7 +316,7 @@ class NxDGenerationMixin(GenerationMixin):
         while True:
             # 1 Token generation using draft model
             is_for_token_generation = assistant_model.kv_cache_populated
-            for _ in range(int(num_assistant_tokens)):
+            for _ in range(spec_len):
                 # 1.1 Prepare assistant model inputs
                 assistant_inputs = assistant_model.prepare_inputs_for_generation(
                     candidate_input_ids,

--- a/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/generation/sampling.py
@@ -20,12 +20,75 @@ import torch
 from neuronx_distributed.operators.argmax import argmax as nxd_argmax
 from neuronx_distributed.operators.topk import topk as nxd_topk
 from neuronx_distributed.parallel_layers import parallel_state
-from torch_neuronx.xla_impl.ops import xla_hlo_call
+from neuronx_distributed.utils.utils import hardware
+from neuronxcc.nki._private_kernels.cumsum import cumsum as nki_cumsum
+from torch_neuronx.utils import get_platform_target
+from torch_neuronx.xla_impl.ops import nki_jit, xla_hlo_call
 
 from ...config import NxDNeuronConfig
 
 
 logger = logging.getLogger("Neuron")
+
+
+def mask_padded_logits(logits, rank_id, world_size, pad_size=None):
+    if pad_size is None or pad_size == 0:
+        return logits
+
+    # invalid if rank_id == tp_degree - 1
+    last_rank_mask = torch.eq(
+        torch.full(logits.shape, world_size - 1, device=logits.device, dtype=torch.int32),
+        rank_id.broadcast_to(logits.shape),
+    )
+    #   and index >= logits.shape[-1] - pad
+    on_pad_mask = torch.ge(
+        torch.arange(logits.shape[-1], device=logits.device, dtype=torch.int32).broadcast_to(logits.shape),
+        torch.full(logits.shape, logits.shape[-1] - pad_size, device=logits.device, dtype=torch.int32),
+    )
+    invalid_mask = last_rank_mask * on_pad_mask
+    logits = torch.where(invalid_mask, torch.full_like(logits, torch.finfo(logits.dtype).min), logits)
+
+    return logits
+
+
+def cumsum(tensor_in, dim, on_cpu: bool = False):
+    if on_cpu:
+        logger.debug("On CPU, using torch cumsum")
+        return torch.cumsum(tensor_in, dim=dim)
+    init_shape_len = len(tensor_in.shape)
+    cumsum_dim = dim % init_shape_len
+    last_dim = init_shape_len - 1
+    is_transposed = False
+    if cumsum_dim != last_dim:
+        tensor_in = torch.transpose(tensor_in, cumsum_dim, last_dim)
+        is_transposed = True
+    init_shape = tensor_in.shape
+    cumsum_len = init_shape[last_dim]
+    # Prioritize nki kernel for float dtype, then matmul cumsum if not input is not float
+    if torch.is_floating_point(tensor_in):
+        logger.debug("Using NKI cumsum")
+        tensor_in = tensor_in.view(-1, cumsum_len)
+        nki_cumsum_func = nki_jit()(nki_cumsum)
+        output = torch.zeros_like(tensor_in, device=tensor_in.device, dtype=tensor_in.dtype)
+        nki_cumsum_func(tensor_in, output, axis=1)
+        output = output.view(init_shape)
+        if is_transposed:
+            output = torch.transpose(output, cumsum_dim, last_dim)
+        return output
+    else:
+        logger.debug("Using matmul cumsum")
+        triu = torch.triu(
+            torch.ones(
+                cumsum_len,
+                cumsum_len,
+                dtype=tensor_in.dtype,
+                device=tensor_in.device,
+            )
+        )
+        output = tensor_in @ triu
+        if is_transposed:
+            output = torch.transpose(output, cumsum_dim, last_dim)
+        return output
 
 
 @xla_hlo_call
@@ -128,7 +191,9 @@ class Sampler(torch.nn.Module):
         on_cpu(`Optional[bool]`): whether to run on CPU or not
     """
 
-    def __init__(self, neuron_config: NxDNeuronConfig, do_sample: Optional[bool] = True, on_cpu: Optional[bool] = False):
+    def __init__(
+        self, neuron_config: NxDNeuronConfig, do_sample: Optional[bool] = True, on_cpu: Optional[bool] = False
+    ):
         super().__init__()
         if not do_sample:
             logger.warning("Greedy sampling is used. Sampling parameters will be ignored at runtime.")
@@ -147,7 +212,20 @@ class Sampler(torch.nn.Module):
     def _soft_max(self, logits, dim):
         return torch.nn.functional.softmax(input=logits, dim=dim)
 
-    def _top_k_masked(self, logits, top_k, dim):
+    def _get_top_k_num_stages(self):
+        hardware_type = hardware(get_platform_target())
+        if (
+            hardware_type == hardware.TRN2
+            and self.neuron_config.tp_degree == self.neuron_config.world_size == 64
+            and self.neuron_config.logical_nc_config == 2
+        ):
+            return 3
+        elif hardware_type == hardware.TRN1 and self.neuron_config.tp_degree == self.neuron_config.world_size == 32:
+            return 2
+        else:
+            return 1
+
+    def _top_k_masked(self, logits, top_k, dim, rank_id):
         if self.neuron_config.max_topk > 0:
             if self.on_cpu:
                 sorted_logits, indeces = torch.topk(input=logits, k=self.neuron_config.max_topk, dim=dim)
@@ -158,6 +236,8 @@ class Sampler(torch.nn.Module):
                     dim=dim,
                     gather_dim=dim,
                     process_group=self.process_group,
+                    stages=self._get_top_k_num_stages(),
+                    rank_id=rank_id,
                 )
         else:
             sorted_logits, indeces = torch.sort(input=logits, dim=dim, descending=True)
@@ -174,14 +254,14 @@ class Sampler(torch.nn.Module):
         top_p_mask = torch.greater(probs_cumsum, top_p)
         top_k_logits_values = top_k_logits_values.masked_fill_(top_p_mask, self.IGNORED_LOGITS_VALUE)
         probs_soft_max = self._soft_max(top_k_logits_values, dim)  # custom call
-        probs_cumsum = torch.cumsum(input=probs_soft_max, dim=dim)
+        probs_cumsum = cumsum(tensor_in=probs_soft_max, dim=dim, on_cpu=self.on_cpu)
         return probs_cumsum
 
     def _rand_selector(self, probs_cumsum, num_samples=1):
         return torch.full((probs_cumsum.shape[0], num_samples), 0.5, device=probs_cumsum.device)
 
     def _multinomial(self, probs, dim, num_samples=1):
-        probs_cumsum = torch.cumsum(input=probs, dim=dim)
+        probs_cumsum = cumsum(tensor_in=probs, dim=dim, on_cpu=self.on_cpu)
         rand_selector = self._rand_selector(probs_cumsum, num_samples)
         greater_than_rand = torch.greater(rand_selector, probs_cumsum)
         counts = torch.sum(greater_than_rand, dim=dim).unsqueeze(dim)
@@ -204,21 +284,21 @@ class Sampler(torch.nn.Module):
                 return tokens, values
             return tokens
 
-    def _multinomial_sample(self, token_logits, sampling_params, return_values, dim):
+    def _multinomial_sample(self, token_logits, sampling_params, return_values, dim, rank_id):
         batch_size = token_logits.shape[0]
         top_k = sampling_params[:, 0].reshape(batch_size, 1)
         top_p = sampling_params[:, 1].reshape(batch_size, 1)
         temperature = sampling_params[:, 2].reshape(batch_size, 1)
 
         # Apply top_k first
-        top_k_logits_values, top_k_logits_indices = self._top_k_masked(token_logits, top_k, dim)
+        top_k_logits_values, top_k_logits_indices = self._top_k_masked(token_logits, top_k, dim, rank_id)
 
         # Apply temperature
         top_k_logits_values = torch.divide(top_k_logits_values, temperature)
 
         # Apply top_p
         probs_soft_max = self._soft_max(top_k_logits_values, dim)
-        probs_cumsum = torch.cumsum(input=probs_soft_max, dim=dim)
+        probs_cumsum = cumsum(tensor_in=probs_soft_max, dim=dim, on_cpu=self.on_cpu)
         top_p = torch.max(torch.min(probs_cumsum), top_p)
         top_p_mask = torch.greater(probs_cumsum, top_p).index_fill_(
             dim, torch.tensor([0], device=top_p.device), False
@@ -232,7 +312,7 @@ class Sampler(torch.nn.Module):
         counts = self._multinomial(probs_soft_max, dim)
         return torch.gather(input=top_k_logits_indices, dim=dim, index=counts).flatten()
 
-    def forward(self, token_logits, sampling_params, return_values=False):
+    def forward(self, token_logits, sampling_params, return_values=False, rank_id=None):
         """
         forward to perform topk, topp, temperature and multinomial sampling.
 
@@ -264,6 +344,6 @@ class Sampler(torch.nn.Module):
         """
         dim = len(token_logits.shape) - 1  # vocab_size dimension
         if self.do_sample:
-            return self._multinomial_sample(token_logits, sampling_params, return_values, dim)
+            return self._multinomial_sample(token_logits, sampling_params, return_values, dim, rank_id)
         else:
             return self._argmax_sample(token_logits, return_values, dim)

--- a/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
+++ b/optimum/neuron/models/inference/nxd/backend/modules/kvcache/utils.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/9993358ce052fd7a1bb4a7497a6318aac36ed95c/src/neuronx_distributed_inference/modules/kvcache/utils.py
+from typing import List
+
+import torch
 from torch_neuronx.xla_impl.ops import xla_hlo_call
 
 
@@ -23,3 +26,19 @@ def fill_prefix(tensor, update):
     shape = tensor.sizes
     start_indices = [scribe.u32.Constant(constant_value=0)] * len(shape)
     return dtype[shape].DynamicUpdateSlice(tensor, update, *start_indices)
+
+
+def dynamic_update_slice(tensor: torch.Tensor, update: torch.Tensor, start_indices: List[torch.Tensor]):
+    """
+    Directly invoke DynamicUpdateSlice XLA op
+    https://openxla.org/xla/operation_semantics#dynamicupdateslice
+    """
+
+    @xla_hlo_call
+    def xla_dynamic_update_slice(tensor, update, *start_indices):
+        dtype = tensor.dtype
+        shape = tensor.sizes
+        return dtype[shape].DynamicUpdateSlice(tensor, update, *start_indices)
+
+    assert len(start_indices) == tensor.dim(), "not enough indices to index into tensor"
+    return xla_dynamic_update_slice(tensor, update, *start_indices)

--- a/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
@@ -544,4 +544,5 @@ class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
             torch_dtype=auto_cast_type,
             on_device_sampling=True,
             fused_qkv=True,
+            continuous_batching=(batch_size > 1) if batch_size else False,
         )

--- a/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/nxd/llama/modeling_llama.py
@@ -18,6 +18,7 @@
 import gc
 import logging
 import math
+import warnings
 from typing import Optional, Tuple, Type
 
 import torch
@@ -536,9 +537,14 @@ class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
         auto_cast_type: str,
     ):
         continuous_batching = (batch_size > 1) if batch_size else False
-        # Neuron SDK 2.22 bug: the model will crash when continuous_batching is enabled
-        # if the tensor parallel size is 2 and on_device_sampling is enabled.
-        on_device_sampling = True if not continuous_batching or tensor_parallel_size != 2 else False
+        on_device_sampling = True
+        if continuous_batching and tensor_parallel_size == 2:
+            # Neuron SDK 2.22 bug: the model will crash when continuous_batching is enabled
+            # if the tensor parallel size is 2 and on_device_sampling is enabled.
+            warnings.warn(
+                "Activating continuous batching but disabling on-device sampling because of a neuron runtime bug when tensor parallel size is 2."
+            )
+            on_device_sampling = False
         return NxDNeuronConfig(
             checkpoint_id=checkpoint_id,
             checkpoint_revision=checkpoint_revision,

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.2.0.dev4"
+__version__ = "0.2.0.dev5"
 
 __sdk_version__ = "2.22.0"

--- a/tests/decoder/test_decoder_generation.py
+++ b/tests/decoder/test_decoder_generation.py
@@ -123,7 +123,7 @@ def test_decoder_generation_greedy_expectations(neuron_decoder_config):
     outputs = model.generate(**inputs, do_sample=False, max_new_tokens=17)
     if isinstance(model, NxDModelForCausalLM):
         expectations = {
-            "llama": " And how does it differ from other Machine Learning approaches?\n\n**What is Deep Learning?",
+            "llama": " And how does it differ from other Machine Learning approaches?\nDeep learning is a type of",
             "qwen2": " - Part 1\n\nDeep Learning is a subset of Machine Learning that is based on",
             "granite": "\n\nDeep Learning is a subset of Machine Learning, which is a branch of Art",
             "phi": "\n\nDeep learning is a subset of machine learning that uses neural networks with many",
@@ -136,7 +136,9 @@ def test_decoder_generation_greedy_expectations(neuron_decoder_config):
             "phi": "\n\nDeep learning is a subset of machine learning that uses neural networks with many",
         }
     config_name = neuron_decoder_config["name"]
-    assert tokenizer.decode(outputs[0]).endswith(expectations[config_name])
+    generated_text = tokenizer.decode(outputs[0])
+    expected_text = expectations[config_name]
+    assert generated_text.endswith(expected_text)
 
 
 @is_inferentia_test


### PR DESCRIPTION
# What does this PR do?

This pull-request fixes a few issues related to continuous batching and activates it by default for the Llama models as soon as the batch size is > 1.

The reason why continuous batching is always set is because with that flag, the prefill (context encoding) always happens with a batch size of 1, which drastically reduces the device memory and allows to use a higher batch size.

This pull-request also aligns some components inspired from NxDI with NxDI 0.2.0. 

Finally, this pull-request adds a test to verify that the assisted decoding with an assistant model works as expected.

Note: while integrating the speculationtest, some issue with the current implementation imported from NxDI were found, leading to suboptimal token matching. This will be adressed in a subsequent pull-request.