### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -40,7 +40,7 @@ jobs:
               version: "1.10.1"
 
           - name: configure aws credentials
-            uses: aws-actions/configure-aws-credentials@v4
+            uses: aws-actions/configure-aws-credentials@v5
             with:
               aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_BUILD_AMI }}
               aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET_BUILD_AMI }}

--- a/.github/workflows/test_sagemaker.yml
+++ b/.github/workflows/test_sagemaker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install optimum-neuron
         uses: ./.github/actions/install_optimum_neuron
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_SANDBOX_GITHUB_CI_PUSH_ECR}}
           aws-region: us-east-1


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `aws-actions/configure-aws-credentials` | [`v4`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4) | [`v5`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | [Release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | build-ami.yml, test_sagemaker.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
