### PR TITLE
Bump accelerate to 1.3.0 + peft to 0.15.2

### DIFF
--- a/optimum/neuron/accelerate/state.py
+++ b/optimum/neuron/accelerate/state.py
@@ -221,3 +221,7 @@ class NeuronAcceleratorState(AcceleratorState):
     @property
     def autocast_backend(self):
         return self._autocast_backend
+
+    @deepspeed_plugin.setter  # noqa: F821
+    def deepspeed_plugin(self, value):
+        self._deepspeed_plugin = value

--- a/optimum/neuron/accelerate/state.py
+++ b/optimum/neuron/accelerate/state.py
@@ -222,6 +222,20 @@ class NeuronAcceleratorState(AcceleratorState):
     def autocast_backend(self):
         return self._autocast_backend
 
-    @deepspeed_plugin.setter  # noqa: F821
+    @property
+    def deepspeed_plugin(self):
+        """
+        Returns the currently active DeepSpeedPlugin.
+
+        If not using deepspeed, returns `None`.
+        """
+        # To maintain original behavior, return None if not using deepspeed.
+        if self.distributed_type != DistributedType.DEEPSPEED:
+            return None
+        from accelerate.utils.deepspeed import get_active_deepspeed_plugin
+
+        return get_active_deepspeed_plugin(self)
+
+    @deepspeed_plugin.setter
     def deepspeed_plugin(self, value):
         self._deepspeed_plugin = value

--- a/optimum/neuron/peft/mapping.py
+++ b/optimum/neuron/peft/mapping.py
@@ -23,10 +23,11 @@ from .tuners import NeuronLoraModel
 
 
 if is_peft_available():
+    from peft import get_peft_model as orig_get_peft_model
+    from peft.auto import MODEL_TYPE_TO_PEFT_MODEL_MAPPING
     from peft.config import PeftConfig
-    from peft.mapping import MODEL_TYPE_TO_PEFT_MODEL_MAPPING, PEFT_TYPE_TO_CONFIG_MAPPING
+    from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
     from peft.mapping import PEFT_TYPE_TO_TUNER_MAPPING as ORIG_PEFT_TYPE_TO_TUNER_MAPPING
-    from peft.mapping import get_peft_model as orig_get_peft_model
     from peft.mixed_model import PeftMixedModel
     from peft.peft_model import PeftModel
     from peft.tuners.tuners_utils import BaseTuner

--- a/optimum/neuron/peft/peft_model.py
+++ b/optimum/neuron/peft/peft_model.py
@@ -94,7 +94,7 @@ class NeuronPeftModel(PeftModel):
         patcher = Patcher(
             [
                 ("peft.peft_model.PEFT_TYPE_TO_MODEL_MAPPING", PEFT_TYPE_TO_MODEL_MAPPING),
-                ("peft.mapping.MODEL_TYPE_TO_PEFT_MODEL_MAPPING", MODEL_TYPE_TO_PEFT_MODEL_MAPPING),
+                ("peft.auto.MODEL_TYPE_TO_PEFT_MODEL_MAPPING", MODEL_TYPE_TO_PEFT_MODEL_MAPPING),
             ]
         )
         with patcher:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ classifiers = [
 ]
 dependencies = [
     "transformers ~= 4.51.0",
-    "accelerate == 0.29.2",
-    "optimum ~= 1.23.3",
+    "accelerate == 1.3.0",
+    "optimum ~= 1.24.0",
     "huggingface_hub >= 0.29.0",
     "numpy>=1.22.2, <=1.25.2",
     "protobuf>=3.20.3, <4",
@@ -63,7 +63,7 @@ tests = [
     "diffusers>=0.29.0, <=0.30.3",
     "safetensors",
     "sentence-transformers >= 2.2.0",
-    "peft==0.14.0",
+    "peft==0.15.2",
     "trl==0.11.4",
     "compel",
     "rjieba",
@@ -83,7 +83,7 @@ quality = [
 ]
 training = [
     "trl == 0.11.4",
-    "peft == 0.14.0",
+    "peft == 0.15.2",
     "evaluate == 0.4.3",
     "neuronx_distributed==0.13.14393",
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ except Exception as error:
 
 INSTALL_REQUIRES = [
     "transformers ~= 4.51.0",
-    "accelerate == 0.29.2",
-    "optimum ~= 1.23.3",
+    "accelerate == 1.3.0",
+    "optimum ~= 1.24.0",
     "huggingface_hub >= 0.29.0",
     "numpy>=1.22.2, <=1.25.2",
     "protobuf>=3.20.3, <4",
@@ -36,7 +36,7 @@ TESTS_REQUIRE = [
     "diffusers>=0.29.0, <=0.30.3",
     "safetensors",
     "sentence-transformers >= 2.2.0",
-    "peft==0.14.0",
+    "peft==0.15.2",
     "trl==0.11.4",
     "compel",
     "rjieba",
@@ -57,7 +57,7 @@ QUALITY_REQUIRES = [
 
 TRAINING_REQUIRES = [
     "trl == 0.11.4",
-    "peft == 0.14.0",
+    "peft == 0.15.2",
     "evaluate == 0.4.3",
 ]
 
@@ -82,7 +82,7 @@ EXTRAS_REQUIRE = {
         "torchvision==0.22.*",
         "libneuronxla==2.2.4410.0",
     ],
-    "diffusers": ["diffusers>=0.28.0, <=0.30.3", "peft==0.14.0"],
+    "diffusers": ["diffusers>=0.28.0, <=0.30.3", "peft==0.15.2"],
     "sentence-transformers": ["sentence-transformers >= 2.2.0"],
     "vllm": ["vllm == 0.9.2"],
 }


### PR DESCRIPTION
# What does this PR do?

As per title, we need to update the accelerate and peft versions to support Flux model integration, thus the PR.
