### PR TITLE
Cleanup inference backend modules

### DIFF
--- a/optimum/neuron/models/inference/backend/config.py
+++ b/optimum/neuron/models/inference/backend/config.py
@@ -127,8 +127,6 @@ class NxDNeuronConfig(NeuronConfig):
         self.is_chunked_prefill = is_chunked_prefill
 
         # Continuous batching
-        # TODO: Check if we really need different batch size for CTE and TKG, given
-        # that we anyway provide two different config instance for them.
         self.continuous_batching = continuous_batching
         self.max_batch_size = batch_size if max_batch_size is None else max_batch_size
 

--- a/optimum/neuron/models/inference/backend/config.py
+++ b/optimum/neuron/models/inference/backend/config.py
@@ -64,7 +64,6 @@ class NxDNeuronConfig(NeuronConfig):
         ep_degree: int | None = 1,
         pp_degree: int | None = 1,
         torch_dtype: str | torch.dtype | None = torch.bfloat16,
-        rpl_reduce_dtype: str | torch.dtype | None = None,
         n_active_tokens: int | None = None,
         max_context_length: int | None = None,
         output_logits: bool | None = False,
@@ -113,10 +112,6 @@ class NxDNeuronConfig(NeuronConfig):
             self.torch_dtype = DTYPE_MAPPER.pt(self.torch_dtype)
         self.n_active_tokens = self.sequence_length if n_active_tokens is None else n_active_tokens
         self.output_logits = output_logits
-
-        self.rpl_reduce_dtype = torch_dtype if rpl_reduce_dtype is None else rpl_reduce_dtype
-        if isinstance(self.rpl_reduce_dtype, str):
-            self.rpl_reduce_dtype = DTYPE_MAPPER.pt(self.rpl_reduce_dtype)
 
         # fallback to sequence_length is for compatibility with vllm
         self.max_context_length = max_context_length

--- a/optimum/neuron/models/inference/backend/config.py
+++ b/optimum/neuron/models/inference/backend/config.py
@@ -68,7 +68,6 @@ class NxDNeuronConfig(NeuronConfig):
         n_active_tokens: int | None = None,
         max_context_length: int | None = None,
         output_logits: bool | None = False,
-        padding_side: str | None = "right",
         fused_qkv: bool | None = False,
         vocab_parallel: bool | None = False,
         sequence_parallel_enabled: bool | None = False,
@@ -114,8 +113,6 @@ class NxDNeuronConfig(NeuronConfig):
             self.torch_dtype = DTYPE_MAPPER.pt(self.torch_dtype)
         self.n_active_tokens = self.sequence_length if n_active_tokens is None else n_active_tokens
         self.output_logits = output_logits
-
-        self.padding_side = padding_side
 
         self.rpl_reduce_dtype = torch_dtype if rpl_reduce_dtype is None else rpl_reduce_dtype
         if isinstance(self.rpl_reduce_dtype, str):

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -104,11 +104,8 @@ class NeuronAttentionBase(nn.Module):
         self.torch_dtype = neuron_config.torch_dtype
         self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
         self.num_cores_per_group = neuron_config.num_cores_per_group
-        self.rpl_reduce_dtype = neuron_config.rpl_reduce_dtype
         self.mlp_kernel_enabled = neuron_config.mlp_kernel_enabled
         self.rms_norm_eps = config.rms_norm_eps
-        self.tp_degree = neuron_config.tp_degree
-        self.fused_qkv = neuron_config.fused_qkv
         self._qk_scale = qk_scale
 
         self.o_proj_layer_name = "o_proj"
@@ -120,11 +117,11 @@ class NeuronAttentionBase(nn.Module):
             head_dim=self.head_dim,
             num_attention_heads=self.num_attention_heads,
             num_key_value_heads=self.num_key_value_heads,
-            tp_degree=self.tp_degree,
+            tp_degree=neuron_config.tp_degree,
             dtype=self.torch_dtype,
             bias=qkv_proj_bias,
             gather_output=False,
