### PR TITLE
chore: remove doc-builder dependency from quality extra

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -61,7 +61,7 @@ jobs:
           python -m ensurepip --upgrade
           python -m pip install --upgrade setuptools
           python -m pip install ".[quality, diffusers]"
-
+          python -m pip install "git+https://github.com/huggingface/doc-builder.git"
       - name: Make documentation
         shell: bash
         run: |

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -45,6 +45,7 @@ jobs:
           source aws_neuron_venv_pytorch/bin/activate
           pip install --upgrade pip
           pip install ".[quality, diffusers]"
+          python -m pip install "git+https://github.com/huggingface/doc-builder.git"
       - name: Make documentation
         shell: bash
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 1. Setup
 ```bash
-pip install hf-doc-builder==0.4.0 watchdog --upgrade
+pip install "git+https://github.com/huggingface/doc-builder.git" watchdog --upgrade
 ```
 
 2. Local Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ tests = [
 quality = [
     "ruff",
     "isort",
-    "hf_doc_builder @ git+https://github.com/huggingface/doc-builder.git",
 ]
 training = [
     "trl == 0.11.4",


### PR DESCRIPTION
To build the documentation, we use doc-builder, but having a git+https dependency in the pyproject.toml file makes the pypi validation fail. so far the solution was to manually remove the line before creating and uploading the package, but this is not very clean nor practical. So the dependency is removed, and the package is installed manually on the pipelines that build the documentation.
