### PR TITLE
Add support for Qwen3Moe models

### DIFF
--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -26,6 +26,7 @@ jobs:
         config: [
           llama,
           qwen,
+          qwen-moe,
           qwen2.5,
           granite,
           phi4,

--- a/docs/source/supported_architectures.mdx
+++ b/docs/source/supported_architectures.mdx
@@ -86,7 +86,7 @@ If a LLM is listed, e.g. a model with a `text-generation` task, it means that th
 | MPNet                     | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | Phi3                      | text-generation                                                                                 |
 | Phi                       | feature-extraction, text-classification, token-classification                                                                                 |
-| Qwen2, Qwen 3                     | text-generation                                                                                 |
+| Qwen2, Qwen3, Qwen3Moe    | text-generation                                                                                 |
 | RoBERTa                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | RoFormer                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | SmolLM3                   | text-generation                                                                                                                               |

--- a/optimum/neuron/models/inference/auto_models.py
+++ b/optimum/neuron/models/inference/auto_models.py
@@ -28,6 +28,7 @@ from .mixtral.modeling_mixtral import MixtralNxDModelForCausalLM
 from .phi3.modeling_phi3 import Phi3NxDModelForCausalLM
 from .qwen2.modeling_qwen2 import Qwen2NxDModelForCausalLM
 from .qwen3.modeling_qwen3 import Qwen3NxDModelForCausalLM
+from .qwen3_moe.modeling_qwen3_moe import Qwen3MoeNxDModelForCausalLM
 from .smollm3.modeling_smollm3 import SmolLM3NxDModelForCausalLM
 
 
@@ -90,6 +91,15 @@ class Qwen2ModelForCausalLM(Qwen2NxDModelForCausalLM):
 class Qwen3NeuronModelForCausalLM(Qwen3NxDModelForCausalLM):
     """
     Qwen3 model with NxD backend for inference on AWS Neuron.
+    """
+
+    pass
+
+
+@register_neuron_model_for_inference("qwen3_moe", "text-generation")
+class Qwen3MoeNeuronModelForCausalLM(Qwen3MoeNxDModelForCausalLM):
+    """
+    Qwen3Moe model with NxD backend for inference on AWS Neuron.
     """
 
     pass

--- a/optimum/neuron/models/inference/backend/config.py
+++ b/optimum/neuron/models/inference/backend/config.py
@@ -75,7 +75,6 @@ class NxDNeuronConfig(NeuronConfig):
         is_chunked_prefill: bool | None = False,
         flash_decoding_enabled: bool | None = False,
         async_mode: bool | None = False,
-        qk_layernorm: bool | None = False,
         attn_kernel_enabled: bool | None = False,
         qkv_kernel_enabled: bool | None = False,
         mlp_kernel_enabled: bool | None = False,
@@ -103,10 +102,6 @@ class NxDNeuronConfig(NeuronConfig):
             raise ValueError("`qkv_kernel_enabled` and `mlp_kernel_enabled` are not supported for trn1 chips.")
         if vocab_parallel:
             raise ValueError("`vocab_parallel` is not supported in optimum-neuron.")
-        if qk_layernorm:
-            raise ValueError(
-                "`qk_layernorm` is not supported in optimum-neuron. It is actually a modeling flag that affects the attention layer."
-            )
         # Required to retrieve a checkpoint from the hub
         self.checkpoint_id = checkpoint_id
         self.checkpoint_revision = checkpoint_revision
@@ -166,9 +161,6 @@ class NxDNeuronConfig(NeuronConfig):
         # Distributed config
         self.pp_degree = pp_degree
         self.ep_degree = ep_degree
-
-        # QK layer normalization
-        self.qk_layernorm = qk_layernorm
 
         # Multi-node
         # TODO: Check if start_rank_id can be modified dynamically at runtime

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -103,7 +103,6 @@ class NeuronAttentionBase(nn.Module):
         self.rope_theta = config.rope_theta
         self.padding_side = neuron_config.padding_side
         self.torch_dtype = neuron_config.torch_dtype
-        self.qk_layernorm = neuron_config.qk_layernorm
         self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
         self.num_cores_per_group = neuron_config.num_cores_per_group
         self.rpl_reduce_dtype = neuron_config.rpl_reduce_dtype
@@ -154,8 +153,10 @@ class NeuronAttentionBase(nn.Module):
         self.num_heads = utils.divide(self.qkv_proj.get_num_attention_heads(), self.tp_degree)
         self.num_key_value_heads = utils.divide(self.qkv_proj.get_num_key_value_heads(), self.tp_degree)
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
-        self.q_layernorm = nn.LayerNorm(self.head_dim) if self.qk_layernorm else None
-        self.k_layernorm = nn.LayerNorm(self.head_dim) if self.qk_layernorm else None
+        # By default we do not use layernorm in q and k projection
+        # This can be changed in the subclass if needed: maybe make it a parameter?
+        self.q_layernorm = None
+        self.k_layernorm = None
         self.attn_kernel_enabled = neuron_config.attn_kernel_enabled
         self.logical_nc_config = neuron_config.logical_nc_config
 

--- a/optimum/neuron/models/inference/backend/pretrained_model.py
+++ b/optimum/neuron/models/inference/backend/pretrained_model.py
@@ -288,7 +288,9 @@ class NxDPreTrainedModel:
         return model_sd
 
     @staticmethod
-    def convert_hf_to_neuron_state_dict(state_dict: dict, config: PretrainedConfig) -> dict:
+    def convert_hf_to_neuron_state_dict(
+        state_dict: dict, config: PretrainedConfig, neuron_config: NxDNeuronConfig
+    ) -> dict:
         """This function should be over-ridden in child classes as needed"""
         return state_dict
 

--- a/optimum/neuron/models/inference/qwen3/modeling_qwen3.py
+++ b/optimum/neuron/models/inference/qwen3/modeling_qwen3.py
@@ -48,9 +48,10 @@ class NeuronQwen3Attention(NeuronAttentionBase):
 
     def __init__(self, config: Qwen3Config, neuron_config: NxDNeuronConfig):
         super().__init__(config, neuron_config)
+        self.rotary_emb = LlamaRotaryEmbedding(config)
+        # Qwen3 specific: set q_layernorm and k_layernorm
         self.q_layernorm = CustomRMSNorm(self.head_dim, eps=config.rms_norm_eps)  # unlike olmo, only on the head dim!
         self.k_layernorm = CustomRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.rotary_emb = LlamaRotaryEmbedding(config)
 
 
 class NeuronQwen3DecoderLayer(NeuronLlamaDecoderLayer):

--- a/optimum/neuron/models/inference/qwen3_moe/modeling_qwen3_moe.py
+++ b/optimum/neuron/models/inference/qwen3_moe/modeling_qwen3_moe.py
@@ -1,0 +1,230 @@
+# coding=utf-8
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Adapted from https://github.com/aws-neuron/neuronx-distributed-inference/blob/main/src/neuronx_distributed_inference/models/qwen3_moe/modeling_qwen3_moe.py
+"""Qwen3 MOE model for NXD inference."""
+
+import gc
+
+import torch
+from neuronx_distributed.parallel_layers import parallel_state
+from neuronx_distributed.parallel_layers.layers import ColumnParallelLinear, ParallelEmbedding
+from torch import nn
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+
+from ..backend.config import NxDNeuronConfig
+from ..backend.modules.attention.attention_base import NeuronAttentionBase
+from ..backend.modules.attention.utils import RotaryEmbedding
+from ..backend.modules.custom_calls import CustomRMSNorm
+from ..backend.modules.decoder import NxDDecoderModel, NxDModelForCausalLM
+from ..backend.modules.moe import initialize_moe_module
+from ..mixtral.modeling_mixtral import NeuronMixtralDecoderLayer
+
+
+def convert_qwen3_moe_hf_to_neuron_state_dict(neuron_state_dict, config, neuron_config):
+    """
+    Helper function which converts the huggingface checkpoints to state dictionary compatible with the stucture of the neuron MoE model.
+    """
+    assert neuron_config.glu_mlp is True, "Only GLU MLP is supported"
+
+    # to facilitate rank usage in base model
+    neuron_state_dict["rank_util.rank"] = torch.arange(0, neuron_config.tp_degree, dtype=torch.int32)
+
+    for l in range(config.num_hidden_layers):  # noqa: E741
+        # Rename the q_norm, k_norm names
+        neuron_state_dict[f"layers.{l}.self_attn.k_layernorm.weight"] = (
+            neuron_state_dict[f"layers.{l}.self_attn.k_norm.weight"].detach().clone()
+        )
+        del neuron_state_dict[f"layers.{l}.self_attn.k_norm.weight"]
+
+        # Rename the q_norm, k_norm names
+        neuron_state_dict[f"layers.{l}.self_attn.q_layernorm.weight"] = (
+            neuron_state_dict[f"layers.{l}.self_attn.q_norm.weight"].detach().clone()
+        )
+        del neuron_state_dict[f"layers.{l}.self_attn.q_norm.weight"]
+
+        # Copy router weights
+        neuron_state_dict[f"layers.{l}.mlp.router.linear_router.weight"] = (
+            neuron_state_dict[f"layers.{l}.mlp.gate.weight"].detach().clone()
+        )
+        del neuron_state_dict[f"layers.{l}.mlp.gate.weight"]
+
+        intermediate_size, hidden_size = neuron_state_dict[f"layers.{l}.mlp.experts.0.gate_proj.weight"].shape
+        device = neuron_state_dict[f"layers.{l}.mlp.experts.0.gate_proj.weight"].device
+        dtype = neuron_state_dict[f"layers.{l}.mlp.experts.0.gate_proj.weight"].dtype
+
+        # copy the MLP parameters
+        gate_up_proj = torch.empty(
+            config.num_experts,
+            hidden_size,
+            2 * intermediate_size,
+            dtype=dtype,
+            device=device,
+        )
+        for e in range(config.num_experts):
+            # Copy gate_proj and up_proj after concatenation
+            gate_proj_weights = neuron_state_dict[f"layers.{l}.mlp.experts.{e}.gate_proj.weight"].T.detach().clone()
+            up_proj_weights = neuron_state_dict[f"layers.{l}.mlp.experts.{e}.up_proj.weight"].T.detach().clone()
+
+            gate_up_proj_slice = torch.narrow(gate_up_proj, 0, e, 1)
+            gate_proj_slice = torch.narrow(gate_up_proj_slice, 2, 0, intermediate_size)
+            gate_proj_slice.copy_(gate_proj_weights)
+            up_proj_slice = torch.narrow(gate_up_proj_slice, 2, intermediate_size, intermediate_size)
+            up_proj_slice.copy_(up_proj_weights)
+
+            del neuron_state_dict[f"layers.{l}.mlp.experts.{e}.gate_proj.weight"]
+            del neuron_state_dict[f"layers.{l}.mlp.experts.{e}.up_proj.weight"]
+        neuron_state_dict[f"layers.{l}.mlp.expert_mlps.mlp_op.gate_up_proj.weight"] = gate_up_proj
+
+        down_proj = torch.empty(
+            config.num_experts,
+            intermediate_size,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+        )
+        for e in range(config.num_experts):
+            # Copy down_proj
+            down_proj_weights = neuron_state_dict[f"layers.{l}.mlp.experts.{e}.down_proj.weight"].T.detach().clone()
+            down_proj_slice = torch.narrow(down_proj, 0, e, 1)
+            down_proj_slice.copy_(down_proj_weights)
+            del neuron_state_dict[f"layers.{l}.mlp.experts.{e}.down_proj.weight"]
+        neuron_state_dict[f"layers.{l}.mlp.expert_mlps.mlp_op.down_proj.weight"] = down_proj
+
+        gc.collect()
+
+    return neuron_state_dict
+
+
+class NeuronQwen3MoEAttention(NeuronAttentionBase):
+    def __init__(self, config: Qwen3MoeConfig, neuron_config: NxDNeuronConfig):
+        super().__init__(config, neuron_config)
+        self.tp_degree = parallel_state.get_tensor_model_parallel_size()
+        self.rotary_emb = RotaryEmbedding(
+            config.head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            base=config.rope_theta,
+        )
+
+        # Qwen3Moe specific: set q_layernorm and k_layernorm
+        self.q_layernorm = CustomRMSNorm(self.head_dim, self.rms_norm_eps)
+        self.k_layernorm = CustomRMSNorm(self.head_dim, self.rms_norm_eps)
+
+
+class NeuronQwen3MoeDecoderLayer(NeuronMixtralDecoderLayer):
+    """
+    The only difference with the NeuronMixtralDecoderLayer is the use
+    of the NeuronQwen3MoEAttention.
+    """
+
+    def __init__(self, config: Qwen3MoeConfig, neuron_config: NxDNeuronConfig, layer_idx: int):
+        nn.Module.__init__(self)
+        self.hidden_size = config.hidden_size
+        self.self_attn = NeuronQwen3MoEAttention(config, neuron_config)
+
+        self.mlp = initialize_moe_module(
+            neuron_config=neuron_config,
+            num_experts=config.num_experts,
+            top_k=config.num_experts_per_tok,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            hidden_act=config.hidden_act,
+        )
+
+        self.input_layernorm = CustomRMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = CustomRMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+
+class NxDQwen3MoeModel(NxDDecoderModel):
+    """
+    NxDQwen3MoeModel extends the Qwen3MoeModel to be traceable.
+    The forward function of this class is traced.
+    """
+
+    def __init__(self, config: Qwen3MoeConfig, neuron_config: NxDNeuronConfig):
+        super().__init__(config, neuron_config)
+
+        self.embed_tokens = ParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            config.pad_token_id,
+            dtype=neuron_config.torch_dtype,
+            shard_across_embedding=True,
+        )
+        self.layers = nn.ModuleList(
+            [
+                NeuronQwen3MoeDecoderLayer(config, neuron_config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = CustomRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = ColumnParallelLinear(
+            config.hidden_size,
+            config.vocab_size,
+            gather_output=not neuron_config.on_device_sampling,
+            bias=False,
+        )
+
+
+class Qwen3MoeNxDModelForCausalLM(NxDModelForCausalLM):
+    """
+    This class can be used as Qwen3MoeForCausalLM
+    """
+
+    _model_cls = NxDQwen3MoeModel
+
+    @classmethod
+    def get_neuron_config_cls(cls):
+        return NxDNeuronConfig
+
+    @staticmethod
+    def convert_hf_to_neuron_state_dict(
+        state_dict: dict, config: Qwen3MoeConfig, neuron_config: NxDNeuronConfig
+    ) -> dict:
+        return convert_qwen3_moe_hf_to_neuron_state_dict(state_dict, config, neuron_config)
+
+    @classmethod
+    def get_compiler_args(cls, neuron_config: NxDNeuronConfig):
+        compiler_args = "--enable-saturate-infinity --enable-mixed-precision-accumulation --model-type transformer -O1"
+        # Add flags for cc-overlap
+        compiler_args += " --tensorizer-options='--enable-ccop-compute-overlap --cc-pipeline-tiling-factor=2'"
+        compiler_args += " --auto-cast=none"
+        # Enable vector-offset DGE
+        compiler_args += " --internal-enable-dge-levels vector_dynamic_offsets"
+        compiler_args += " --internal-hlo2tensorizer-options='--verify-hlo=true'"
+        return compiler_args
+
+    @classmethod
+    def _get_neuron_config(
+        cls,
+        checkpoint_id: str,
+        checkpoint_revision: str,
+        batch_size: int,
+        sequence_length: int,
+        tensor_parallel_size: int,
+        auto_cast_type: str,
+    ):
+        return NxDNeuronConfig(
+            checkpoint_id=checkpoint_id,
+            checkpoint_revision=checkpoint_revision,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            tp_degree=tensor_parallel_size,
+            torch_dtype=auto_cast_type,
+        )

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.1.dev1"
+__version__ = "0.3.1.dev2"
 
 __sdk_version__ = "2.24.0"

--- a/tests/decoder/test_decoder_export.py
+++ b/tests/decoder/test_decoder_export.py
@@ -23,10 +23,11 @@ from optimum.neuron.utils import DTYPE_MAPPER
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
 
 
-DECODER_MODEL_ARCHITECTURES = ["llama", "granite", "qwen2", "phi3", "mixtral"]
+DECODER_MODEL_ARCHITECTURES = ["llama", "granite", "qwen2", "qwen3-moe", "phi3", "mixtral"]
 DECODER_MODEL_NAMES = {
     "llama": "llamafactory/tiny-random-Llama-3",
     "qwen2": "yujiepan/qwen2.5-128k-tiny-random",
+    "qwen3-moe": "optimum-internal-testing/tiny-random-qwen3_moe",
     "granite": "hf-internal-testing/tiny-random-GraniteForCausalLM",
     "phi3": "yujiepan/phi-4-tiny-random",
     "mixtral": "dacorvo/Mixtral-tiny",


### PR DESCRIPTION
# What does this PR do?

This adds support for a new model architecture: Qwen3Moe.

The pull-request only includes an export test with a tiny model, as there are no small Qwen3Moe models that could be used for an inference test.