### PR TITLE
Remove optimized model dependency in LLM models

### DIFF
--- a/docs/source/guides/export_model.mdx
+++ b/docs/source/guides/export_model.mdx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Export a model to Inferentia
+# Export a model to Neuron
 
 ## Summary
 
@@ -36,7 +36,7 @@ optimum-cli export neuron --help
 
 ## Why compile to Neuron model?
 
-AWS provides two generations of the Inferentia accelerator built for machine learning inference with higher throughput, lower latency but lower cost: [inf2 (NeuronCore-v2)](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/arch/neuron-hardware/inf2-arch.html) and [inf1 (NeuronCore-v1)](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/arch/neuron-hardware/inf1-arch.html#aws-inf1-arch).
+AWS provides two generations of the Trainium/Inferentia accelerator built for machine learning inference with higher throughput, lower latency but lower cost: [inf2 (NeuronCore-v2)](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/arch/neuron-hardware/inf2-arch.html) and [inf1 (NeuronCore-v1)](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/arch/neuron-hardware/inf1-arch.html#aws-inf1-arch).
 
 In production environments, to deploy 🤗 [Transformers](https://huggingface.co/docs/transformers/index) models on Neuron devices, you need to compile your models and export them to a serialized format before inference. Through Ahead-Of-Time (AOT) compilation with Neuron Compiler( [neuronx-cc](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/compiler/neuronx-cc/index.html) or [neuron-cc](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/compiler/neuron-cc/neuron-cc.html) ), your models will be converted to serialized and optimized [TorchScript modules](https://pytorch.org/docs/stable/generated/torch.jit.ScriptModule.html).
 
@@ -317,9 +317,6 @@ optimum-cli export neuron --model stabilityai/stable-diffusion-xl-base-1.0 \
 
 ### Exporting LLMs to Neuron
 
-LLM models are not exported using Torch tracing, but converted directly to Neuron graphs into which the
-transformers checkpoint weights can be loaded.
-
 Just like the standard NLP models, you need to specify static parameters when exporting an LLM model:
 
 - `batch_size` is the number of input sequences that the model will accept. Defaults to 1,
@@ -329,16 +326,13 @@ Just like the standard NLP models, you need to specify static parameters when ex
 bigger models need to be split on multiple cores. Defaults to 1,
 
 ```bash
-optimum-cli export neuron --model meta-llama/Meta-Llama-3-8B \
+optimum-cli export neuron --model meta-llama/Llama-3.2-1B \
   --batch_size 1 \
   --sequence_length 4096 \
-  --auto_cast_type fp16 `# cast operations from BF16 to FP16` \
+  --auto_cast_type bf16 \
   --num_cores 2 \
   llama3_neuron/
 ```
-
-An important restriction is that LLM models can only be exported on Neuron platforms, as they are tailored
-to fit on the actual devices during export.
 
 <Tip>
 The export of LLM models can take much longer than standard models (sometimes more than one hour).
@@ -351,7 +345,7 @@ This means in particular that during inference:
 - the `length` of the input sequences should be lower than the `sequence_length` used during export,
 - the maximum number of tokens (input + generated) cannot exceed the `sequence_length` used during export.
 
-Once exported, neuron mmodels can simply be reloaded using the `NeuronModelForCausalLM` class.
+Once exported, neuron llm models can simply be reloaded using the `NeuronModelForCausalLM` class.
 As with the original transformers models, use `generate()` instead of `forward()` to generate text sequences.
 
 ```diff
@@ -360,10 +354,10 @@ from transformers import AutoTokenizer
 +from optimum.neuron import NeuronModelForCausalLM
 
 # Instantiate and convert to Neuron a PyTorch checkpoint
--model = AutoModelForCausalLM.from_pretrained("gpt2")
-+model = NeuronModelForCausalLM.from_pretrained("./gpt2-neuron")
+-model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B")
++model = NeuronModelForCausalLM.from_pretrained("./llama3-neuron")
 
-tokenizer = AutoTokenizer.from_pretrained("gpt2")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
 tokenizer.pad_token_id = tokenizer.eos_token_id
 
 tokens = tokenizer("I really wish ", return_tensors="pt")
@@ -371,8 +365,7 @@ with torch.inference_mode():
     sample_output = model.generate(
         **tokens,
         do_sample=True,
-        min_length=128,
-        max_length=256,
+        max_new_tokens=256,
         temperature=0.7,
     )
     outputs = [tokenizer.decode(tok) for tok in sample_output]
@@ -386,33 +379,6 @@ Please be aware that:
 - for each model architecture, default values are provided for all parameters, but values passed to the `generate` method will take precedence,
 - the generation parameters can be stored in a `generation_config.json` file. When such a file is present in model directory,
 it will be parsed to set the default parameters (the values passed to the `generate` method still take precedence).
-
-
-## Exporting a model to Neuron programmatically via NeuronModel
-
-As an alternative to the `optimim-cli`, you will also be able to export your models to Neuron
-inside your own python script or notebook with `optimum.neuron.NeuronModelForXXX` model classes.
-
-Here is an example:
-
-```python
->>> from optimum.neuron import NeuronModelForSequenceClassification
-
->>> input_shapes = {"batch_size": 1, "sequence_length": 64}  # mandatory shapes
->>> model = NeuronModelForSequenceClassification.from_pretrained(
-...   "distilbert-base-uncased-finetuned-sst-2-english", export=True, **input_shapes
-... )
-
-# Save the model
->>> model.save_pretrained("./distilbert-base-uncased-finetuned-sst-2-english_neuron/")
-
-# Push the neuron model to HF Hub
->>> model.push_to_hub(  # doctest: +SKIP
-...     "a_local_path_for_compiled_neuron_model", repository_id="my-neuron-repo"
-... )
-```
-
-This example can be adapted for other model types using the same export parameters as the `optimum-cli`.
 
 ## Exporting neuron models using NeuronX TGI
 

--- a/examples/inference/text-generation/generation.py
+++ b/examples/inference/text-generation/generation.py
@@ -26,71 +26,33 @@ def generate(model, tokenizer, prompts, max_new_tokens, temperature):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(help="Action to perform", dest="action")
-    parent_parser = argparse.ArgumentParser(add_help=False)
-    parent_parser.add_argument("model", type=str, help="The HF Hub model id or a local directory.")
-    export_parser = subparsers.add_parser("export", parents=[parent_parser], help="Convert model to Neuron.")
-    export_parser.add_argument(
-        "--batch_size",
-        type=int,
-        default=1,
-        help="The batch size.",
-    )
-    export_parser.add_argument("--sequence_length", type=int, help="The maximum sequence length.")
-    export_parser.add_argument(
-        "--num_cores", type=int, default=1, help="The number of cores on which the model should be split."
-    )
-    export_parser.add_argument(
-        "--auto_cast_type", type=str, default="fp32", choices=["fp32", "fp16", "bf16"], help="One of fp32, fp16, bf16."
-    )
-    export_parser.add_argument(
-        "--save_dir", type=str, help="The save directory. Allows to avoid recompiling the model every time."
-    )
-    run_parser = subparsers.add_parser(
-        "run", parents=[parent_parser], help="Generate tokens using the specified model."
-    )
-    run_parser.add_argument(
+    parser.add_argument("model", type=str, help="The HF Hub model id or a local directory.")
+    parser.add_argument(
         "--prompts",
         type=str,
         default="One of my fondest memory is",
         help="The prompts to use for generation, using | as separator.",
     )
-    run_parser.add_argument("--length", type=int, default=128, help="The number of tokens in the generated sequences.")
-    run_parser.add_argument(
+    parser.add_argument("--length", type=int, default=128, help="The number of tokens in the generated sequences.")
+    parser.add_argument(
         "--temperature",
         type=float,
         default=1.0,
         help="The temperature to generate. 1.0 has no effect, lower tend toward greedy sampling.",
     )
-    run_parser.add_argument("--seed", type=int, default=None, help="Pass a seed for reproducibility.")
+    parser.add_argument("--seed", type=int, default=None, help="Pass a seed for reproducibility.")
     args = parser.parse_args()
-    if args.action == "export":
-        model = NeuronModelForCausalLM.from_pretrained(
-            args.model,
-            export=True,
-            low_cpu_mem_usage=True,
-            # These are parameters required for the conversion
-            batch_size=args.batch_size,
-            sequence_length=args.sequence_length,
-            num_cores=args.num_cores,
-            auto_cast_type=args.auto_cast_type,
-        )
-        if args.save_dir:
-            model.save_pretrained(args.save_dir)
-            tokenizer = AutoTokenizer.from_pretrained(args.model)
-            tokenizer.save_pretrained(args.save_dir)
-    else:
-        if args.seed is not None:
-            set_seed(args.seed)
-        start = time.time()
-        model = NeuronModelForCausalLM.from_pretrained(args.model, export=False, low_cpu_mem_usage=True)
-        end = time.time()
-        print(f"Neuron model loaded in {end - start:.2f} s.")
-        batch_size = model.neuron_config.batch_size
-        prompts = args.prompts.split("|")
-        if len(prompts) < batch_size:
-            prompts = prompts + [prompts[-1]] * (batch_size - len(prompts))
-        tokenizer = AutoTokenizer.from_pretrained(args.model)
-        outputs, latency = generate(model, tokenizer, prompts, args.length, args.temperature)
-        print(outputs)
-        print(f"{len(outputs)} outputs generated using Neuron model in {latency:.4f} s")
+    if args.seed is not None:
+        set_seed(args.seed)
+    start = time.time()
+    model = NeuronModelForCausalLM.from_pretrained(args.model, low_cpu_mem_usage=True)
+    end = time.time()
+    print(f"Neuron model loaded in {end - start:.2f} s.")
+    batch_size = model.neuron_config.batch_size
+    prompts = args.prompts.split("|")
+    if len(prompts) < batch_size:
+        prompts = prompts + [prompts[-1]] * (batch_size - len(prompts))
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    outputs, latency = generate(model, tokenizer, prompts, args.length, args.temperature)
+    print(outputs)
+    print(f"{len(outputs)} outputs generated using Neuron model in {latency:.4f} s")

--- a/optimum/exporters/neuron/__main__.py
+++ b/optimum/exporters/neuron/__main__.py
@@ -762,14 +762,27 @@ def maybe_export_from_neuron_model_class(
     if not has_neuron_model_class(model_type=config.model_type, task=task, mode="inference"):
         return False
     neuron_model_class = get_neuron_model_class(model_type=config.model_type, task=task, mode="inference")
-    neuron_model = neuron_model_class.from_pretrained(
+    batch_size = kwargs.pop("batch_size", None)
+    sequence_length = kwargs.pop("sequence_length", None)
+    tensor_parallel_size = kwargs.pop("num_cores", None)
+    auto_cast_type = kwargs.pop("auto_cast_type", None)
+    neuron_config = neuron_model_class.get_neuron_config(
+        model_name_or_path=model,
+        config=config,
+        token=kwargs.get("token", None),
+        revision=kwargs.get("revision", "main"),
+        batch_size=batch_size,
+        sequence_length=sequence_length,
+        tensor_parallel_size=tensor_parallel_size,
+        auto_cast_type=auto_cast_type,
+    )
+    neuron_model = neuron_model_class.export(
         model_id=model,
-        export=True,
+        config=config,
+        neuron_config=neuron_config,
         cache_dir=cache_dir,
         subfolder=subfolder,
-        config=config,
         trust_remote_code=trust_remote_code,
-        load_weights=False,  # Reduce model size for nxd models
         **kwargs,
     )
     if not output.parent.exists():

--- a/optimum/neuron/modeling_base.py
+++ b/optimum/neuron/modeling_base.py
@@ -12,28 +12,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import TYPE_CHECKING
+from abc import ABC
+from dataclasses import dataclass
 
 import torch
 
-from optimum.modeling_base import OptimizedModel
+
+class PreTrainedModel:
+    # A fake PreTrainedModel class to be inserted in NeuronModel class hierarchy
+    # to fool transformers pipeline framework identification algorithm
+    pass
 
 
-if TYPE_CHECKING:
-    from transformers import PretrainedConfig, PreTrainedModel
+@dataclass
+class NeuronModel(PreTrainedModel, ABC):
+    """Base class for all Neuron models."""
 
+    device: torch.device = torch.device("cpu")
 
-class NeuronModel(OptimizedModel):
-    def __init__(self, model: "PreTrainedModel", config: "PretrainedConfig"):
-        super().__init__(model, config)
-        if hasattr(model, "device"):
-            self.device = model.device
-        else:
-            self.device = torch.device("cpu")
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
 
     def to(self, device: str | torch.device):
         if not isinstance(device, torch.device):
             device = torch.device(device)
         if device.type != self.device.type:
             raise ValueError(f"Neuron models cannot be moved to {device.type}.")
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError("NeuronModel is an abstract class. Please use a subclass.")

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -107,7 +107,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
     def get_neuron_config(
         cls,
         model_name_or_path: str | Path,
-        config: "PretrainedConfig",
+        config: PretrainedConfig | None = None,
         token: bool | str | None = None,
         revision: str | None = None,
         batch_size: int | None = None,
@@ -126,7 +126,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
                 The class of the target neuron model.
             model_name_or_path (`str` or `Path`):
                 The model name or path to the model directory.
-            config (`PretrainedConfig`):
+            config (`PretrainedConfig`, *optional*):
                 The model configuration.
             token (`str`, *optional*):
                 The token to use for authentication with the Hugging Face Hub.
@@ -152,6 +152,12 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
             api = HfApi(token=token)
             model_info = api.repo_info(model_name_or_path, revision=revision)
             checkpoint_revision = model_info.sha
+        if config is None:
+            config = AutoConfig.from_pretrained(
+                model_name_or_path,
+                revision=checkpoint_revision,
+                use_auth_token=token,
+            )
 
         if batch_size is None:
             batch_size = 1
@@ -193,8 +199,8 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
     def export(
         cls,
         model_id: str,
-        config: "PretrainedConfig",
         neuron_config: NeuronConfig,
+        config: PretrainedConfig | None = None,
         token: bool | str | None = None,
         revision: str | None = None,
         load_weights: bool | None = False,
@@ -207,10 +213,10 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         Args:
             model_id (`str`):
                 The model ID or path to the model directory.
-            config (`PretrainedConfig`):
-                The model configuration.
             neuron_config (`NxDNeuronConfig`):
                 The Neuron configuration for the model.
+            config (`PretrainedConfig`, *optional*):
+                The model configuration.
             token (`str`, *optional*):
                 The token to use for authentication with the Hugging Face Hub.
             revision (`str`, *optional*):
@@ -221,6 +227,12 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         Returns:
             `NeuronModelForCausalLM`: The exported Neuron model.
         """
+        if config is None:
+            config = AutoConfig.from_pretrained(
+                model_id,
+                revision=revision,
+                use_auth_token=token,
+            )
         if cls is NeuronModelForCausalLM:
             # Instantiation through the abstract class: find the correct model class
             cls = get_neuron_causal_lm_model_class(config)
@@ -308,10 +320,10 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         Args:
             model_id (`str`):
                 The model ID or path to the model directory.
-            config (`PretrainedConfig`):
-                The model configuration.
             neuron_config (`NeuronConfig`):
                 The Neuron configuration for the model.
+            config (`PretrainedConfig`, *optional*):
+                The model configuration.
             token (`str`, *optional*):
                 The token to use for authentication with the Hugging Face Hub.
             revision (`str`, *optional*):

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import torch
 from huggingface_hub import HfApi
-from transformers import GenerationConfig, PretrainedConfig
+from transformers import AutoConfig, GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 from transformers.generation import StoppingCriteriaList
 
@@ -103,8 +103,6 @@ def get_neuron_causal_lm_model_class(config: PretrainedConfig):
     NEURON_CAUSALLM_MODEL_START_DOCSTRING,
 )
 class NeuronModelForCausalLM(NeuronModel, ABC):
-    preprocessors = []  # Required by optimum OptimizedModel
-
     @classmethod
     def get_neuron_config(
         cls,
@@ -116,7 +114,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         sequence_length: int | None = None,
         tensor_parallel_size: int | None = None,
         auto_cast_type: str | None = None,
-    ):
+    ) -> NeuronConfig:
         """
         Get the Neuron configuration for the target model class.
 
@@ -177,7 +175,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
             elif config.torch_dtype == "bfloat16":
                 auto_cast_type = "bf16"
 
-        if type(cls) is NeuronModelForCausalLM:
+        if cls is NeuronModelForCausalLM:
             # Instantiation through the abstract class: find the correct model class
             cls = get_neuron_causal_lm_model_class(config)
 
@@ -192,81 +190,62 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         )
 
     @classmethod
-    def _from_transformers(cls, *args, **kwargs):
-        # Deprecate it when optimum uses `_export` as from_pretrained_method in a stable release.
-        return cls._export(*args, **kwargs)
-
-    @classmethod
-    def _export(
+    def export(
         cls,
         model_id: str,
         config: "PretrainedConfig",
+        neuron_config: NeuronConfig,
         token: bool | str | None = None,
         revision: str | None = None,
-        batch_size: int | None = None,
-        sequence_length: int | None = None,
-        num_cores: int | None = None,
-        auto_cast_type: str | None = "bf16",
-        task: str | None = "text-generation",
+        load_weights: bool | None = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
-        """Implementation of the `optimum.OptimizedModel._export` method.
+        """Export a Decoder model to Neuron.
 
-        It accepts simplified parameters and converts them to a NeuronConfig object.
-        This NeuronConfig object is then passed to the `export` method that is in charge
-        of exporting the model to Neuron format.
+        It requires a NeuronConfig object that can be created for instance by the get_neuron_config class method.
 
         Args:
             model_id (`str`):
                 The model ID or path to the model directory.
             config (`PretrainedConfig`):
                 The model configuration.
+            neuron_config (`NxDNeuronConfig`):
+                The Neuron configuration for the model.
             token (`str`, *optional*):
                 The token to use for authentication with the Hugging Face Hub.
             revision (`str`, *optional*):
                 The revision of the model to use. If not specified, the latest revision will be used.
-            batch_size (`int`, *optional*):
-                The batch size to use for inference. If not specified, defaults to 1.
-            sequence_length (`int`, *optional*):
-                The sequence length to use for inference. If not specified, defaults to the model's maximum sequence length.
-            num_cores (`int`, *optional*):
-                The number of cores to use for tensor parallelism. If not specified, all available cores will be used.
-            auto_cast_type (`str`, *optional*):
-                The data type to use for automatic casting. If not specified, defaults to the model's data type.
-            task (`str`, *optional*):
-                The task for which the model is being exported. Defaults to "text-generation".
+            load_weights (`bool`, *optional*, defaults to `False`):
+                Whether to load the model weights after exporting. If `False`, the model will be exported
 
         Returns:
             `NeuronModelForCausalLM`: The exported Neuron model.
         """
-        if task != "text-generation":
-            raise ValueError(
-                f"Task {task} is not supported for causal language models. Please use another base model."
-            )
         if cls is NeuronModelForCausalLM:
             # Instantiation through the abstract class: find the correct model class
             cls = get_neuron_causal_lm_model_class(config)
 
-        # Create the neuron config for the specified parameters
-        neuron_config = cls.get_neuron_config(
-            model_id,
-            config,
-            token=token,
-            revision=revision,
-            batch_size=batch_size,
-            sequence_length=sequence_length,
-            tensor_parallel_size=num_cores,
-            auto_cast_type=auto_cast_type,
-        )
-
-        return cls.export(
+        return cls._export(
             model_id,
             config,
             neuron_config,
             token=token,
             revision=revision,
+            load_weights=load_weights,
             **kwargs,
         )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_id: "str | Path",
+        **kwargs,
+    ) -> "NeuronModelForCausalLM":
+        config = AutoConfig.from_pretrained(model_id, **kwargs)
+        if cls is NeuronModelForCausalLM:
+            # Find the correct model class
+            cls = get_neuron_causal_lm_model_class(config)
+        return cls._from_pretrained(model_id, config, **kwargs)
 
     @classmethod
     def _from_pretrained(
@@ -275,9 +254,7 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         config: "PretrainedConfig",
         **kwargs,
     ) -> "NeuronModelForCausalLM":
-        # Find the correct model class
-        cls = get_neuron_causal_lm_model_class(config)
-        return cls._from_pretrained(model_id, config, **kwargs)
+        raise NotImplementedError("The _from_pretrained method must be implemented in the subclass.")
 
     @add_start_docstrings(
         NEURON_CAUSALLM_MODEL_GENERATE_DOCSTRING
@@ -308,17 +285,21 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
         tensor_parallel_size: int,
         auto_cast_type: str,
     ):
-        raise NotImplementedError("The `get_neuron_config` method must be implemented in the subclass.")
+        raise NotImplementedError("The `_get_neuron_config` method must be implemented in the subclass.")
 
     @classmethod
-    def export(
+    def _export(
         cls,
         model_id: str,
         config: "PretrainedConfig",
         neuron_config: "NeuronConfig",
         token: bool | str | None = None,
         revision: str | None = None,
-        load_weights: bool | None = True,
+        cache_dir: str | None = None,
+        force_download: bool | None = False,
+        local_files_only: bool | None = False,
+        trust_remote_code: bool | None = False,
+        load_weights: bool | None = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
         """Export the model to Neuron format.
@@ -335,11 +316,40 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
                 The token to use for authentication with the Hugging Face Hub.
             revision (`str`, *optional*):
                 The revision of the model to use. If not specified, the latest revision will be used.
-            load_weights (`bool`, *optional*, defaults to `True`):
+            load_weights (`bool`, *optional*, defaults to `False`):
                 Whether to load the model weights after exporting. If `False`, the model will be exported without weights.
         Returns:
             `NeuronModelForCausalLM`: The exported Neuron model.
         """
         raise NotImplementedError(
-            "The `export` method must be implemented in the subclass. It should handle the export of the model to Neuron format."
+            "The `_export` method must be implemented in the subclass. It should handle the export of the model to Neuron format."
         )
+
+    def save_pretrained(self, save_directory: str, **kwargs):
+        """
+        Save a Neuron model and its configuration file to a directory, so that it can be re-loaded using the
+        [`~NeuronModelForCausalLM.from_pretrained`] class method.
+
+        Args:
+            save_directory (`str`):
+                The directory where the model and its configuration files will be saved.
+        """
+        if not os.path.exists(save_directory):
+            os.makedirs(save_directory)
+        # Save the Neuron configuration
+        neuron_config = self.neuron_config
+        neuron_config.save_pretrained(save_directory)
+        # Save the model configuration
+        self.config.save_pretrained(save_directory)
+        logger.info(f"Model and configuration files saved in {save_directory}")
+        self._save_pretrained(save_directory, **kwargs)
+
+    def _save_pretrained(self, save_directory: str, **kwargs):
+        """
+        Save the model to a directory. This method should be implemented by the subclass.
+
+        Args:
+            save_directory (`str`):
+                The directory where the model weights will be saved.
+        """
+        raise NotImplementedError("The `_save_pretrained` method must be implemented in the subclass.")

--- a/optimum/neuron/modeling_decoder.py
+++ b/optimum/neuron/modeling_decoder.py
@@ -165,6 +165,8 @@ class NeuronModelForCausalLM(NeuronModel, ABC):
                 sequence_length = config.max_position_embeddings
             else:
                 sequence_length = 1024
+            # Restrict default sequence length, as some models can have very large position embeddings
+            sequence_length = min(sequence_length, 4096)
         if tensor_parallel_size is None:
             # Use all available cores
             tensor_parallel_size = get_available_cores()

--- a/optimum/neuron/modeling_traced.py
+++ b/optimum/neuron/modeling_traced.py
@@ -28,6 +28,7 @@ from transformers import AutoConfig, AutoModel, GenerationMixin
 from optimum.exporters.neuron import main_export
 from optimum.exporters.neuron.model_configs import *  # noqa: F403
 from optimum.exporters.tasks import TasksManager
+from optimum.modeling_base import OptimizedModel
 from optimum.utils import logging
 from optimum.utils.save_utils import maybe_load_preprocessors
 
@@ -66,7 +67,7 @@ if is_neuronx_available():
 logger = logging.get_logger(__name__)
 
 
-class NeuronTracedModel(NeuronModel):
+class NeuronTracedModel(OptimizedModel, NeuronModel):
     """
     Base class running compiled and optimized models on Neuron devices.
 
@@ -102,6 +103,10 @@ class NeuronTracedModel(NeuronModel):
         **kwargs,
     ):
         super().__init__(model, config)
+        if hasattr(model, "device"):
+            self.device = model.device
+        else:
+            self.device = torch.device("cpu")
 
         self.model = model
         self.model_file_name = model_file_name or NEURON_FILE_NAME

--- a/optimum/neuron/models/inference/backend/modules/decoder/modeling_decoder.py
+++ b/optimum/neuron/models/inference/backend/modules/decoder/modeling_decoder.py
@@ -618,9 +618,7 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         token: bool | str | None = None,
         cache_dir: str | None = None,
         force_download: bool | None = False,
-        subfolder: str | None = "",
         local_files_only: bool | None = False,
-        trust_remote_code: bool | None = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
         if len(kwargs) > 0:
@@ -665,7 +663,7 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         return model
 
     @classmethod
-    def export(
+    def _export(
         cls,
         model_id: str,
         config: "PretrainedConfig | None",
@@ -674,10 +672,9 @@ class NxDModelForCausalLM(NxDGenerationMixin, NxDPreTrainedModel, NeuronModelFor
         revision: str | None = None,
         cache_dir: str | None = None,
         force_download: bool | None = False,
-        subfolder: str | None = "",
         local_files_only: bool | None = False,
         trust_remote_code: bool | None = False,
-        load_weights: bool = True,
+        load_weights: bool = False,
         **kwargs,
     ) -> "NeuronModelForCausalLM":
         if len(kwargs) > 0:

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -174,14 +174,8 @@ def load_pipeline(
 
         if issubclass(neuronx_model_class, NeuronModelForCausalLM):
             if export:
-                config = AutoConfig.from_pretrained(model, **hub_kwargs)
-                neuron_config = neuronx_model_class.get_neuron_config(
-                    model, config=AutoConfig.from_pretrained(model, **hub_kwargs), **export_kwargs
-                )
-                print(neuron_config)
-                model = neuronx_model_class.export(
-                    model, config=config, neuron_config=neuron_config, load_weights=True, **hub_kwargs
-                )
+                neuron_config = neuronx_model_class.get_neuron_config(model, **export_kwargs)
+                model = neuronx_model_class.export(model, neuron_config=neuron_config, load_weights=True, **hub_kwargs)
             else:
                 model = neuronx_model_class.from_pretrained(model, **hub_kwargs)
         else:

--- a/optimum/neuron/pipelines/transformers/base.py
+++ b/optimum/neuron/pipelines/transformers/base.py
@@ -159,16 +159,10 @@ def load_pipeline(
     revision: str = "main",
     compiler_args: dict[str, Any] | None = {},
     hub_kwargs: dict[str, Any] | None = {},
-    **kwargs,
+    **export_kwargs,
 ):
-    # loads default model
-    if model is None:
-        model_id = supported_tasks[targeted_task]["default"]
-        model = supported_tasks[targeted_task]["class"][0].from_pretrained(
-            model_id, export=True, **compiler_args, **input_shapes, **hub_kwargs, **kwargs
-        )
     # loads model from model id and converts it to neuronx optionally
-    elif isinstance(model, str):
+    if isinstance(model, str):
         model_id = model
         neuronx_model_class = supported_tasks[targeted_task]["class"][0]
         # Try to determine the correct feature extraction class to use.
@@ -178,9 +172,22 @@ def load_pipeline(
             logger.info("Using Sentence Transformers compatible Feature extraction pipeline")
             neuronx_model_class = NeuronModelForSentenceTransformers
 
-        model = neuronx_model_class.from_pretrained(
-            model, export=export, **compiler_args, **input_shapes, **hub_kwargs, **kwargs
-        )
+        if issubclass(neuronx_model_class, NeuronModelForCausalLM):
+            if export:
+                config = AutoConfig.from_pretrained(model, **hub_kwargs)
+                neuron_config = neuronx_model_class.get_neuron_config(
+                    model, config=AutoConfig.from_pretrained(model, **hub_kwargs), **export_kwargs
+                )
+                print(neuron_config)
+                model = neuronx_model_class.export(
+                    model, config=config, neuron_config=neuron_config, load_weights=True, **hub_kwargs
+                )
+            else:
+                model = neuronx_model_class.from_pretrained(model, **hub_kwargs)
+        else:
+            model = neuronx_model_class.from_pretrained(
+                model, export=export, **compiler_args, **input_shapes, **hub_kwargs
+            )
     # uses neuron model
     elif isinstance(model, NeuronModel):
         if tokenizer is None and load_tokenizer:
@@ -239,6 +246,9 @@ def pipeline(
         raise ValueError(
             f"Task {task} is not supported for the optimum neuron pipeline. Supported tasks are {list(NEURONX_SUPPORTED_TASKS.keys())}"
         )
+    # loads default model
+    if model is None:
+        model = NEURONX_SUPPORTED_TASKS[task]["default"]
 
     # copied from transformers.pipelines.__init__.py
     commit_hash = kwargs.pop("_commit_hash", None)
@@ -248,6 +258,7 @@ def pipeline(
         "trust_remote_code": trust_remote_code,
         "_commit_hash": commit_hash,
     }
+    batch_size = kwargs.pop("batch_size", None)
 
     config = kwargs.get("config", None)
     if config is None:
@@ -271,6 +282,7 @@ def pipeline(
         elif isinstance(model, NeuronModel):
             neuron_config = getattr(model, "neuron_config", None)
 
+    export_kwargs = {}
     if export:
         if neuron_config is not None:
             raise ValueError("This model has already been exported to Neuron format")
@@ -278,6 +290,13 @@ def pipeline(
         if task != "text-generation" and not input_shapes:
             input_shapes = {"batch_size": 1, "sequence_length": 128}
             logger.warning(f"No input shapes provided, using default shapes, {input_shapes}")
+        else:
+            export_kwargs = {
+                "batch_size": batch_size,
+                "sequence_length": kwargs.pop("sequence_length", None),
+                "tensor_parallel_size": kwargs.pop("num_cores", None),
+                "auto_cast_type": kwargs.pop("auto_cast_type", None),
+            }
     else:
         if neuron_config is None:
             raise ValueError("The model must be exported to Neuron format first")
@@ -335,6 +354,7 @@ def pipeline(
         supported_tasks=NEURONX_SUPPORTED_TASKS,
         hub_kwargs=hub_kwargs,
         token=token,
+        **export_kwargs,
     )
 
     if tokenizer is None and load_tokenizer:
@@ -344,19 +364,21 @@ def pipeline(
     if image_processor is None and load_image_processor:
         image_processor = get_preprocessor(model_id)
 
-    # If we don't specify a batch_size, the pipeline will assume batch_size 1
-    # and it will process the inputs one by one instead of processing them in parallel
-    batch_size = 1
-    neuron_config = (
-        getattr(config, "neuron", None)
-        or getattr(model.config, "neuron", None)
-        or getattr(model, "neuron_config", None)
-    )
-    if isinstance(neuron_config, NeuronConfig):
-        batch_size = neuron_config.batch_size
-    elif isinstance(neuron_config, dict):
-        for attr in ["batch_size", "static_batch_size"]:
-            batch_size = neuron_config.get(attr, batch_size)
+    if batch_size is None:
+        # If we don't specify a batch_size, the pipeline will assume batch_size 1
+        # and it will process the inputs one by one instead of processing them in parallel
+        neuron_config = (
+            getattr(config, "neuron", None)
+            or getattr(model.config, "neuron", None)
+            or getattr(model, "neuron_config", None)
+        )
+        if isinstance(neuron_config, NeuronConfig):
+            batch_size = neuron_config.batch_size
+        elif isinstance(neuron_config, dict):
+            for attr in ["batch_size", "static_batch_size"]:
+                batch_size = neuron_config.get(attr, batch_size)
+        else:
+            batch_size = 1
     if batch_size > 1 and tokenizer is not None and tokenizer.pad_token_id is None:
         # The pipeline needs a pad token to be able to batch
         if isinstance(model.config.eos_token_id, list):

--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.3.1.dev5"
+__version__ = "0.3.1.dev6"
 
 __sdk_version__ = "2.24.0"

--- a/optimum/neuron/vllm/model_loader.py
+++ b/optimum/neuron/vllm/model_loader.py
@@ -17,7 +17,6 @@ import logging
 
 import torch
 import torch.nn as nn
-from transformers import AutoConfig
 from vllm.config import ModelConfig, ParallelConfig, SchedulerConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.sampler import Sampler, SamplerOutput
@@ -258,10 +257,8 @@ def get_optimum_neuron_model(
             )
             raise ValueError(error_msg)
         logger.warning("%s is not a neuron model: it will be exported using cached artifacts.", model_id)
-        config = AutoConfig.from_pretrained(model_id, revision=revision, token=token)
         neuron_config = NeuronModelForCausalLM.get_neuron_config(
             model_name_or_path=model_id,
-            config=config,
             batch_size=batch_size,
             sequence_length=sequence_length,
             tensor_parallel_size=tensor_parallel_size,
@@ -269,7 +266,6 @@ def get_optimum_neuron_model(
         )
         neuron_model = NeuronModelForCausalLM.export(
             model_id,
-            config=config,
             neuron_config=neuron_config,
             token=token,
             revision=revision,

--- a/optimum/neuron/vllm/model_loader.py
+++ b/optimum/neuron/vllm/model_loader.py
@@ -17,6 +17,7 @@ import logging
 
 import torch
 import torch.nn as nn
+from transformers import AutoConfig
 from vllm.config import ModelConfig, ParallelConfig, SchedulerConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.sampler import Sampler, SamplerOutput
@@ -231,7 +232,6 @@ def get_optimum_neuron_model(
             model_id,
             revision=revision,
             token=token,
-            export=False,
         )
     else:
         # Model needs to be exported: look for compatible hub cached configs
@@ -258,14 +258,21 @@ def get_optimum_neuron_model(
             )
             raise ValueError(error_msg)
         logger.warning("%s is not a neuron model: it will be exported using cached artifacts.", model_id)
-        neuron_model = NeuronModelForCausalLM.from_pretrained(
-            model_id,
-            revision=revision,
-            token=token,
-            export=True,
+        config = AutoConfig.from_pretrained(model_id, revision=revision, token=token)
+        neuron_config = NeuronModelForCausalLM.get_neuron_config(
+            model_name_or_path=model_id,
+            config=config,
             batch_size=batch_size,
             sequence_length=sequence_length,
-            num_cores=tensor_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
             auto_cast_type=torch_dtype,
+        )
+        neuron_model = NeuronModelForCausalLM.export(
+            model_id,
+            config=config,
+            neuron_config=neuron_config,
+            token=token,
+            revision=revision,
+            load_weights=True,
         )
     return OptimumNeuronModelForCausalLM(neuron_model)

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -24,7 +24,7 @@ import PIL
 import pytest
 import torch
 from huggingface_hub import HfApi
-from transformers import AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer
 
 from optimum.neuron import (
     NeuronModelForCausalLM,
@@ -67,15 +67,22 @@ def cache_repos():
 def export_decoder_model(model_id):
     batch_size = 2
     sequence_length = 512
-    num_cores = 2
+    tensor_parallel_size = 2
     auto_cast_type = "bf16"
-    return NeuronModelForCausalLM.from_pretrained(
+    config = AutoConfig.from_pretrained(model_id)
+    neuron_config = NeuronModelForCausalLM.get_neuron_config(
         model_id,
-        export=True,
+        config=config,
         batch_size=batch_size,
         sequence_length=sequence_length,
-        num_cores=num_cores,
+        tensor_parallel_size=tensor_parallel_size,
         auto_cast_type=auto_cast_type,
+    )
+    return NeuronModelForCausalLM.export(
+        model_id,
+        config=config,
+        neuron_config=neuron_config,
+        load_weights=True,
     )
 
 

--- a/tests/cache/test_neuronx_cache.py
+++ b/tests/cache/test_neuronx_cache.py
@@ -24,7 +24,7 @@ import PIL
 import pytest
 import torch
 from huggingface_hub import HfApi
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoTokenizer
 
 from optimum.neuron import (
     NeuronModelForCausalLM,
@@ -69,10 +69,8 @@ def export_decoder_model(model_id):
     sequence_length = 512
     tensor_parallel_size = 2
     auto_cast_type = "bf16"
-    config = AutoConfig.from_pretrained(model_id)
     neuron_config = NeuronModelForCausalLM.get_neuron_config(
         model_id,
-        config=config,
         batch_size=batch_size,
         sequence_length=sequence_length,
         tensor_parallel_size=tensor_parallel_size,
@@ -80,7 +78,6 @@ def export_decoder_model(model_id):
     )
     return NeuronModelForCausalLM.export(
         model_id,
-        config=config,
         neuron_config=neuron_config,
         load_weights=True,
     )

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -95,9 +95,8 @@ def _get_hub_neuron_model_id(config_name: str, model_config: dict[str, str]):
 
 def _export_model(model_id, export_kwargs, neuron_model_path):
     try:
-        config = AutoConfig.from_pretrained(model_id)
-        neuron_config = NeuronModelForCausalLM.get_neuron_config(model_id, config, **export_kwargs)
-        model = NeuronModelForCausalLM.export(model_id, config=config, neuron_config=neuron_config, load_weights=False)
+        neuron_config = NeuronModelForCausalLM.get_neuron_config(model_id, **export_kwargs)
+        model = NeuronModelForCausalLM.export(model_id, neuron_config=neuron_config, load_weights=False)
         model.save_pretrained(neuron_model_path)
         return model
     except Exception as e:

--- a/tests/decoder/conftest.py
+++ b/tests/decoder/conftest.py
@@ -32,7 +32,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "fp16",
         },
     },
@@ -41,7 +41,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "fp16",
         },
     },
@@ -50,7 +50,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "bf16",
         },
     },
@@ -59,7 +59,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "bf16",
         },
     },
@@ -68,7 +68,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "bf16",
         },
     },
@@ -77,7 +77,7 @@ DECODER_MODEL_CONFIGURATIONS = {
         "export_kwargs": {
             "batch_size": 4,
             "sequence_length": 4096,
-            "num_cores": 2,
+            "tensor_parallel_size": 2,
             "auto_cast_type": "bf16",
         },
     },
@@ -95,7 +95,9 @@ def _get_hub_neuron_model_id(config_name: str, model_config: dict[str, str]):
 
 def _export_model(model_id, export_kwargs, neuron_model_path):
     try:
-        model = NeuronModelForCausalLM.from_pretrained(model_id, export=True, load_weights=False, **export_kwargs)
+        config = AutoConfig.from_pretrained(model_id)
+        neuron_config = NeuronModelForCausalLM.get_neuron_config(model_id, config, **export_kwargs)
+        model = NeuronModelForCausalLM.export(model_id, config=config, neuron_config=neuron_config, load_weights=False)
         model.save_pretrained(neuron_model_path)
         return model
     except Exception as e:
@@ -190,7 +192,7 @@ def base_neuron_decoder_config():
             "export_kwargs": {
                 "batch_size": 1,
                 "sequence_length": 4096,
-                "num_cores": 2,
+                "tensor_parallel_size": 2,
                 "auto_cast_type": "bf16",
             },
         }

--- a/tests/decoder/test_decoder_hub.py
+++ b/tests/decoder/test_decoder_hub.py
@@ -19,7 +19,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 from huggingface_hub import HfApi, get_token
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM
 
 from optimum.neuron import NeuronModelForCausalLM
 from optimum.neuron.utils.testing_utils import is_inferentia_test, requires_neuronx
@@ -43,13 +43,8 @@ def test_decoder_push_to_hub(from_local):
                 # Save must happen within the context of the tmpdir or checkpoint dir is lost
                 model.save_pretrained(model_path)
         else:
-            config = AutoConfig.from_pretrained(model_id)
-            neuron_config = NeuronModelForCausalLM.get_neuron_config(
-                model_name_or_path=model_id, config=config, **export_kwargs
-            )
-            model = NeuronModelForCausalLM.export(
-                model_id, config=config, neuron_config=neuron_config, load_weights=False
-            )
+            neuron_config = NeuronModelForCausalLM.get_neuron_config(model_name_or_path=model_id, **export_kwargs)
+            model = NeuronModelForCausalLM.export(model_id, neuron_config=neuron_config, load_weights=False)
             model.save_pretrained(model_path)
         # The hub model contains the checkpoint only when the model is exported from a local path
         ignore_patterns = [] if from_local else [model.CHECKPOINT_DIR + "/*"]

--- a/tests/decoder/test_vllm.py
+++ b/tests/decoder/test_vllm.py
@@ -54,7 +54,7 @@ def test_vllm_from_hub_model(neuron_decoder_config):
         model=model_id,
         max_num_seqs=export_kwargs["batch_size"],
         max_model_len=export_kwargs["sequence_length"],
-        tensor_parallel_size=export_kwargs["num_cores"],
+        tensor_parallel_size=export_kwargs["tensor_parallel_size"],
         dtype=DTYPE_MAPPER.pt(export_kwargs["auto_cast_type"]),
     )
     _test_vllm_generation(llm)


### PR DESCRIPTION
# What does this PR do?

Before this pull-request `NeuronModelForCausalLM` used to inherit from `OptimizedModel`, but all methods were actually overridden, and the inheritance was more a hindrance than a benefit, with the awkward `from_pretrained` API for export. This removes the inheritance and simplifies the export of LLM models.