### PR TITLE
Move `NEURON_FUSE_SOFTMAX` and `NEURON_CUSTOM_SILU` env var to diffusers model loading

### DIFF
--- a/docs/source/model_doc/diffusers/controlnet.mdx
+++ b/docs/source/model_doc/diffusers/controlnet.mdx
@@ -25,7 +25,7 @@ We can either compile one or multiple ControlNet via the Optimum CLI or programm
 ### Option 1: CLI
 
 ```bash
-optimum-cli export neuron -m runwayml/stable-diffusion-v1-5 --batch_size 1 --height 512 --width 512 --controlnet_ids lllyasviel/sd-controlnet-canny --num_images_per_prompt 1 sd_neuron_controlnet/
+optimum-cli export neuron -m stable-diffusion-v1-5/stable-diffusion-v1-5 --batch_size 1 --height 512 --width 512 --controlnet_ids lllyasviel/sd-controlnet-canny --num_images_per_prompt 1 sd_neuron_controlnet/
 ```
 
 ### Option 2: Python API
@@ -33,7 +33,7 @@ optimum-cli export neuron -m runwayml/stable-diffusion-v1-5 --batch_size 1 --hei
 ```python
 from optimum.neuron import NeuronStableDiffusionControlNetPipeline
 
-model_id = "runwayml/stable-diffusion-v1-5"
+model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 controlnet_id = "lllyasviel/sd-controlnet-canny"
 
 # [Neuron] pipeline

--- a/docs/source/model_doc/diffusers/ip_adapter.mdx
+++ b/docs/source/model_doc/diffusers/ip_adapter.mdx
@@ -52,7 +52,7 @@ Here is an example of exporting stable diffusion components with `NeuronStableDi
 ```python
 from optimum.neuron import NeuronStableDiffusionPipeline
 
-model_id = "runwayml/stable-diffusion-v1-5"
+model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
 input_shapes = {"batch_size": 1, "height": 512, "width": 512}
 
@@ -79,7 +79,7 @@ stable_diffusion.save_pretrained(save_directory)
 ```python
 from optimum.neuron import NeuronStableDiffusionPipeline
 
-model_id = "runwayml/stable-diffusion-v1-5"
+model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
 input_shapes = {"batch_size": 1, "height": 512, "width": 512}
 

--- a/docs/source/model_doc/diffusers/stable_diffusion.mdx
+++ b/docs/source/model_doc/diffusers/stable_diffusion.mdx
@@ -66,7 +66,7 @@ Besides, don't hesitate to tweak the compilation configuration to find the best 
 ```python
 >>> from optimum.neuron import NeuronStableDiffusionPipeline
 
->>> model_id = "runwayml/stable-diffusion-v1-5"
+>>> model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 >>> compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16"}
 >>> input_shapes = {"batch_size": 1, "height": 512, "width": 512}
 
@@ -143,7 +143,7 @@ from PIL import Image
 from io import BytesIO
 from optimum.neuron import NeuronStableDiffusionInpaintPipeline
 
-model_id = "runwayml/stable-diffusion-inpainting"
+model_id = "stable-diffusion-v1-5/stable-diffusion-inpainting"
 input_shapes = {"batch_size": 1, "height": 512, "width": 512}
 pipeline = NeuronStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True, **input_shapes)
 pipeline.save_pretrained("sd_inpaint/")

--- a/optimum/commands/export/neuronx.py
+++ b/optimum/commands/export/neuronx.py
@@ -19,16 +19,7 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 from pathlib import Path
 
 from ...exporters import TasksManager
-from ...utils import is_diffusers_available
 from ..base import BaseOptimumCLICommand, CommandInfo
-
-
-if is_diffusers_available():
-    # Mandatory for applying optimized attention score of Stable Diffusion
-    import os
-
-    os.environ["NEURON_FUSE_SOFTMAX"] = "1"
-    os.environ["NEURON_CUSTOM_SILU"] = "1"
 
 
 def parse_args_neuronx(parser: "ArgumentParser"):

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -328,6 +328,9 @@ def get_submodels_and_neuron_configs(
         # TODO: Enable optional outputs for Stable Diffusion
         if output_attentions:
             raise ValueError(f"`output_attentions`is not supported by the {task} task yet.")
+        # Custom lowering for Softmax and SILU operations. Mandatory for applying optimized attention score of diffusion models.
+        os.environ["NEURON_FUSE_SOFTMAX"] = "1"
+        os.environ["NEURON_CUSTOM_SILU"] = "1"
         models_and_neuron_configs, output_model_names = _get_submodels_and_neuron_configs_for_stable_diffusion(
             model=model,
             input_shapes=input_shapes,

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -1572,7 +1572,7 @@ class NeuronStableDiffusionInstructPix2PixPipeline(
     NeuronDiffusionPipelineBase, StableDiffusionInstructPix2PixPipeline
 ):
     main_input_name = "prompt"
-    task = "task-to-image"
+    task = "text-to-image"
     auto_model_class = StableDiffusionInstructPix2PixPipeline
 
 

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -107,9 +107,6 @@ if is_diffusers_available():
         NeuronStableDiffusionXLControlNetPipelineMixin,
         NeuronStableDiffusionXLPipelineMixin,
     )
-
-    os.environ["NEURON_FUSE_SOFTMAX"] = "1"
-    os.environ["NEURON_CUSTOM_SILU"] = "1"
 else:
     raise ModuleNotFoundError("`diffusers` python package is not installed.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ tests = [
     "mediapipe",
     "timm >= 1.0.0",
     "hf_transfer",
+    "torchcodec",
 ]
 quality = [
     "ruff",


### PR DESCRIPTION
# What does this PR do?

Move both env var to the loading of diffusers model so it would not impact the compilation of other models.

