### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -31,7 +31,7 @@ jobs:
           AWS_REGION: us-east-1
         steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
 
           - name: Setup Packer
             uses: hashicorp/setup-packer@main

--- a/.github/workflows/build-vllm-image.yml
+++ b/.github/workflows/build-vllm-image.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       -
         name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Extract version
         run: |

--- a/.github/workflows/cache_diffusion.yml
+++ b/.github/workflows/cache_diffusion.yml
@@ -39,7 +39,7 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/cache_llm.yml
+++ b/.github/workflows/cache_llm.yml
@@ -42,7 +42,7 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -25,9 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     - name: Install Neuronx runtime

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -24,13 +24,13 @@ jobs:
       PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Neuronx runtime

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -23,13 +23,13 @@ jobs:
       PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Neuronx runtime
@@ -69,7 +69,7 @@ jobs:
           echo ${{ env.COMMIT_SHA }} > ./commit_sha
           echo ${{ env.PR_NUMBER }} > ./pr_number
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: doc-build-artifact
           path: neuron-doc-build/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Secret Scanning

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 5 days.'

--- a/.github/workflows/test_cpu_compilation.yml
+++ b/.github/workflows/test_cpu_compilation.yml
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install Neuronx runtime

--- a/.github/workflows/test_cpu_lookup.yml
+++ b/.github/workflows/test_cpu_lookup.yml
@@ -26,9 +26,9 @@ jobs:
       MODEL_ID: Qwen/Qwen3-0.6B
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install Neuronx runtime

--- a/.github/workflows/test_inf2_diffusers.yml
+++ b/.github/workflows/test_inf2_diffusers.yml
@@ -43,7 +43,7 @@ jobs:
       group: aws-inf2-8xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Install cv2 dependencies

--- a/.github/workflows/test_inf2_export.yml
+++ b/.github/workflows/test_inf2_export.yml
@@ -51,7 +51,7 @@ jobs:
       group: aws-inf2-8xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_inf2_llm.yml
+++ b/.github/workflows/test_inf2_llm.yml
@@ -67,7 +67,7 @@ jobs:
       HF_XET_HIGH_PERFORMANCE: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_inf2_seq2seq.yml
+++ b/.github/workflows/test_inf2_seq2seq.yml
@@ -39,7 +39,7 @@ jobs:
       group: aws-inf2-8xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_inf2_slow.yml
+++ b/.github/workflows/test_inf2_slow.yml
@@ -34,7 +34,7 @@ jobs:
       group: aws-inf2-8xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_inf2_transformers.yml
+++ b/.github/workflows/test_inf2_transformers.yml
@@ -49,7 +49,7 @@ jobs:
       group: aws-inf2-8xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_inf2_vllm.yml
+++ b/.github/workflows/test_inf2_vllm.yml
@@ -66,7 +66,7 @@ jobs:
       HF_XET_HIGH_PERFORMANCE: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment

--- a/.github/workflows/test_sagemaker.yml
+++ b/.github/workflows/test_sagemaker.yml
@@ -24,9 +24,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install Neuronx runtime

--- a/.github/workflows/test_trainium_training.yml
+++ b/.github/workflows/test_trainium_training.yml
@@ -32,7 +32,7 @@ jobs:
       group: aws-trn1-32xlarge
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Neuronx runtime
         uses: ./.github/actions/install_neuronx_runtime
       - name: Prepare virtual environment


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v2`](https://github.com/actions/checkout/releases/tag/v2), [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build-ami.yml, build-vllm-image.yml, cache_diffusion.yml, cache_llm.yml, check_code_quality.yml, doc-build.yml, doc-pr-build.yml, security.yml, test_cpu_compilation.yml, test_cpu_lookup.yml, test_inf2_diffusers.yml, test_inf2_export.yml, test_inf2_llm.yml, test_inf2_seq2seq.yml, test_inf2_slow.yml, test_inf2_transformers.yml, test_inf2_vllm.yml, test_sagemaker.yml, test_trainium_training.yml |
| `actions/setup-node` | [`v3`](https://github.com/actions/setup-node/releases/tag/v3), [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | doc-build.yml, doc-pr-build.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | check_code_quality.yml, doc-build.yml, doc-pr-build.yml, test_cpu_compilation.yml, test_cpu_lookup.yml, test_sagemaker.yml |
| `actions/stale` | [`v9`](https://github.com/actions/stale/releases/tag/v9) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) | stale.yaml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | doc-pr-build.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
