### PR TITLE
[LLM] Reenable on device sampling for (almost) all configurations

### DIFF
--- a/optimum/neuron/models/inference/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/llama/modeling_llama.py
@@ -18,7 +18,6 @@
 import gc
 import logging
 import math
-import warnings
 from typing import Optional, Tuple, Type
 
 import torch
@@ -515,14 +514,6 @@ class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
         auto_cast_type: str,
     ):
         continuous_batching = (batch_size > 1) if batch_size else False
-        on_device_sampling = True
-        if continuous_batching and tensor_parallel_size == 2:
-            # Neuron SDK 2.22 bug: the model will crash when continuous_batching is enabled
-            # if the tensor parallel size is 2 and on_device_sampling is enabled.
-            warnings.warn(
-                "Activating continuous batching but disabling on-device sampling because of a neuron runtime bug when tensor parallel size is 2."
-            )
-            on_device_sampling = False
         return NxDNeuronConfig(
             checkpoint_id=checkpoint_id,
             checkpoint_revision=checkpoint_revision,
@@ -530,7 +521,7 @@ class LlamaNxDModelForCausalLM(NxDModelForCausalLM):
             sequence_length=sequence_length,
             tp_degree=tensor_parallel_size,
             torch_dtype=auto_cast_type,
-            on_device_sampling=on_device_sampling,
+            on_device_sampling=True,
             fused_qkv=True,
             continuous_batching=continuous_batching,
         )

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.0.dev4"
+__version__ = "0.3.0.dev5"
 
 __sdk_version__ = "2.24.0"

--- a/tests/decoder/test_decoder_generation.py
+++ b/tests/decoder/test_decoder_generation.py
@@ -21,7 +21,6 @@ from transformers import AutoTokenizer
 from transformers.generation import StoppingCriteria
 
 from optimum.neuron import NeuronModelForCausalLM
-from optimum.neuron.models.inference.backend.modules.decoder import NxDModelForCausalLM
 from optimum.neuron.models.inference.backend.modules.generation.generation_utils import prepare_sampling_params
 from optimum.neuron.models.inference.llama.modeling_llama import LlamaNxDModelForCausalLM
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
@@ -89,30 +88,6 @@ def test_decoder_generation_custom_stopping_criteria(model_and_tokenizer):
     criteria = CustomStoppingCriteria()
     model.generate(input_ids=torch.ones([1, 10], dtype=torch.int64), stopping_criteria=[criteria])
     assert criteria.called, "Custom StoppingCriteria should have been called"
-
-
-@is_inferentia_test
-@requires_neuronx
-def test_decoder_generation_padded_inputs(model_and_tokenizer):
-    model, tokenizer = model_and_tokenizer
-    if isinstance(model, NxDModelForCausalLM):
-        pytest.skip("NxDModelForCausalLM use right padding and are not prone to this error")
-    prompt = "One of my fondest memory is of my grandmother making homemade bread"
-    first_input = tokenizer(prompt)
-    first_ids = first_input["input_ids"]
-    first_mask = first_input["attention_mask"]
-    max_padding = 12
-    input_len = len(first_ids)
-    for i in range(max_padding):
-        second_ids = [tokenizer.eos_token_id] * i + first_ids[: input_len - i]
-        second_mask = [0] * i + [1] * (input_len - i)
-        input_ids = torch.tensor([first_ids, second_ids], dtype=torch.int64)
-        attention_mask = torch.tensor([first_mask, second_mask], dtype=torch.int64)
-        outputs = model.generate(
-            input_ids=input_ids, attention_mask=attention_mask, do_sample=False, max_new_tokens=10
-        )
-        # Verify we did not generate any unknown token
-        assert torch.all(outputs[:, -1] != 0), f"Unknown token generated for padding {i}"
 
 
 @is_inferentia_test


### PR DESCRIPTION
# What does this PR do?

There was a bug in Neuron SDK 2.22 that led to a compilation crash when `on-device` sampling was enabled if continuous batching was on and TP was 2.

The bug is gone, but the output is garbage for Qwen2/Qwen3 in that configuration, so on-device-sampling is disabled for these models in those configurations.
