### PR TITLE
Avoid loading weights when exporting an NxD model using the CLI

### DIFF
--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -35,6 +35,7 @@ from optimum.utils import is_diffusers_available, logging
 from optimum.utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessors
 
 from ...neuron.models.auto_model import get_neuron_model_class, has_neuron_model_class
+from ...neuron.models.inference.hlo.backend.modeling_decoder import HloModelForCausalLM
 from ...neuron.utils import (
     DECODER_NAME,
     DIFFUSION_MODEL_CONTROLNET_NAME,
@@ -722,6 +723,7 @@ def maybe_export_from_neuron_model_class(
     if not has_neuron_model_class(model_type=config.model_type, task=task, mode="inference"):
         return False
     neuron_model_class = get_neuron_model_class(model_type=config.model_type, task=task, mode="inference")
+    is_hlo = issubclass(neuron_model_class, HloModelForCausalLM)
     neuron_model = neuron_model_class.from_pretrained(
         model_id=model,
         export=True,
@@ -729,6 +731,7 @@ def maybe_export_from_neuron_model_class(
         subfolder=subfolder,
         config=config,
         trust_remote_code=trust_remote_code,
+        load_weights=True if is_hlo else False,  # Reduce model size for nxd models
         **kwargs,
     )
     if not output.parent.exists():

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -317,6 +317,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         neuron_config: "NeuronConfig",
         token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
+        load_weights: Optional[bool] = True,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
         """Export the model to Neuron format.
@@ -333,6 +334,8 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
                 The token to use for authentication with the Hugging Face Hub.
             revision (`str`, *optional*):
                 The revision of the model to use. If not specified, the latest revision will be used.
+            load_weights (`bool`, *optional*, defaults to `True`):
+                Whether to load the model weights after exporting. If `False`, the model will be exported without weights.
         Returns:
             `NeuronModelForCausalLM`: The exported Neuron model.
         """

--- a/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
+++ b/optimum/neuron/models/inference/hlo/backend/modeling_decoder.py
@@ -190,10 +190,16 @@ class HloModelForCausalLM(NeuronModelForCausalLM, GenerationMixin):
         neuron_config: HloNeuronConfig,
         token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
+        load_weights: Optional[bool] = True,
         **kwargs,
     ) -> "HloModelForCausalLM":
         if not os.path.isdir("/sys/class/neuron_device/"):
             raise SystemError("Decoder models can only be exported on a neuron platform.")
+
+        if not load_weights:
+            warnings.warn(
+                "Ignoring the `load_weights` argument set to False since weights are always loaded for these models."
+            )
 
         if os.path.isdir(model_id):
             checkpoint_dir = model_id

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.2.0.dev7"
+__version__ = "0.2.0.dev8"
 
 __sdk_version__ = "2.22.0"

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -32,7 +32,13 @@ OPTIMUM_CACHE_REPO_ID = "optimum-internal-testing/neuron-testing-cache"
 DECODER_MODEL_CONFIGURATIONS = {
     "llama": {
         "model_id": "unsloth/Llama-3.2-1B-Instruct",
-        "export_kwargs": {"batch_size": 4, "sequence_length": 4096, "num_cores": 2, "auto_cast_type": "fp16"},
+        "export_kwargs": {
+            "batch_size": 4,
+            "sequence_length": 4096,
+            "num_cores": 2,
+            "auto_cast_type": "fp16",
+            "load_weights": False,
+        },
     },
     "qwen2": {
         "model_id": "Qwen/Qwen2.5-0.5B",

--- a/tests/exporters/test_export.py
+++ b/tests/exporters/test_export.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional
 
 from parameterized import parameterized
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, set_seed
+from transformers import __version__ as transformers_version
 from transformers.testing_utils import require_vision
 
 from optimum.exporters.neuron import (
@@ -125,6 +126,11 @@ class NeuronExportTestCase(unittest.TestCase):
         dynamic_batch_size: bool = False,
         inline_weights_to_neff: bool = True,
     ):
+        # REMOVEME: convnextv2 contains a bug in the GRN layer, which is used in the convnextv2 model, but the bug has
+        # been fixed in the transformers library on newer versions. For more info see:
+        # https://github.com/huggingface/transformers/issues/38015
+        if model_type == "convnextv2" and transformers_version.startswith("4.51"):
+            self.skipTest("convnextv2 contains a bug in this version of transformers.")
         library_name = TasksManager.infer_library_from_model(model_name)
         if library_name == "sentence_transformers":
             model_class = TasksManager.get_model_class_for_task(task, framework="pt", library=library_name)


### PR DESCRIPTION
# What does this PR do?

When exporting through the CLI, the exported model is immediately saved to disk, so there is no need to load the weights.
Also, it seems that the `model.pt` is much bigger when the weights have been loaded.