### PR TITLE
[Inference] Fix head_dim usage in modeling

### DIFF
--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -99,7 +99,7 @@ class NeuronAttentionBase(nn.Module):
         self.hidden_size = config.hidden_size
         self.num_attention_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_key_value_heads
-        self.head_dim = self.hidden_size // self.num_attention_heads
+        self.head_dim = getattr(config, "head_dim", self.hidden_size // self.num_attention_heads)
         self.max_position_embeddings = config.max_position_embeddings
         self.rope_theta = config.rope_theta
         self.padding_side = neuron_config.padding_side
@@ -116,12 +116,6 @@ class NeuronAttentionBase(nn.Module):
         self.qk_scale = qk_scale
 
         self.o_proj_layer_name = "o_proj"
-
-        if (self.head_dim * self.num_attention_heads) != self.hidden_size:
-            raise ValueError(
-                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
-                f" and `num_heads`: {self.num_attention_heads})."
-            )
 
         self.sequence_parallel_enabled = neuron_config.sequence_parallel_enabled
         self.sequence_dimension = 1 if self.sequence_parallel_enabled else None

--- a/optimum/neuron/models/inference/backend/modules/kvcache/kv_cache_manager.py
+++ b/optimum/neuron/models/inference/backend/modules/kvcache/kv_cache_manager.py
@@ -87,17 +87,11 @@ class KVCacheManager(nn.Module):
 
         return utils.divide(num_key_value_heads, tp_degree)
 
-    def _get_hidden_dim_per_head(self, config: PretrainedConfig):
-        hidden_size = config.hidden_size
-        num_atten_head = config.num_attention_heads
-        hidden_dim_per_head = hidden_size // num_atten_head
-        return hidden_dim_per_head
-
     def _init_kv_shape(self, config: PretrainedConfig, neuron_config: NxDNeuronConfig):
         max_batch_size = neuron_config.max_batch_size
         max_len = neuron_config.sequence_length
         num_kv_heads_per_rank = self._get_num_kv_heads_per_rank(config, neuron_config)
-        hidden_dim_per_head = self._get_hidden_dim_per_head(config)
+        hidden_dim_per_head = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
 
         if self.flash_decoding_enabled:
             padded_max_len = max_len

--- a/optimum/neuron/models/inference/backend/pretrained_model.py
+++ b/optimum/neuron/models/inference/backend/pretrained_model.py
@@ -17,7 +17,6 @@ import logging
 import os
 from functools import partial
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import List, Optional, Union
 
 import neuronx_distributed.trace.hlo_utils as hlo_utils
@@ -246,20 +245,16 @@ class NxDPreTrainedModel:
                 logger.info(f"Checkpoint file not found in {model_name_or_path}, trying to load from HuggingFace Hub.")
         if self.neuron_config.checkpoint_id is not None:
             # Fetch weights from the checkpoint
-            checkpoint_dir = TemporaryDirectory()
-            os.chmod(checkpoint_dir.name, 0o775)
-            snapshot_download(
+            checkpoint_path = snapshot_download(
                 repo_id=self.neuron_config.checkpoint_id,
                 revision=self.neuron_config.checkpoint_revision,
                 cache_dir=cache_dir,
                 force_download=force_download,
                 local_files_only=local_files_only,
                 token=token,
-                local_dir=checkpoint_dir.name,
                 allow_patterns=["*.safetensors*"],
             )
-            self._load_weights_from_path(checkpoint_dir.name)
-            checkpoint_dir.cleanup()
+            self._load_weights_from_path(checkpoint_path)
         else:
             raise ValueError(f"Checkpoint file not found under {model_name_or_path}.")
 

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.0.dev2"
+__version__ = "0.3.0.dev3"
 
 __sdk_version__ = "2.22.0"

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -65,7 +65,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         },
     },
     "qwen3": {
-        "model_id": "Qwen/Qwen3-1.7B",
+        "model_id": "Qwen/Qwen3-0.6B",
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,

--- a/tests/decoder/test_decoder_generation.py
+++ b/tests/decoder/test_decoder_generation.py
@@ -127,7 +127,7 @@ def test_decoder_generation_greedy_expectations(neuron_decoder_config):
     expectations = {
         "llama": " and how does it work?\nDeep learning is a subset of machine learning that uses artificial",
         "qwen2": "Deep Learning is a subset of Machine Learning that involves the use of artificial neural networks",
-        "qwen3": "What is Deep Learning? A Deep Learning is a subset of machine learning that uses neural networks with multiple layers to",
+        "qwen3": " What is the difference between Deep Learning and Machine Learning?\n\nDeep Learning is a subset of",
         "granite": "\n\nDeep learning is a subset of machine learning techniques based on artificial neural networks",
         "phi": "\nDeep Learning is a subset of machine learning that uses neural networks with many layers",
     }


### PR DESCRIPTION
# What does this PR do?

This fixes a serious issue in the decoder modeling code for Inference.

The legacy modeling code wrongly always assumed that `head_dim` was equal to `hidden_size // num_attention_heads`: this is true for a lot of models, but not for all of them for which a specific `head_dim` parameter is added to the config.

The issue was revealed by compilation errors due to shape mismatches with `Qwen3-0.6B` and `Qwen3-32B`.
