### PR TITLE
Few inference fixes

### DIFF
--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -113,7 +113,7 @@ class NeuronAttentionBase(nn.Module):
         self.tp_degree = neuron_config.tp_degree
         self.fused_qkv = neuron_config.fused_qkv
         self.clip_qkv = None
-        self.qk_scale = qk_scale
+        self._qk_scale = qk_scale
 
         self.o_proj_layer_name = "o_proj"
 
@@ -160,8 +160,12 @@ class NeuronAttentionBase(nn.Module):
         self.attn_kernel_enabled = neuron_config.attn_kernel_enabled
         self.logical_nc_config = neuron_config.logical_nc_config
 
+    @property
+    def qk_scale(self):
+        return self._qk_scale or (1.0 / math.sqrt(self.head_dim))
+
     def scaled_qk(self, Q, K, attention_mask):
-        qk_scale = self.qk_scale or (1.0 / math.sqrt(self.head_dim))
+        qk_scale = self.qk_scale
         QK = torch.matmul(Q, K.transpose(2, 3)) * qk_scale
         QK = torch.where(attention_mask, QK, torch.finfo(QK.dtype).min)
         return QK
@@ -223,7 +227,7 @@ class NeuronAttentionBase(nn.Module):
                 .reshape((bsz * self.num_heads, self.head_dim, q_len))
                 .to(self.torch_dtype)
             )
-            Q = Q / math.sqrt(self.head_dim)
+            Q = Q * self.qk_scale
             K_active = (
                 K_active.permute(0, 1, 3, 2).reshape((bsz * self.num_heads, self.head_dim, q_len)).to(self.torch_dtype)
             )
@@ -287,7 +291,7 @@ class NeuronAttentionBase(nn.Module):
         TODO: Throw an exception instead of disabling flash attention if explicitly enabled but not eligible.
               This must consider bucketing to avoid throwing an exception for smaller buckets.
         """
-        if self.qk_scale is not None:
+        if self._qk_scale is not None:
             # If a custom qk_scale is provided, flash attention is not supported.
             return FlashAttentionStrategy.NONE
         if int(self.logical_nc_config) > 1:
@@ -316,13 +320,13 @@ class NeuronAttentionBase(nn.Module):
         n_repeat = Q.shape[1]
         K_active = repeat_kv(K, n_repeat)
         V_active = repeat_kv(V, n_repeat)
-        active_scores = (torch.matmul(Q, K_active.transpose(2, 3)) / math.sqrt(self.head_dim)).to(torch.float32)
+        active_scores = (torch.matmul(Q, K_active.transpose(2, 3)) * self.qk_scale).to(torch.float32)
         active_scores = torch.where(active_mask, active_scores, torch.finfo(active_scores.dtype).min)
 
         # prior attention
         K_prior = repeat_kv(past_key_value[0], n_repeat)
         V_prior = repeat_kv(past_key_value[1], n_repeat)
-        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) / math.sqrt(self.head_dim)
+        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) * self.qk_scale
         prior_scores = torch.where(attention_mask, prior_scores, torch.finfo(prior_scores.dtype).min)
         prior_scores = prior_scores.to(torch.float32)
 
@@ -345,14 +349,14 @@ class NeuronAttentionBase(nn.Module):
         V_prior = past_key_value[1]
         K_prior = repeat_kv(K_prior, self.num_key_value_groups)
         V_prior = repeat_kv(V_prior, self.num_key_value_groups)
-        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) / math.sqrt(self.head_dim)
+        prior_scores = torch.matmul(Q, K_prior.transpose(2, 3)) * self.qk_scale
         prior_scores = torch.where(attention_mask, prior_scores, torch.finfo(prior_scores.dtype).min)
         prior_scores = prior_scores.to(torch.float32)
 
         # ii. active (current/new) KV
         K_active = repeat_kv(K, self.num_key_value_groups)
         V_active = repeat_kv(V, self.num_key_value_groups)
-        active_scores = torch.matmul(Q, K_active.transpose(2, 3)) / math.sqrt(self.head_dim)
+        active_scores = torch.matmul(Q, K_active.transpose(2, 3)) * self.qk_scale
         if is_speculation:
             active_scores = torch.where(active_mask, active_scores, torch.finfo(active_scores.dtype).min)
         active_scores = active_scores.to(torch.float32)

--- a/optimum/neuron/models/inference/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/backend/modules/decoder/modeling_decoder.py
@@ -822,7 +822,7 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
     def export(
         cls,
         model_id: str,
-        config: "PretrainedConfig",
+        config: Union["PretrainedConfig", None],
         neuron_config: "NxDNeuronConfig",
         token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
@@ -836,14 +836,15 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
     ) -> "NeuronModelForCausalLM":
         if len(kwargs) > 0:
             logger.warning("Ignoring the following kwargs as they are not supported by neuron: %s", kwargs.keys())
-        config = AutoConfig.from_pretrained(
-            model_id,
-            token=token,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            trust_remote_code=trust_remote_code,
-        )
+        if config is None:
+            config = AutoConfig.from_pretrained(
+                model_id,
+                token=token,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                trust_remote_code=trust_remote_code,
+            )
         # Override torch_dtype in config as it is used by the neuronx_distributed code to cast weights to the correct type
         config.torch_dtype = neuron_config.torch_dtype
         context_encoding_model, token_generation_model, speculation_model = cls.create_model_wrappers(


### PR DESCRIPTION
# What does this PR do?

Few inference fixes encountered while working on a new model integration. Notably:

- fix to use config when provided instead of pulling it from the hub
- fix to use qk_scale in attention when provided (e.g.: in Granite)
- small refactor to simplify Mixtral RMS norm modeling.
- small refactor to simplify test 
