### PR TITLE
allow safetensors to be downloaded for flux

### DIFF
--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -643,7 +643,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
             # Downloads all repo's files matching the allowed patterns
             is_flux_model = "flux" in model_id.lower()
             if is_flux_model:
-                ignore_patterns = ["*.msgpack", "*.bin"]  # Weights an
+                ignore_patterns = ["*.msgpack", "*.bin"] 
             else:
                 ignore_patterns = ["*.msgpack", "*.safetensors", "*.bin"]
 

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -643,7 +643,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
             # Downloads all repo's files matching the allowed patterns
             is_flux_model = "flux" in model_id.lower()
             if is_flux_model:
-                ignore_patterns = ["*.msgpack", "*.bin"] 
+                ignore_patterns = ["*.msgpack", "*.bin"]
             else:
                 ignore_patterns = ["*.msgpack", "*.safetensors", "*.bin"]
 

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -641,12 +641,6 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 }
             )
             # Downloads all repo's files matching the allowed patterns
-            is_flux_model = "flux" in model_id.lower()
-            if is_flux_model:
-                ignore_patterns = ["*.msgpack", "*.bin"]
-            else:
-                ignore_patterns = ["*.msgpack", "*.safetensors", "*.bin"]
-
             model_id = snapshot_download(
                 model_id,
                 cache_dir=cache_dir,
@@ -655,7 +649,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 revision=revision,
                 force_download=force_download,
                 allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns,
+                ignore_patterns=["*.msgpack", "*.bin"],
             )
 
         new_model_save_dir = Path(model_id)

--- a/optimum/neuron/modeling_diffusion.py
+++ b/optimum/neuron/modeling_diffusion.py
@@ -641,6 +641,12 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 }
             )
             # Downloads all repo's files matching the allowed patterns
+            is_flux_model = "flux" in model_id.lower()
+            if is_flux_model:
+                ignore_patterns = ["*.msgpack", "*.bin"]  # Weights an
+            else:
+                ignore_patterns = ["*.msgpack", "*.safetensors", "*.bin"]
+
             model_id = snapshot_download(
                 model_id,
                 cache_dir=cache_dir,
@@ -649,7 +655,7 @@ class NeuronDiffusionPipelineBase(NeuronTracedModel):
                 revision=revision,
                 force_download=force_download,
                 allow_patterns=allow_patterns,
-                ignore_patterns=["*.msgpack", "*.safetensors", "*.bin"],
+                ignore_patterns=ignore_patterns,
             )
 
         new_model_save_dir = Path(model_id)


### PR DESCRIPTION
When trying to download Flux models with `from_pretrained` from the Hub, the `.safetensors` weights inside the `transforms/weights` folder are currently ignored and therefore not downloaded.

Example:

```python
from optimum.neuron import NeuronFluxPipeline
pipe = NeuronFluxPipeline.from_pretrained("Jingya/FLUX.1-dev-neuronx-1024x1024-tp8")
```

This leads to missing weight files, since for Flux the weights and graph are stored separately, and the weights are provided as `.safetensors`.

Fix:

This PR updates the download logic to include `.safetensors` files, ensuring that the Flux pipeline loads correctly and all necessary weights are available.
