### PR TITLE
chore: bump dev version

### DIFF
--- a/optimum/neuron/version.py
+++ b/optimum/neuron/version.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.4.0.dev0"
+__version__ = "0.4.1.dev0"
 
 __sdk_version__ = "2.26.0"


### PR DESCRIPTION
# What does this PR do?

This simply bumps the dev version after the release 0.4.0 release.
