### PR TITLE
Sync training custom modeling to transformers=4.55.4

### DIFF
--- a/optimum/neuron/models/training/granite/modeling_granite.py
+++ b/optimum/neuron/models/training/granite/modeling_granite.py
@@ -39,6 +39,7 @@ from ..llama.modeling_llama import (
     LlamaRMSNorm,
     LlamaRotaryEmbedding,
 )
+from ..masking_utils import create_causal_mask
 
 
 # Wrap the gather and scatter functions to ensure they are properly traced by `torch.fx`.
@@ -91,7 +92,8 @@ class GraniteDecoderLayer(LlamaDecoderLayer):
 
 
 class GraniteModel(LlamaModel):
-    config_class = GraniteConfig
+    config = GraniteConfig
+    _no_split_modules = ["GraniteDecoderLayer"]
 
     def __init__(self, config: GraniteConfig, trn_config: TrainingNeuronConfig):
         LlamaPreTrainedModel.__init__(self, config)
@@ -123,28 +125,14 @@ class GraniteModel(LlamaModel):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
-        use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        **flash_attn_kwargs,
-    ) -> tuple | BaseModelOutputWithPast:
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        use_cache = use_cache if use_cache is not None else self.config.use_cache
-
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
-                "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
-            )
-            use_cache = False
-
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
+
         if self.trn_config.sequence_parallel_enabled:
             inputs_embeds = inputs_embeds.transpose(0, 1).contiguous()
             inputs_embeds = scatter_to_sequence_parallel_region(inputs_embeds)
@@ -164,56 +152,45 @@ class GraniteModel(LlamaModel):
         if self.trn_config.recompute_causal_mask:
             causal_mask = None
         else:
-            causal_mask = self._update_causal_mask(attention_mask, inputs_embeds, cache_position)
+            causal_mask = create_causal_mask(
+                config=self.config,
+                trn_config=self.trn_config,
+                input_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                cache_position=cache_position,
+                past_key_values=None,  # Not used in training
+                position_ids=position_ids,
+            )
 
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        # decoder layers
-        all_hidden_states = () if output_hidden_states else None
-        all_self_attns = () if output_attentions else None
-
+        # Decoder layers
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
-            if output_hidden_states:
-                all_hidden_states += (hidden_states,)
-
             if self.gradient_checkpointing and self.training:
-                layer_outputs = checkpoint(
+                hidden_states = checkpoint(
                     decoder_layer.__call__,
                     hidden_states,
                     causal_mask,
                     position_ids,
-                    output_attentions,
                     position_embeddings,
+                    **kwargs,
                 )
             else:
-                layer_outputs = decoder_layer(
+                hidden_states = decoder_layer(
                     hidden_states,
                     attention_mask=causal_mask,
                     position_ids=position_ids,
-                    output_attentions=output_attentions,
                     position_embeddings=position_embeddings,
-                    **flash_attn_kwargs,
                 )
 
-            hidden_states = layer_outputs[0]
-
-            if output_attentions:
-                all_self_attns += (layer_outputs[1],)
-
         hidden_states = self.norm(hidden_states)
-
-        # add hidden states from the last decoder layer
-        if output_hidden_states:
-            all_hidden_states += (hidden_states,)
 
         output = BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=None,
-            hidden_states=all_hidden_states,
-            attentions=all_self_attns,
         )
         return output
 
@@ -250,7 +227,7 @@ class GraniteForCausalLM(LlamaForCausalLM):
         output_attentions: bool | None = None,
         output_hidden_states: bool | None = None,
         **kwargs: Unpack[KwargsForCausalLM],
-    ) -> tuple | CausalLMOutputWithPast:
+    ) -> CausalLMOutputWithPast:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/optimum/neuron/models/training/granite/modeling_granite.py
+++ b/optimum/neuron/models/training/granite/modeling_granite.py
@@ -65,19 +65,17 @@ class GraniteDecoderLayer(LlamaDecoderLayer):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        output_attentions: bool | None = False,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,  # necessary, but kept here for BC
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
         # Self Attention
-        hidden_states, self_attn_weights = self.self_attn(
+        hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            output_attentions=output_attentions,
             position_embeddings=position_embeddings,
             **kwargs,
         )
@@ -89,12 +87,7 @@ class GraniteDecoderLayer(LlamaDecoderLayer):
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states * self.residual_multiplier  # main diff with Llama
 
-        outputs = (hidden_states,)
-
-        if output_attentions:
-            outputs += (self_attn_weights,)
-
-        return outputs
+        return hidden_states
 
 
 class GraniteModel(LlamaModel):

