### PR TITLE
fix: flux neuron cache detection

### DIFF
--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -991,7 +991,9 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
 
         if cache_exist:
             # load cache
-            logger.info(f"Neuron cache found at {model_cache_dir}. If you want to recompile the model, please set `disable_neuron_cache=True`.")
+            logger.info(
+                f"Neuron cache found at {model_cache_dir}. If you want to recompile the model, please set `disable_neuron_cache=True`."
+            )
             neuron_model = cls.from_pretrained(model_cache_dir, data_parallel_mode=data_parallel_mode)
             # replace weights
             if not inline_weights_to_neff:

--- a/optimum/neuron/models/inference/flux/modeling_flux.py
+++ b/optimum/neuron/models/inference/flux/modeling_flux.py
@@ -117,7 +117,7 @@ class NeuronFluxTransformer2DModel(torch.nn.Module):
         joint_attention_dim: int = 4096,
         pooled_projection_dim: int = 768,
         guidance_embeds: bool = False,
-        axes_dims_rope: tuple[int] = (16, 56, 56),
+        axes_dims_rope: list[int] = [16, 56, 56],
         reduce_dtype: torch.dtype = torch.bfloat16,
     ):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ tests = [
     "mediapipe",
     "timm >= 1.0.0",
     "hf_transfer",
-    "torchcodec",
+    "torchcodec < 0.6.0",
 ]
 quality = [
     "ruff",


### PR DESCRIPTION
# What does this PR do?

TP size was not considered for diffusers before Flux, thus Optimum Neuron was unable to identify cached Flux artifacts, this PR would fix it.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
