### PR TITLE
chore: bump dev version

### DIFF
--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.0.dev5"
+__version__ = "0.3.1.dev0"
 
 __sdk_version__ = "2.24.0"


### PR DESCRIPTION
# What does this PR do?

The dev version hasn't been bumped since the last release.
