### PR TITLE
chore(mixtral): align compile options to NXDi

### DIFF
--- a/optimum/neuron/models/inference/mixtral/modeling_mixtral.py
+++ b/optimum/neuron/models/inference/mixtral/modeling_mixtral.py
@@ -254,9 +254,7 @@ class MixtralNxDModelForCausalLM(NxDModelForCausalLM):
         compiler_args = "--enable-saturate-infinity --enable-mixed-precision-accumulation --model-type transformer -O1"
         # Add flags for cc-overlap
         compiler_args += " --tensorizer-options='--enable-ccop-compute-overlap --cc-pipeline-tiling-factor=2'"
-        # Prevent auto-down casting when running with fp32
-        if neuron_config.torch_dtype == torch.float32:
-            compiler_args += " --auto-cast=none"
+        compiler_args += " --auto-cast=none"
         # Enable vector-offset DGE
         compiler_args += " --internal-enable-dge-levels vector_dynamic_offsets"
         return compiler_args


### PR DESCRIPTION
This is to aligne to the command line in NXDi 2.2.3: https://github.com/aws-neuron/neuronx-distributed-inference/blob/9b90cd02ffc3cc76bb3e81113a177f10d7a350a8/src/neuronx_distributed_inference/models/mixtral/modeling_mixtral.py#L333

The "--auto-cast=none" is now done always, not just in fp32.
