### PR TITLE
ci(vllm): login to docker

### DIFF
--- a/.github/workflows/build-vllm-image.yml
+++ b/.github/workflows/build-vllm-image.yml
@@ -33,6 +33,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       -
         name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
# What does this PR do?

Add login to docker to prevent errors when building the image.

See this failure for example: https://github.com/huggingface/optimum-neuron/actions/runs/18754605681/job/53503150736

It can be avoided using this login.