-            fused_qkv=self.fused_qkv,
+            fused_qkv=neuron_config.fused_qkv,
             sequence_parallel_enabled=self.sequence_parallel_enabled,
             sequence_dimension=self.sequence_dimension,
             tensor_model_parallel_group=self.tensor_model_parallel_group,
@@ -137,7 +134,7 @@ class NeuronAttentionBase(nn.Module):
             head_dim=self.head_dim,
             num_attention_heads=self.num_attention_heads,
             num_key_value_heads=self.num_key_value_heads,
-            tp_degree=self.tp_degree,
+            tp_degree=neuron_config.tp_degree,
             dtype=self.torch_dtype,
             bias=o_proj_bias,
             input_is_parallel=True,
@@ -145,10 +142,10 @@ class NeuronAttentionBase(nn.Module):
             sequence_parallel_enabled=self.sequence_parallel_enabled,
             sequence_dimension=self.sequence_dimension,
             tensor_model_parallel_group=self.tensor_model_parallel_group,
-            rpl_reduce_dtype=self.rpl_reduce_dtype,
+            rpl_reduce_dtype=neuron_config.rpl_reduce_dtype,
         )
-        self.num_heads = utils.divide(self.qkv_proj.get_num_attention_heads(), self.tp_degree)
-        self.num_key_value_heads = utils.divide(self.qkv_proj.get_num_key_value_heads(), self.tp_degree)
+        self.num_heads = utils.divide(self.qkv_proj.get_num_attention_heads(), neuron_config.tp_degree)
+        self.num_key_value_heads = utils.divide(self.qkv_proj.get_num_key_value_heads(), neuron_config.tp_degree)
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         # By default we do not use layernorm in q and k projection
         # This can be changed in the subclass if needed: maybe make it a parameter?

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -141,7 +141,7 @@ class NeuronAttentionBase(nn.Module):
             sequence_parallel_enabled=self.sequence_parallel_enabled,
             sequence_dimension=self.sequence_dimension,
             tensor_model_parallel_group=self.tensor_model_parallel_group,
-            rpl_reduce_dtype=neuron_config.rpl_reduce_dtype,
+            rpl_reduce_dtype=neuron_config.torch_dtype,
         )
         self.num_heads = utils.divide(self.qkv_proj.get_num_attention_heads(), neuron_config.tp_degree)
         self.num_key_value_heads = utils.divide(self.qkv_proj.get_num_key_value_heads(), neuron_config.tp_degree)

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -94,7 +94,6 @@ class NeuronAttentionBase(nn.Module):
             self.tensor_model_parallel_group = nxd.parallel_layers.parallel_state.get_tensor_model_parallel_group()
             self.rank_util = SPMDRank(world_size=self.tensor_model_parallel_group.size())
 