--- a/optimum/neuron/models/training/llama/modeling_llama.py
+++ b/optimum/neuron/models/training/llama/modeling_llama.py
@@ -31,7 +31,6 @@ from torch import nn
 from torch_xla.utils.checkpoint import checkpoint
 from transformers import PreTrainedModel
 from transformers.activations import ACT2FN
-from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_outputs import (
     BaseModelOutputWithPast,
     CausalLMOutputWithPast,
@@ -44,8 +43,8 @@ from transformers.utils import TransformersKwargs, can_return_tuple, logging
 
 from ..config import TrainingNeuronConfig
 from ..loss_utils import ForCausalLMLoss
+from ..masking_utils import create_causal_mask
 from ..modeling_utils import NeuronModelMixin
-from ..pipeline_utils import dynamic_torch_fx_wrap
 from ..transformations_utils import (
     CustomModule,
     FusedLinearsSpec,
@@ -89,7 +88,7 @@ class LlamaRotaryEmbedding(nn.Module):
     def __init__(self, config: LlamaConfig, device=None):
         super().__init__()
         # BC: "rope_type" was originally "type"
-        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
+        if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
             self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
         else:
             self.rope_type = "default"
@@ -461,7 +460,7 @@ class LlamaAttention(nn.Module, CustomModule):
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        **kwargs: Unpack[FlashAttentionKwargs],
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self.trn_config.sequence_parallel_enabled:
             q_len, bsz, _ = hidden_states.size()
@@ -553,7 +552,7 @@ class LlamaDecoderLayer(nn.Module):
         position_ids: torch.LongTensor | None = None,
         output_attentions: bool | None = False,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,  # necessary, but kept here for BC
-        **kwargs: Unpack[FlashAttentionKwargs],
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         residual = hidden_states
 
@@ -589,7 +588,7 @@ class LlamaPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["LlamaDecoderLayer"]
     _skip_keys_device_placement = ["past_key_values"]
-    _supports_flash_attn_2 = True
+    _supports_flash_attn = True
     _supports_sdpa = False
     _supports_flex_attn = False
     _supports_cache_class = False
@@ -597,16 +596,9 @@ class LlamaPreTrainedModel(PreTrainedModel):
     _supports_static_cache = False
     _supports_attention_backend = False
 
-    def _init_weights(self, module):
-        std = self.config.initializer_range
-        if isinstance(module, nn.Linear):
-            module.weight.data.normal_(mean=0.0, std=std)
-            if module.bias is not None:
-                module.bias.data.zero_()
-        elif isinstance(module, nn.Embedding):
-            module.weight.data.normal_(mean=0.0, std=std)
-            if module.padding_idx is not None:
-                module.weight.data[module.padding_idx].zero_()
+    # Neuron-specific: torch.compile not supported on Trainium/Inferentia hardware
+    _can_compile_fullgraph = False
+    _can_record_outputs = None
 
 
 class LlamaModel(NeuronModelMixin, LlamaPreTrainedModel):
@@ -639,12 +631,6 @@ class LlamaModel(NeuronModelMixin, LlamaPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def get_input_embeddings(self):
-        return self.embed_tokens
-
-    def set_input_embeddings(self, value):
-        self.embed_tokens = value
-
     @can_return_tuple
     def forward(
         self,
@@ -655,7 +641,7 @@ class LlamaModel(NeuronModelMixin, LlamaPreTrainedModel):
         use_cache: bool | None = None,
         output_attentions: bool | None = None,
         output_hidden_states: bool | None = None,
-        **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
+        **flash_attn_kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -688,7 +674,15 @@ class LlamaModel(NeuronModelMixin, LlamaPreTrainedModel):
         if self.trn_config.recompute_causal_mask:
             causal_mask = None
         else:
-            causal_mask = self._update_causal_mask(attention_mask, inputs_embeds, cache_position)
+            causal_mask = create_causal_mask(
+                config=self.config,
+                trn_config=self.trn_config,
+                input_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                cache_position=cache_position,
+                past_key_values=None,  # Not used in training
+                position_ids=position_ids,
+            )
 
         hidden_states = inputs_embeds
 
@@ -741,79 +735,6 @@ class LlamaModel(NeuronModelMixin, LlamaPreTrainedModel):
         )
         return output
 
-    def _update_causal_mask(
-        self,
-        attention_mask: torch.Tensor,
-        input_tensor: torch.Tensor,
-        cache_position: torch.Tensor,
-    ):
-        if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and (attention_mask == 0.0).any():
-                raise RuntimeError(f"Only a causal mask is supported with {self.config._attn_implementation}.")
-            return None
-
-        dtype, device = input_tensor.dtype, input_tensor.device
-        if self.trn_config.sequence_parallel_enabled:
-            sequence_length = input_tensor.shape[0] * self.trn_config.tensor_parallel_size
-        else:
-            sequence_length = input_tensor.shape[1]
-
-        target_length = attention_mask.shape[-1] if isinstance(attention_mask, torch.Tensor) else sequence_length + 1
-
-        # In case the provided `attention` mask is 2D, we generate a causal mask here (4D).
-        batch_size = input_tensor.shape[1] if self.trn_config.sequence_parallel_enabled else input_tensor.shape[0]
-        causal_mask = self._prepare_4d_causal_attention_mask_with_cache_position(
-            attention_mask,
-            sequence_length=sequence_length,
-            target_length=target_length,
-            dtype=dtype,
-            device=device,
-            cache_position=cache_position,
-            batch_size=batch_size,
-        )
-
-        return causal_mask
-
-    @staticmethod
-    @dynamic_torch_fx_wrap
-    def _prepare_4d_causal_attention_mask_with_cache_position(
-        attention_mask: torch.Tensor,
-        sequence_length: int,
-        target_length: int,
-        dtype: torch.dtype,
-        device: torch.device,
-        cache_position: torch.Tensor,
-        batch_size: int,
-        **kwargs,
-    ):
-        if attention_mask is not None and attention_mask.dim() == 4:
-            # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
-            causal_mask = attention_mask
-        else:
-            min_dtype = torch.finfo(dtype).min
-            causal_mask = torch.full(
-                (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
-            )
-            if sequence_length != 1:
-                causal_mask = torch.triu(causal_mask, diagonal=1)
-            causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
-            causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
-            if attention_mask is not None:
-                causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
-                mask_length = attention_mask.shape[-1]
-                padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(
-                    causal_mask.device
-                )
-                padding_mask = padding_mask == 0
-                causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
-                    padding_mask, min_dtype
-                )
-
-        return causal_mask
-
-
-class KwargsForCausalLM(FlashAttentionKwargs, TransformersKwargs): ...
-
 
 class LlamaForCausalLM(NeuronModelMixin, LlamaPreTrainedModel):
     _tied_weights_keys = ["lm_head.weight"]
@@ -845,18 +766,6 @@ class LlamaForCausalLM(NeuronModelMixin, LlamaPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def get_input_embeddings(self):
-        return self.model.embed_tokens
-
-    def set_input_embeddings(self, value):
-        self.model.embed_tokens = value
-
-    def get_output_embeddings(self):
-        return self.lm_head
-
-    def set_output_embeddings(self, new_embeddings):
-        self.lm_head = new_embeddings
-
     def set_decoder(self, decoder):
         self.model = decoder
 
@@ -873,7 +782,7 @@ class LlamaForCausalLM(NeuronModelMixin, LlamaPreTrainedModel):
         labels: torch.LongTensor | None = None,
         output_attentions: bool | None = None,
         output_hidden_states: bool | None = None,
-        **kwargs: Unpack[KwargsForCausalLM],
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | CausalLMOutputWithPast:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/optimum/neuron/models/training/masking_utils.py
+++ b/optimum/neuron/models/training/masking_utils.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+import torch
+from transformers import PretrainedConfig
+from transformers.cache_utils import Cache
+
+from ....utils import logging
+from ...utils.training_utils import is_main_worker_for_metrics
+from .config import TrainingNeuronConfig
+from .pipeline_utils import dynamic_torch_fx_wrap
+
+
+_LOGGED_WARNING_FLASH_ATTENTION_2 = False
+
+logger = logging.get_logger(__name__)
+
+
+def create_causal_mask(
+    config: PretrainedConfig,
+    trn_config: TrainingNeuronConfig,
+    input_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    cache_position: torch.Tensor,
+    past_key_values: Cache | None = None,
+    position_ids: torch.Tensor = None,
+    or_mask_function: Callable | None = None,
+    and_mask_function: Callable | None = None,
+):
+    global _LOGGED_WARNING_FLASH_ATTENTION_2
+    if past_key_values is not None:
+        raise RuntimeError("`past_key_values` is not supported for training in optimum-neuron.")
+
+    if or_mask_function is not None or and_mask_function is not None:
+        raise RuntimeError(
+            "`or_mask_function` and `and_mask_function` are not supported for training in optimum-neuron."
+        )
+
+    if config._attn_implementation == "flash_attention_2":
+        if not _LOGGED_WARNING_FLASH_ATTENTION_2 and is_main_worker_for_metrics():
+            _LOGGED_WARNING_FLASH_ATTENTION_2 = True
+            logger.warning(
+                "You are using `flash_attention_2` as attention implementation. "
+                "In this case, only a causal mask is supported and it is computed inside the attention operator, the "
+                "attention mask passed to the model will be ignored."
+            )
+        return None
+
+    dtype, device = input_embeds.dtype, input_embeds.device
+    if trn_config.sequence_parallel_enabled:
+        batch_size = input_embeds.shape[1]
+        sequence_length = input_embeds.shape[0] * trn_config.tensor_parallel_size
+    else:
+        batch_size = input_embeds.shape[0]
+        sequence_length = input_embeds.shape[1]
+
+    target_length = attention_mask.shape[-1] if attention_mask is not None else sequence_length + 1
+
+    causal_mask = _compute_causal_mask(
+        attention_mask, cache_position, batch_size, sequence_length, target_length, dtype, device
+    )
+    return causal_mask
+
+
+@dynamic_torch_fx_wrap
+def _compute_causal_mask(attention_mask, cache_position, batch_size, sequence_length, target_length, dtype, device):
+    # In case the provided `attention` mask is 2D, we generate a causal mask here (4D).
+    if attention_mask is not None and attention_mask.dim() == 4:
+        # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+        causal_mask = attention_mask
+    else:
+        min_dtype = torch.finfo(dtype).min
+        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+        if sequence_length != 1:
+            causal_mask = torch.triu(causal_mask, diagonal=1)
+        causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+        causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.contiguous()
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(causal_mask.device)
+            padding_mask = padding_mask == 0
+            causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+                padding_mask, min_dtype
+            )
+    return causal_mask

--- a/optimum/neuron/models/training/modeling_utils.py
+++ b/optimum/neuron/models/training/modeling_utils.py
@@ -922,7 +922,7 @@ class NeuronModelMixin:
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, model_kwargs = cls.config_class.from_pretrained(
+            config, model_kwargs = cls.config.from_pretrained(
                 config_path,
                 cache_dir=cache_dir,
                 return_unused_kwargs=True,

--- a/optimum/neuron/models/training/qwen3/modeling_qwen3.py
+++ b/optimum/neuron/models/training/qwen3/modeling_qwen3.py
@@ -21,10 +21,9 @@ from neuronx_distributed.kernels.flash_attn import nki_flash_attn_func
 from neuronx_distributed.parallel_layers.layers import ParallelEmbedding
 from neuronx_distributed.parallel_layers.parallel_state import get_tensor_model_parallel_size
 from torch import nn
-from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 from transformers.processing_utils import Unpack
-from transformers.utils import logging
+from transformers.utils import TransformersKwargs, logging
 
 from ..config import TrainingNeuronConfig
 from ..llama.modeling_llama import (
@@ -38,7 +37,6 @@ from ..llama.modeling_llama import (
     eager_attention_forward,
     repeat_kv,
 )
-from ..pipeline_utils import dynamic_torch_fx_wrap
 
 
 logger = logging.get_logger(__name__)
@@ -95,7 +93,7 @@ class Qwen3Attention(LlamaAttention):
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        **kwargs: Unpack[FlashAttentionKwargs],
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self.trn_config.sequence_parallel_enabled:
             q_len, bsz, _ = hidden_states.size()
@@ -176,6 +174,9 @@ class Qwen3DecoderLayer(LlamaDecoderLayer):
 
 
 class Qwen3Model(LlamaModel):
+    config = Qwen3Config
+    _no_split_modules = ["Qwem3DecoderLayer"]
+
     def __init__(self, config: Qwen3Config, trn_config: TrainingNeuronConfig):
         LlamaPreTrainedModel.__init__(self, config)
         # In this Neuron implementation of Qwen3, we do not support sliding window.
@@ -208,49 +209,10 @@ class Qwen3Model(LlamaModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @staticmethod
-    @dynamic_torch_fx_wrap
-    def _prepare_4d_causal_attention_mask_with_cache_position(
-        attention_mask: torch.Tensor,
-        sequence_length: int,
-        target_length: int,
-        dtype: torch.dtype,
-        device: torch.device,
-        cache_position: torch.Tensor,
-        batch_size: int,
-        **kwargs,
-    ):
-        if attention_mask is not None and attention_mask.dim() == 4:
-            # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
-            causal_mask = attention_mask
-        else:
-            min_dtype = torch.finfo(dtype).min
-            causal_mask = torch.full(
-                (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
-            )
-            diagonal_attend_mask = torch.arange(target_length, device=cache_position.device) > cache_position.reshape(
-                -1, 1
-            )
-            causal_mask *= diagonal_attend_mask
-            causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
-            if attention_mask is not None:
-                causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
-                if attention_mask.shape[-1] > target_length:
-                    attention_mask = attention_mask[:, :target_length]
-                mask_length = attention_mask.shape[-1]
-                padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(
-                    causal_mask.device
-                )
-                padding_mask = padding_mask == 0
-                causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
-                    padding_mask, min_dtype
-                )
-
-        return causal_mask
-
 
 class Qwen3ForCausalLM(LlamaForCausalLM):
-    config_class = Qwen3Config
+    config = Qwen3Config
+    _no_split_modules = ["Qwem3DecoderLayer"]
 
     # Pipeline parallelism support
     SUPPORTS_PIPELINE_PARALLELISM = True

--- a/optimum/neuron/models/training/qwen3/modeling_qwen3.py
+++ b/optimum/neuron/models/training/qwen3/modeling_qwen3.py
@@ -175,7 +175,7 @@ class Qwen3DecoderLayer(LlamaDecoderLayer):
 
 class Qwen3Model(LlamaModel):
     config = Qwen3Config
-    _no_split_modules = ["Qwem3DecoderLayer"]
+    _no_split_modules = ["Qwen3DecoderLayer"]
 
     def __init__(self, config: Qwen3Config, trn_config: TrainingNeuronConfig):
         LlamaPreTrainedModel.__init__(self, config)
@@ -212,7 +212,7 @@ class Qwen3Model(LlamaModel):
 
 class Qwen3ForCausalLM(LlamaForCausalLM):
     config = Qwen3Config
-    _no_split_modules = ["Qwem3DecoderLayer"]
+    _no_split_modules = ["Qwen3DecoderLayer"]
 
     # Pipeline parallelism support
     SUPPORTS_PIPELINE_PARALLELISM = True

--- a/tests/training/test_custom_modeling.py
+++ b/tests/training/test_custom_modeling.py
@@ -99,7 +99,7 @@ def _check_output(name: str, original_output, output):
             kv_size_multiplier = len(get_kv_shared_group(as_list=True)[0])
             output = torch.chunk(output, kv_size_multiplier, dim=1)[0]
 
-        torch.testing.assert_close(original_output, output)
+        torch.testing.assert_close(output, original_output)
     else:
         assert original_output == output, f"Output named {name} do not match."
 

--- a/tests/training/test_custom_modeling.py
+++ b/tests/training/test_custom_modeling.py
@@ -132,7 +132,9 @@ def _custom_model_matches_original_model(
     with static_seed_patcher:
         # We need to specify `attn_implementation="eager"` to ensure that the original model does not use
         # another default such as sdpa or flash attention.
-        orig_model = orig_model_class.from_pretrained(model_name_or_path, torch_dtype=torch_dtype, attn_implementation="eager")
+        orig_model = orig_model_class.from_pretrained(
+            model_name_or_path, torch_dtype=torch_dtype, attn_implementation="eager"
+        )
 
     # It is ok to use this accelerator because `patch_model_for_neuron` does not depend on the TP or PP size.
     orig_model = accelerator.patch_model_for_neuron(orig_model)

--- a/tests/training/test_custom_modeling.py
+++ b/tests/training/test_custom_modeling.py
@@ -130,7 +130,9 @@ def _custom_model_matches_original_model(
 
     orig_model_class = getattr(transformers, model_class_name)
     with static_seed_patcher:
-        orig_model = orig_model_class.from_pretrained(model_name_or_path, torch_dtype=torch_dtype)
+        # We need to specify `attn_implementation="eager"` to ensure that the original model does not use
+        # another default such as sdpa or flash attention.
+        orig_model = orig_model_class.from_pretrained(model_name_or_path, torch_dtype=torch_dtype, attn_implementation="eager")
 
     # It is ok to use this accelerator because `patch_model_for_neuron` does not depend on the TP or PP size.
     orig_model = accelerator.patch_model_for_neuron(orig_model)


### PR DESCRIPTION
# What does this PR do?

The transformers version required for ON what changed to `v4.55.4`. 
This "broke" our tests for custom modeling because SDPA is now used by default for some models (I guess it's config dependent), so our baseline model from transformers was outputting NaNs.

This PR:

- Fixes our broken tests by forcing the baseline transformers model to use the eager attention implementation
- Aligns our custom Llama implementation to transformers
- Aligns our custom Qwen3 implementation to transformers
- Aligns our custom Granite implementation to transformers