### PR TITLE
feat: changes the way we break graphs for logging / saving during Training

### DIFF
--- a/optimum/neuron/trainers/base.py
+++ b/optimum/neuron/trainers/base.py
@@ -492,8 +492,12 @@ class _TrainerForNeuron:
                 self.control.should_save = is_new_best_metric
 
         if self.control.should_save:
-            self._save_checkpoint(model, trial)
-            self.control = self.callback_handler.on_save(self.args, self.state, self.control)
+
+            def save_closure(self, model, trial):
+                self._save_checkpoint(model, trial)
+                self.control = self.callback_handler.on_save(self.args, self.state, self.control)
+
+            xm.add_step_closure(save_closure, (self, model, trial))
 
     def _save_xla(self, output_dir: str | None = None):
         output_dir = output_dir if output_dir is not None else self.args.output_dir


### PR DESCRIPTION
# What does this PR do?

This PR changes the way we break XLA graphs during training.

**Before**: `training_step + loss_reduction` for every non-logging steps and  `training_step + loss_reduction` + `tr_loss.zero_()` for logging steps

**Proposal**: `training_step` for every non-logging steps and `training_step` + `loss_reduction and tr_loss.zero_()` for logging steps