### PR TITLE
Ci install pytorch cpu

### DIFF
--- a/.github/actions/prepare_venv/action.yml
+++ b/.github/actions/prepare_venv/action.yml
@@ -13,3 +13,4 @@ runs:
           python -m pip install -U pip
           python -m pip install --upgrade setuptools==69.5.1
           python -m pip install hf_transfer
+          python -m pip install torch==2.7.1 torchvision~=0.22 --index-url https://download.pytorch.org/whl/cpu

--- a/.github/actions/prepare_venv/action.yml
+++ b/.github/actions/prepare_venv/action.yml
@@ -13,4 +13,6 @@ runs:
           python -m pip install -U pip
           python -m pip install --upgrade setuptools==69.5.1
           python -m pip install hf_transfer
+          # Install torch and torchvision for CPU: this avoids having to install CUDA related dependencies, that use a lot
+          # of disk space. Note dependencies should be updated when we bump the PyTorch version.
           python -m pip install torch==2.7.1 torchvision~=0.22 --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/precompile_tests.yml
+++ b/.github/workflows/precompile_tests.yml
@@ -1,4 +1,4 @@
-name: Neuron Parallel Compile Tests
+name: Neuron Parallel Compile Training Tests
 
 on:
   release:
@@ -8,14 +8,14 @@ on:
   workflow_dispatch:
     inputs:
       test_path:
-        description: "Test path (default: tests/)"
+        description: "Test path (default: tests/training)"
         required: false
-        default: 'tests/'
+        default: 'tests/training'
         type: string
 
 jobs:
   neuron-parallel-compile-tests:
-    name: Run Neuron Parallel Compile Tests
+    name: Run Neuron Parallel Compile Training Tests
     runs-on:
       group: aws-trn1-32xlarge
     steps:
@@ -32,11 +32,11 @@ jobs:
         uses: ./.github/actions/install_optimum_neuron
       - name: Setup PATH
         run: echo "/home/ubuntu/.local/bin" >> $GITHUB_PATH
-      - name: Collect neuron_parallel_compile tests
+      - name: Collect neuron_parallel_compile training tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate
           HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} pytest -m "neuron_parallel_compile" ${{ inputs.test_path }} --collect-only
-      - name: Run neuron_parallel_compile tests
+      - name: Run neuron_parallel_compile training tests
         run: |
           source aws_neuron_venv_pytorch/bin/activate
           HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_NEURON_CI }} neuron_parallel_compile pytest -m "neuron_parallel_compile" ${{ inputs.test_path }} -vs


### PR DESCRIPTION
# What does this PR do?

Optimum Neuron requires torch, but it does not need the default CUDA based installation. This dependency takes a lot of disk storage.
Manually installing the CPU version will mitigate failures due to disk being full.

Also, there were some [failures](https://github.com/huggingface/optimum-neuron/actions/runs/18057781790/job/51389972521#step:8:89) due to tests dependencies on vLLM when pre-compiling tests. Restricting those to training tests should sort this out.