### PR TITLE
chore: bump huggingface_hub version, set HF_XET_HIGH_PERFORMANCE

### DIFF
--- a/.github/actions/prepare_venv/action.yml
+++ b/.github/actions/prepare_venv/action.yml
@@ -26,7 +26,6 @@ runs:
           python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
           python -m pip install -U pip
           python -m pip install --upgrade setuptools==69.5.1
-          python -m pip install hf_transfer
       - name: Install torch and torchvision (CUDA)
         if: ${{ inputs.use_cuda == 'true' }}
         shell: bash

--- a/.github/workflows/inference_cache_diffusion.yml
+++ b/.github/workflows/inference_cache_diffusion.yml
@@ -19,7 +19,7 @@ jobs:
       group: aws-inf2-8xlarge
     env:
       AWS_REGION: us-east-1
-      HF_HUB_ENABLE_HF_TRANSFER: 1
+      HF_XET_HIGH_PERFORMANCE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/inference_cache_llm.yml
+++ b/.github/workflows/inference_cache_llm.yml
@@ -17,7 +17,7 @@ jobs:
     name: Create optimum-neuron inference cache
     runs-on: aws-general-8-plus-use1-public-80
     env:
-      HF_HUB_ENABLE_HF_TRANSFER: 1
+      HF_XET_HIGH_PERFORMANCE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_inf2_llm.yml
+++ b/.github/workflows/test_inf2_llm.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     env:
-      HF_HUB_ENABLE_HF_TRANSFER: 1
+      HF_XET_HIGH_PERFORMANCE: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_inf2_vllm.yml
+++ b/.github/workflows/test_inf2_vllm.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on:
       group: aws-inf2-8xlarge
     env:
-      HF_HUB_ENABLE_HF_TRANSFER: 1
+      HF_XET_HIGH_PERFORMANCE: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -36,7 +36,7 @@ ENV PATH="/opt/bin/:/opt/aws/neuron/bin:${PATH}"
 
 # Install HuggingFace packages
 RUN pip3 install \
-    hf_transfer huggingface_hub
+    huggingface_hub
 
 # Install manually torch CPU version to avoid pulling CUDA
 RUN pip3 install \
@@ -54,7 +54,7 @@ RUN cd optimum-neuron && pip3 install .[neuronx,vllm] \
 
 # HF base env
 ENV HUGGINGFACE_HUB_CACHE=/tmp \
-    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    HF_XET_HIGH_PERFORMANCE=1 \
     HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:neuron:inference:vllm-optimum-neuron
 
 # Create the entrypoint script

--- a/infrastructure/ami/hcl2-files/build.pkr.hcl
+++ b/infrastructure/ami/hcl2-files/build.pkr.hcl
@@ -15,7 +15,7 @@ build {
   }
   provisioner "shell" {
     inline = [
-      "echo 'export HF_HUB_ENABLE_HF_TRANSFER=1' | sudo tee -a /home/ubuntu/.bashrc",
+      "echo 'export HF_XET_HIGH_PERFORMANCE=1' | sudo tee -a /home/ubuntu/.bashrc",
       "echo 'source /opt/aws_neuronx_venv_pytorch_2_8/bin/activate' | sudo tee -a /home/ubuntu/.bashrc"
     ]
   }

--- a/infrastructure/ami/scripts/install-huggingface-libraries.sh
+++ b/infrastructure/ami/scripts/install-huggingface-libraries.sh
@@ -15,14 +15,13 @@ pip install --upgrade --no-cache-dir \
     "markupsafe==2.1.1" \
     "jinja2==3.1.2" \
     "attrs==23.1.0" \
-    "hf_transfer>=0.1.4" \
     "rich>=14.1.0"
 
 # Temporary fix for the issue: https://github.com/huggingface/optimum-neuron/issues/142
 pip install -U optimum
 echo 'export PATH="${HOME}/.local/bin:$PATH"' >> "${HOME}/.bashrc"
-# Add HF_TRANSFER by default
-echo 'export HF_HUB_ENABLE_HF_TRANSFER=1' >> "${HOME}/.bashrc"
+# Set HF_XET_HIGH_PERFORMANCE by default
+echo 'export HF_XET_HIGH_PERFORMANCE=1' >> "${HOME}/.bashrc"
 
 echo "Step: install-and-copy-optimum-neuron-examples"
 git clone -b $OPTIMUM_VERSION https://github.com/huggingface/optimum-neuron.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "transformers ~= 4.55.4",
     "accelerate == 1.8.1",
     "optimum ~= 1.24.0",
-    "huggingface_hub >= 0.29.0",
+    "huggingface_hub >= 0.31.4",
     "numpy>=1.22.2, <=1.26.4",
     "protobuf>=3.20.3, <4",
 ]
@@ -67,7 +67,6 @@ tests = [
     "soundfile",
     "librosa",
     "controlnet-aux",
-    "hf_transfer",
 ]
 quality = [
     "pre-commit",


### PR DESCRIPTION
HF_XET_HIGH_PERFORMANCE is the setting that currently brings the fastest transfer, and HF_HUB_ENABLE_HF_TRANSFER is being deprecated. This commit updates accordingly.