-        self.is_causal = True
         self.hidden_size = config.hidden_size
         self.num_attention_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_key_value_heads

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -100,7 +100,6 @@ class NeuronAttentionBase(nn.Module):
         self.head_dim = getattr(config, "head_dim", self.hidden_size // self.num_attention_heads)
         self.max_position_embeddings = config.max_position_embeddings
         self.rope_theta = config.rope_theta
-        self.padding_side = neuron_config.padding_side
         self.torch_dtype = neuron_config.torch_dtype
         self.flash_decoding_enabled = neuron_config.flash_decoding_enabled
         self.num_cores_per_group = neuron_config.num_cores_per_group
@@ -205,10 +204,6 @@ class NeuronAttentionBase(nn.Module):
 
         if flash_attn_strategy != FlashAttentionStrategy.NONE:
             logger.debug(f"ATTN kernel: logical_nc_config={self.logical_nc_config}")
-            # if we are using left padding, then the bzs needs be 1 (otherwise we get wrong result
-            # because flash attention does not use attention_mask). In practice, we use right
-            # padding so this is unlikely to cause issues
-            assert self.padding_side == "right" or bsz == 1
 
             # original shape of q, k, v is BHSD, and expected output is also BHSD.
             logger.debug(f"Using flash_fwd for Q.shape={Q.shape}")

--- a/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
+++ b/optimum/neuron/models/inference/backend/modules/attention/attention_base.py
@@ -109,7 +109,6 @@ class NeuronAttentionBase(nn.Module):
         self.rms_norm_eps = config.rms_norm_eps
         self.tp_degree = neuron_config.tp_degree
         self.fused_qkv = neuron_config.fused_qkv
-        self.clip_qkv = None
         self._qk_scale = qk_scale
 
         self.o_proj_layer_name = "o_proj"
@@ -126,7 +125,6 @@ class NeuronAttentionBase(nn.Module):
             bias=qkv_proj_bias,
             gather_output=False,
             fused_qkv=self.fused_qkv,
-            clip_qkv=self.clip_qkv,
             sequence_parallel_enabled=self.sequence_parallel_enabled,
             sequence_dimension=self.sequence_dimension,
             tensor_model_parallel_group=self.tensor_model_parallel_group,

--- a/optimum/neuron/models/inference/backend/modules/decoder/decoder_wrapper.py
+++ b/optimum/neuron/models/inference/backend/modules/decoder/decoder_wrapper.py
@@ -52,7 +52,6 @@ def get_bucket_model_config_from_tag(
             bucket_kernel=get_context_encoder_bk,
             bucket_kernel_constant_args=(
                 torch.tensor(buckets),
-                neuron_config.padding_side,
                 pad_token,
             ),
             shared_state_buffer=None,
@@ -63,7 +62,6 @@ def get_bucket_model_config_from_tag(
             bucket_kernel=get_generation_model_bk,
             bucket_kernel_constant_args=(
                 torch.tensor(buckets),
-                neuron_config.padding_side,
                 0,
             ),
             shared_state_buffer=None,

--- a/optimum/neuron/models/inference/backend/modules/generation/generation_utils.py
+++ b/optimum/neuron/models/inference/backend/modules/generation/generation_utils.py
@@ -258,17 +258,11 @@ class NxDGenerationMixin(GenerationMixin):
         if "attention_mask" in model_kwargs:
             attention_mask = model_kwargs["attention_mask"]
             if is_for_token_generation:
-                if self.neuron_config.padding_side == "left":
-                    attention_mask = torch.cat(
-                        [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))],
-                        dim=-1,
-                    )
-                    attention_mask = attention_mask[:, 1:]
-                else:
-                    attention_mask = torch.cat(
-                        [attention_mask.new_ones((attention_mask.shape[0], 1)), attention_mask],
-                        dim=-1,
-                    )
+                # Prepend 1 to the attention mask (inputs are right padded)
+                attention_mask = torch.cat(
+                    [attention_mask.new_ones((attention_mask.shape[0], 1)), attention_mask],
+                    dim=-1,
+                )
             model_kwargs["attention_mask"] = attention_mask
         return model_kwargs
 

--- a/optimum/neuron/models/inference/llama/modeling_llama.py
+++ b/optimum/neuron/models/inference/llama/modeling_llama.py
@@ -122,7 +122,7 @@ class NeuronLlamaMLP(nn.Module):
             pad=True,
             sequence_parallel_enabled=self.sequence_parallel_enabled,
             sequence_dimension=self.sequence_dimension,
-            reduce_dtype=neuron_config.rpl_reduce_dtype,
+            reduce_dtype=neuron_config.torch_dtype,
         )
 
         if self.mlp_kernel_enabled:

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.1.dev3"
+__version__ = "0.3.1.dev4"
 
 __sdk_version__ = "2.24.0"


### PR DESCRIPTION
# What does this PR do?

This simplifies the inference backend modules by removing code paths conditioned by config parameters whose value is fixed for the models we currently support.