### PR TITLE
feat(gemma3): add VLM (image-text-to-text) support

### DIFF
--- a/docs/source/supported_architectures.mdx
+++ b/docs/source/supported_architectures.mdx
@@ -47,7 +47,7 @@ The following table lists the architectures and tasks that Optimum Neuron suppor
 
 <Tip>
 
-If a LLM is listed, e.g. a model with a `text-generation` task, it means that there is also [vLLM](https://github.com/vllm-project/vllm) support for it.
+If a LLM is listed, e.g. a model with a `text-generation` or `image-text-to-text` task, it means that there is also [vLLM](https://github.com/vllm-project/vllm) support for it.
 
 </Tip>
 
@@ -74,6 +74,7 @@ If a LLM is listed, e.g. a model with a `text-generation` task, it means that th
 | ELECTRA                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | ESM                       | feature-extraction, fill-mask, text-classification, token-classification                                                                      |
 | FlauBERT                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
+| Gemma3                    | text-generation, image-text-to-text                                                                                                           |
 | Granite                   | text-generation                                                                                                                               |
 | Hubert                    | feature-extraction, automatic-speech-recognition, audio-classification                                                                        |
 | Levit                     | feature-extraction, image-classification                                                                                                      |
@@ -93,6 +94,7 @@ If a LLM is listed, e.g. a model with a `text-generation` task, it means that th
 | RoBERTa                   | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | RoFormer                  | feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification                                 |
 | SmolLM3                   | text-generation                                                                                                                               |
+| SmolVLM                   | image-text-to-text                                                                                                           |
 | Swin                      | feature-extraction, image-classification                                                                                                      |
 | T5                        | text2text-generation                                                                                                                          |
 | UniSpeech                 | feature-extraction, automatic-speech-recognition, audio-classification                                                                        |

--- a/optimum/neuron/models/inference/auto_models.py
+++ b/optimum/neuron/models/inference/auto_models.py
@@ -22,7 +22,7 @@ automatically by the neuron factory classes such as NeuronModelForCausalLM.
 import os
 
 from ..auto_model import register_neuron_model
-from .gemma3.modeling_gemma3 import Gemma3NxDModelForCausalLM
+from .gemma3.modeling_gemma3 import Gemma3NxDModelForCausalLM, Gemma3NxDModelForImageTextToText
 from .granite.modeling_granite import GraniteNxDModelForCausalLM
 from .llama.modeling_llama import LlamaNxDModelForCausalLM
 from .llama4.modeling_llama4 import Llama4NxDModelForCausalLM
@@ -49,6 +49,15 @@ def register_neuron_model_for_inference(model_type: str, task: str):
 class Gemma3NeuronModelForCausalLM(Gemma3NxDModelForCausalLM):
     """
     Gemma3 model with NxD backend for inference on AWS Neuron.
+    """
+
+    pass
+
+
+@register_neuron_model_for_inference("gemma3", "image-text-to-text")
+class Gemma3NeuronModelForImageTextToText(Gemma3NxDModelForImageTextToText):
+    """
+    Gemma3 VLM model with NxD backend for vision-language inference on AWS Neuron.
     """
 
     pass

--- a/optimum/neuron/models/inference/gemma3/AGENTS.md
+++ b/optimum/neuron/models/inference/gemma3/AGENTS.md
@@ -110,6 +110,55 @@ Reference: [NxDI Gemma3 implementation](https://github.com/aws-neuron/neuronx-di
 
 Optimum Neuron prioritizes **stability and HF ecosystem compatibility**.
 
+## VLM (image-text-to-text) support
+
+Gemma3 supports vision-language inference via `Gemma3NxDModelForImageTextToText`, registered as `("gemma3", "image-text-to-text")`.
+
+### Architecture
+
+Two compiled bundles:
+- **`model_vision.pt`**: `NeuronGemma3VisionEncoder` — SigLIP vision transformer + multi-modal projector
+- **`model_text.pt`**: `NxDGemma3VLMDecoderModel` — Gemma3 text decoder with image embedding injection
+
+Class hierarchy:
+- `Gemma3NxDModelForImageTextToText` → `NxDModelForImageTextToText` (base VLM class)
+- `NxDGemma3VLMDecoderModel` → `NxDGemma3Model` (inherits mixed sliding/full attention)
+- `NeuronGemma3VisionEncoder` → contains `NeuronGemma3SigLIPVisionTransformer` + `NeuronGemma3MultiModalProjector`
+
+### TP-sharded vision encoder
+
+The SigLIP vision encoder (27 layers at 896×896) exceeds Neuron compiler instruction limits when `batch_size * max_num_images > 2` without tensor parallelism. The vision encoder uses `ColumnParallelLinear`/`RowParallelLinear` in attention Q/K/V/out and MLP fc1/fc2 to distribute across TP ranks.
+
+Key classes:
+- `NeuronGemma3SigLIPAttention` — TP-sharded multi-head attention
+- `NeuronGemma3SigLIPMLP` — TP-sharded MLP
+- `NeuronGemma3SigLIPEncoderLayer` / `NeuronGemma3SigLIPEncoder` — layer stack
+
+### Multi-modal projector
+
+`NeuronGemma3MultiModalProjector` downsamples vision features using `AvgPool2d` then projects via RMSNorm + linear from vision hidden dim to text hidden dim. Attribute names (`mm_input_projection_weight`, `mm_soft_emb_norm`) match HF for direct state dict loading.
+
+### Position embeddings
+
+Gemma3 uses standard sequential position IDs `[0, 1, ..., num_patches - 1]` (via `NeuronGemma3SigLIPVisionEmbeddings`), NOT Idefics3-style fractional-coordinate bucketing used by SmolVLM.
+
+### Image injection
+
+During context encoding, `NxDGemma3VLMDecoderModel.forward()` computes text embeddings, then replaces embeddings at `image_token_id` positions with vision features using `torch.where`.
+
+### VLM state dict conversion
+
+`Gemma3NxDModelForImageTextToText`:
+- `_STATE_DICT_MODEL_PREFIX = "language_model.model."` — strips HF nesting for text weights
+- `_get_vision_encoder_state_dict()`: remaps `vision_tower.vision_model.*` → `vision_model.*`, keeps `multi_modal_projector.*` as-is
+- `convert_hf_to_neuron_state_dict()`: preserves `language_model.lm_head.weight` → `lm_head.weight`, removes remaining vision/projector/language_model keys, delegates to CausalLM converter
+
+### Constraints
+
+- **Chunked prefill not supported** (`_supports_chunked_prefill = False`): the mixed sliding/full attention masks are not compatible with chunked prefill. `prefill_chunk_size` is forced to 0.
+- **No image tiling**: unlike SmolVLM/Idefics3, Gemma3 processes each image at full resolution. Each image produces exactly `mm_tokens_per_image` features.
+- **`max_num_images`**: set to 5 in `_get_neuron_config()`. This determines the vision batch size (`batch_size * max_num_images`).
+
 ## Key files
 - [optimum/neuron/models/inference/gemma3/modeling_gemma3.py](modeling_gemma3.py)
 - [optimum/neuron/models/inference/backend/modules/attention/attention_base.py](../backend/modules/attention/attention_base.py)

--- a/optimum/neuron/models/inference/gemma3/__init__.py
+++ b/optimum/neuron/models/inference/gemma3/__init__.py
@@ -1,4 +1,4 @@
-from .modeling_gemma3 import Gemma3NxDModelForCausalLM
+from .modeling_gemma3 import Gemma3NxDModelForCausalLM, Gemma3NxDModelForImageTextToText
 
 
-__all__ = ["Gemma3NxDModelForCausalLM"]
+__all__ = ["Gemma3NxDModelForCausalLM", "Gemma3NxDModelForImageTextToText"]

--- a/optimum/neuron/models/inference/gemma3/modeling_gemma3.py
+++ b/optimum/neuron/models/inference/gemma3/modeling_gemma3.py
@@ -25,14 +25,17 @@ from neuronx_distributed.parallel_layers.layers import (
 from neuronx_distributed.parallel_layers.mappings import _gather_along_dim
 from torch import nn
 from torch_neuronx.xla_impl.ops import RmsNorm
+from transformers import AutoConfig, PretrainedConfig
 from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
 
-from ..backend.config import NxDNeuronConfig
+from ..backend.config import NxDNeuronConfig, NxDVLMNeuronConfig
 from ..backend.modules.attention.attention_base import NeuronAttentionBase
 from ..backend.modules.attention.utils import RotaryEmbedding
 from ..backend.modules.decoder import NxDDecoderModelForCausalLM, NxDModelForCausalLM
+from ..backend.modules.decoder.vlm_decoder import NxDModelForImageTextToText
 from ..backend.modules.generation.sampling import mask_padded_logits
 from ..llama.modeling_llama import convert_state_dict_to_fused_qkv
+from ..smolvlm.modeling_smolvlm import NeuronSigLIPEncoder
 
 
 logger = logging.getLogger("Neuron")
@@ -308,6 +311,10 @@ class NxDGemma3Model(NxDDecoderModelForCausalLM):
         # Final normalization (use custom Gemma3RMSNorm)
         self.norm = NeuronGemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
+    def compute_input_embeddings(self, input_ids):
+        """Compute scaled word embeddings from input IDs."""
+        return self.embed_tokens(input_ids)
+
     def forward(
         self,
         input_ids,
@@ -315,18 +322,30 @@ class NxDGemma3Model(NxDDecoderModelForCausalLM):
         seq_ids,
         sampling_params,
     ):
-        """Forward pass with per-layer sliding window / full attention masks.
+        """Forward pass — delegates to compute_input_embeddings + _forward_from_embeddings."""
+        hidden_states = self.compute_input_embeddings(input_ids)
+        return self._forward_from_embeddings(hidden_states, position_ids, seq_ids, sampling_params)
 
-        This overrides the base NxDDecoderModelForCausalLM.forward() to create
-        two attention masks (full causal and sliding window) and select the
+    def _forward_from_embeddings(
+        self,
+        hidden_states,
+        position_ids,
+        seq_ids,
+        sampling_params,
+    ):
+        """Run Gemma3 decoder layers with dual sliding/full attention masks.
+
+        This overrides the base NxDDecoderModelForCausalLM._forward_from_embeddings()
+        to create two attention masks (full causal and sliding window) and select the
         appropriate one for each decoder layer based on its attention_type.
         """
-        is_for_context_encoding = self._is_context_encoding(input_ids.shape[-1])
-        if self._is_for_speculation(input_ids.shape[-1]):
+        batch_size, seq_length = hidden_states.shape[:2]
+        is_for_context_encoding = self._is_context_encoding(seq_length)
+        if self._is_for_speculation(seq_length):
             raise ValueError("Speculation is not supported for Gemma3 model")
 
         cache_size = self.n_positions
-        device = input_ids.device
+        device = hidden_states.device
 
         if is_for_context_encoding:
             past_key_values = None
@@ -366,11 +385,7 @@ class NxDGemma3Model(NxDDecoderModelForCausalLM):
             "sliding_attention": sliding_attention_mask,
         }
 
-        batch_size, seq_length = input_ids.shape[:2]
         position_ids = position_ids.view(-1, seq_length).long()
-
-        inputs_embeds = self.embed_tokens(input_ids)
-        hidden_states = inputs_embeds
 
         new_key_values = []
         # Gemma3 uses different RoPE bases for sliding (rope_local_base_freq) vs
@@ -551,4 +566,265 @@ class Gemma3NxDModelForCausalLM(NxDModelForCausalLM):
             fused_qkv=True,
             continuous_batching=continuous_batching,
             prefill_chunk_size=prefill_chunk_size,
+        )
+
+
+# ---------------------------------------------------------------------------
+# VLM (image-text-to-text) components
+# ---------------------------------------------------------------------------
+
+
+class NeuronGemma3SigLIPVisionEmbeddings(nn.Module):
+    """SigLIP vision embeddings with standard sequential position IDs.
+
+    Gemma3 uses standard SigLIP (not Idefics3), which assigns position IDs as
+    simple sequential integers ``[0, 1, ..., num_patches - 1]``.  This differs
+    from SmolVLM's ``NeuronSigLIPVisionEmbeddings`` which uses Idefics3-specific
+    fractional-coordinate bucketing — using the wrong scheme would produce
+    incorrect position embeddings.
+    """
+
+    def __init__(self, vision_config):
+        super().__init__()
+        num_channels = getattr(vision_config, "num_channels", 3)
+        embed_dim = vision_config.hidden_size
+        patch_size = vision_config.patch_size
+        image_size = vision_config.image_size
+        num_patches = (image_size // patch_size) ** 2
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=num_channels,
+            out_channels=embed_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+            padding="valid",
+        )
+        self.position_embedding = nn.Embedding(num_patches, embed_dim)
+        # Standard sequential position IDs [0, 1, ..., num_patches - 1]
+        self.register_buffer("position_ids", torch.arange(num_patches).unsqueeze(0), persistent=False)
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        batch_size = pixel_values.shape[0]
+        patch_embeds = self.patch_embedding(pixel_values)
+        hidden_states = patch_embeds.flatten(2).transpose(1, 2)
+        return hidden_states + self.position_embedding(self.position_ids.expand(batch_size, -1))
+
+
+class NeuronGemma3SigLIPVisionTransformer(nn.Module):
+    """SigLIP vision transformer for Gemma3.
+
+    Uses standard sequential position embeddings and reuses ``NeuronSigLIPEncoder``
+    from SmolVLM (encoder layers are architecture-identical between standard SigLIP
+    and Idefics3 SigLIP).
+    """
+
+    def __init__(self, vision_config):
+        super().__init__()
+        embed_dim = vision_config.hidden_size
+        self.embeddings = NeuronGemma3SigLIPVisionEmbeddings(vision_config)
+        self.encoder = NeuronSigLIPEncoder(vision_config)
+        self.post_layernorm = nn.LayerNorm(embed_dim, eps=vision_config.layer_norm_eps)
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.embeddings(pixel_values)
+        hidden_states = self.encoder(hidden_states)
+        return self.post_layernorm(hidden_states)
+
+
+class NeuronGemma3MultiModalProjector(nn.Module):
+    """Gemma3 multi-modal projector: AvgPool2d → RMSNorm → linear projection.
+
+    Downsamples vision features from ``patches_per_image ** 2`` tokens to
+    ``mm_tokens_per_image`` tokens using average pooling, then projects from
+    the vision hidden dimension to the text hidden dimension.
+
+    Attribute names match HF ``Gemma3MultiModalProjector`` for direct state
+    dict loading (``mm_input_projection_weight``, ``mm_soft_emb_norm``).
+    """
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        vision_hidden_size = config.vision_config.hidden_size
+        text_hidden_size = config.text_config.hidden_size
+        image_size = config.vision_config.image_size
+        patch_size = config.vision_config.patch_size
+        mm_tokens_per_image = config.mm_tokens_per_image
+
+        self.patches_per_image = image_size // patch_size
+        self.tokens_per_side = int(mm_tokens_per_image**0.5)
+        self.kernel_size = self.patches_per_image // self.tokens_per_side
+
+        self.mm_input_projection_weight = nn.Parameter(torch.zeros(vision_hidden_size, text_hidden_size))
+        self.mm_soft_emb_norm = NeuronGemma3RMSNorm(vision_hidden_size, eps=config.vision_config.layer_norm_eps)
+        self.avg_pool = nn.AvgPool2d(kernel_size=self.kernel_size, stride=self.kernel_size)
+
+    def forward(self, vision_outputs: torch.Tensor) -> torch.Tensor:
+        batch_size, num_patches, hidden_size = vision_outputs.shape
+        # Reshape to 2D spatial grid for pooling
+        x = vision_outputs.transpose(1, 2)
+        x = x.reshape(batch_size, hidden_size, self.patches_per_image, self.patches_per_image)
+        x = x.contiguous()
+        x = self.avg_pool(x)
+        # Flatten back to sequence
+        x = x.flatten(2).transpose(1, 2)
+        x = self.mm_soft_emb_norm(x)
+        x = torch.matmul(x, self.mm_input_projection_weight)
+        return x.type_as(vision_outputs)
+
+
+class NeuronGemma3VisionEncoder(nn.Module):
+    """Gemma3 vision encoder: SigLIP vision transformer + multi-modal projector.
+
+    Compiled as a separate bundle (``model_vision.pt``).  Attribute names
+    (``vision_model``, ``multi_modal_projector``) match the HF key namespace
+    after prefix stripping by ``_get_vision_encoder_state_dict``.
+    """
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.vision_model = NeuronGemma3SigLIPVisionTransformer(config.vision_config)
+        self.multi_modal_projector = NeuronGemma3MultiModalProjector(config)
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        hidden = self.vision_model(pixel_values)
+        return self.multi_modal_projector(hidden)
+
+
+class NxDGemma3VLMDecoderModel(NxDGemma3Model):
+    """Text decoder for Gemma3 VLM.
+
+    Receives the full ``Gemma3Config`` and extracts ``text_config`` before
+    delegating to the standard Gemma3 decoder construction.  Overrides
+    :meth:`forward` to accept and inject image embeddings during context
+    encoding, following the same pattern as ``NxDSmolVLMDecoderModel``.
+    """
+
+    def __init__(self, config: PretrainedConfig, neuron_config: NxDVLMNeuronConfig):
+        text_config = getattr(config, "text_config", config)
+        self._full_config = config
+        super().__init__(text_config, neuron_config)
+
+    def forward(
+        self,
+        input_ids,
+        position_ids,
+        seq_ids,
+        sampling_params,
+        image_embeds=None,
+        image_token_mask=None,
+    ):
+        """VLM-aware forward: injects image features into text embeddings."""
+        hidden_states = self.compute_input_embeddings(input_ids)
+
+        # Inject image features at image token positions during context encoding
+        if (
+            self._is_context_encoding(input_ids.shape[-1])
+            and image_embeds is not None
+            and image_token_mask is not None
+        ):
+            mask = image_token_mask.to(torch.bool).unsqueeze(-1)
+            hidden_states = torch.where(mask, image_embeds.to(hidden_states.dtype), hidden_states)
+
+        return self._forward_from_embeddings(hidden_states, position_ids, seq_ids, sampling_params)
+
+
+class Gemma3NxDModelForImageTextToText(NxDModelForImageTextToText):
+    """NxD model for Gemma3 VLM inference.
+
+    Manages two compiled bundles:
+    - ``model_vision.pt``: SigLIP vision encoder + Gemma3MultiModalProjector
+    - ``model_text.pt``: Gemma3 text decoder with VLM image injection
+    """
+
+    _model_cls = NxDGemma3VLMDecoderModel
+    _vision_encoder_cls = NeuronGemma3VisionEncoder
+    _STATE_DICT_MODEL_PREFIX = "language_model.model."
+    _supports_chunked_prefill = False
+    task = "image-text-to-text"
+
+    @classmethod
+    def _get_vision_encoder_state_dict(cls, full_sd: dict) -> dict:
+        """Extract and remap Gemma3 vision encoder weights from full HF state dict."""
+        sd = {}
+        for k, v in full_sd.items():
+            if k.startswith("vision_tower.vision_model."):
+                sd["vision_model." + k[len("vision_tower.vision_model.") :]] = v
+            elif k.startswith("multi_modal_projector."):
+                sd[k] = v
+        return sd
+
+    @staticmethod
+    def convert_hf_to_neuron_state_dict(
+        state_dict: dict, config: PretrainedConfig, neuron_config: NxDVLMNeuronConfig
+    ) -> dict:
+        # Preserve lm_head before blanket language_model.* removal (needed when tie_word_embeddings=False)
+        if "language_model.lm_head.weight" in state_dict:
+            state_dict["lm_head.weight"] = state_dict.pop("language_model.lm_head.weight")
+
+        # Remove vision and projector weights (loaded through vision bundle)
+        keys_to_remove = [
+            k
+            for k in state_dict
+            if k.startswith("vision_tower.")
+            or k.startswith("multi_modal_projector.")
+            or k.startswith("vision_model.")
+            or k.startswith("language_model.")
+        ]
+        for k in keys_to_remove:
+            del state_dict[k]
+
+        text_config = getattr(config, "text_config", config)
+        return Gemma3NxDModelForCausalLM.convert_hf_to_neuron_state_dict(state_dict, text_config, neuron_config)
+
+    @staticmethod
+    def update_state_dict_for_tied_weights(state_dict):
+        if "embed_tokens.embedding.weight" in state_dict:
+            state_dict["lm_head.weight"] = state_dict["embed_tokens.embedding.weight"].clone()
+
+    @classmethod
+    def _get_neuron_config(
+        cls,
+        checkpoint_id: str,
+        checkpoint_revision: str,
+        instance_type: str,
+        batch_size: int,
+        sequence_length: int,
+        tensor_parallel_size: int,
+        dtype: torch.dtype,
+        prefill_chunk_size: int = 0,
+    ) -> NxDVLMNeuronConfig:
+        if prefill_chunk_size > 0:
+            logger.warning(
+                "Gemma3 VLM does not support chunked prefill; ignoring prefill_chunk_size=%d and using 0.",
+                prefill_chunk_size,
+            )
+        continuous_batching = (batch_size > 1) if batch_size else False
+        config = AutoConfig.from_pretrained(checkpoint_id, revision=checkpoint_revision)
+        if not hasattr(config, "vision_config"):
+            raise ValueError(f"{checkpoint_id} does not have a vision_config; is it a VLM checkpoint?")
+
+        image_size = config.vision_config.image_size
+        mm_tokens_per_image = config.mm_tokens_per_image
+
+        # Gemma3 does NOT tile images (unlike SmolVLM/Idefics3).
+        # Each image produces exactly mm_tokens_per_image features.
+        # The 27-layer SigLIP at 896x896 generates very large HLOs;
+        # batch_size = 2 * max_num_images > 1 exceeds the compiler instruction limit.
+        max_num_images = 1
+
+        return NxDVLMNeuronConfig(
+            checkpoint_id=checkpoint_id,
+            checkpoint_revision=checkpoint_revision,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            tp_degree=tensor_parallel_size,
+            torch_dtype=dtype,
+            target=instance_type,
+            on_device_sampling=True,
+            fused_qkv=True,
+            continuous_batching=continuous_batching,
+            prefill_chunk_size=0,
+            max_num_images=max_num_images,
+            image_size=image_size,
+            image_seq_len=mm_tokens_per_image,
         )

--- a/optimum/neuron/models/inference/gemma3/modeling_gemma3.py
+++ b/optimum/neuron/models/inference/gemma3/modeling_gemma3.py
@@ -26,6 +26,7 @@ from neuronx_distributed.parallel_layers.mappings import _gather_along_dim
 from torch import nn
 from torch_neuronx.xla_impl.ops import RmsNorm
 from transformers import AutoConfig, PretrainedConfig
+from transformers.activations import ACT2FN
 from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
 
 from ..backend.config import NxDNeuronConfig, NxDVLMNeuronConfig
@@ -35,7 +36,6 @@ from ..backend.modules.decoder import NxDDecoderModelForCausalLM, NxDModelForCau
 from ..backend.modules.decoder.vlm_decoder import NxDModelForImageTextToText
 from ..backend.modules.generation.sampling import mask_padded_logits
 from ..llama.modeling_llama import convert_state_dict_to_fused_qkv
-from ..smolvlm.modeling_smolvlm import NeuronSigLIPEncoder
 
 
 logger = logging.getLogger("Neuron")
@@ -610,19 +610,115 @@ class NeuronGemma3SigLIPVisionEmbeddings(nn.Module):
         return hidden_states + self.position_embedding(self.position_ids.expand(batch_size, -1))
 
 
-class NeuronGemma3SigLIPVisionTransformer(nn.Module):
-    """SigLIP vision transformer for Gemma3.
+class NeuronGemma3SigLIPAttention(nn.Module):
+    """TP-sharded multi-headed attention for the SigLIP vision encoder.
 
-    Uses standard sequential position embeddings and reuses ``NeuronSigLIPEncoder``
-    from SmolVLM (encoder layers are architecture-identical between standard SigLIP
-    and Idefics3 SigLIP).
+    Uses ``ColumnParallelLinear`` for Q/K/V projections and ``RowParallelLinear``
+    for the output projection so the vision encoder is distributed across TP
+    ranks, reducing per-rank HLO size.
+    """
+
+    def __init__(self, vision_config):
+        super().__init__()
+        self.embed_dim = vision_config.hidden_size
+        self.num_heads = vision_config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = ColumnParallelLinear(self.embed_dim, self.embed_dim, bias=True, gather_output=False, pad=True)
+        self.k_proj = ColumnParallelLinear(self.embed_dim, self.embed_dim, bias=True, gather_output=False, pad=True)
+        self.v_proj = ColumnParallelLinear(self.embed_dim, self.embed_dim, bias=True, gather_output=False, pad=True)
+        self.out_proj = RowParallelLinear(self.embed_dim, self.embed_dim, bias=True, input_is_parallel=True, pad=True)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_length, _ = hidden_states.shape
+
+        queries = self.q_proj(hidden_states)
+        keys = self.k_proj(hidden_states)
+        values = self.v_proj(hidden_states)
+
+        # Per-rank output dim = embed_dim // tp_degree; derive per-rank head count
+        per_rank_dim = queries.shape[-1]
+        num_heads_per_rank = per_rank_dim // self.head_dim
+        queries = queries.view(batch_size, seq_length, num_heads_per_rank, self.head_dim).transpose(1, 2)
+        keys = keys.view(batch_size, seq_length, num_heads_per_rank, self.head_dim).transpose(1, 2)
+        values = values.view(batch_size, seq_length, num_heads_per_rank, self.head_dim).transpose(1, 2)
+
+        attn_weights = torch.matmul(queries, keys.transpose(-1, -2)) * self.scale
+        attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(queries.dtype)
+        attn_output = torch.matmul(attn_weights, values)
+
+        attn_output = attn_output.transpose(1, 2).reshape(batch_size, seq_length, per_rank_dim)
+        return self.out_proj(attn_output)
+
+
+class NeuronGemma3SigLIPMLP(nn.Module):
+    """TP-sharded MLP for the SigLIP vision encoder."""
+
+    def __init__(self, vision_config):
+        super().__init__()
+        hidden_size = vision_config.hidden_size
+        intermediate_size = vision_config.intermediate_size
+        self.activation_fn = ACT2FN[vision_config.hidden_act]
+        self.fc1 = ColumnParallelLinear(hidden_size, intermediate_size, bias=True, gather_output=False, pad=True)
+        self.fc2 = RowParallelLinear(intermediate_size, hidden_size, bias=True, input_is_parallel=True, pad=True)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        return self.fc2(hidden_states)
+
+
+class NeuronGemma3SigLIPEncoderLayer(nn.Module):
+    """Single TP-sharded SigLIP vision encoder layer."""
+
+    def __init__(self, vision_config):
+        super().__init__()
+        embed_dim = vision_config.hidden_size
+        self.self_attn = NeuronGemma3SigLIPAttention(vision_config)
+        self.layer_norm1 = nn.LayerNorm(embed_dim, eps=vision_config.layer_norm_eps)
+        self.mlp = NeuronGemma3SigLIPMLP(vision_config)
+        self.layer_norm2 = nn.LayerNorm(embed_dim, eps=vision_config.layer_norm_eps)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class NeuronGemma3SigLIPEncoder(nn.Module):
+    """Stack of TP-sharded SigLIP encoder layers."""
+
+    def __init__(self, vision_config):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [NeuronGemma3SigLIPEncoderLayer(vision_config) for _ in range(vision_config.num_hidden_layers)]
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class NeuronGemma3SigLIPVisionTransformer(nn.Module):
+    """SigLIP vision transformer for Gemma3 with TP-sharded encoder layers.
+
+    Uses standard sequential position embeddings and TP-sharded attention/MLP
+    layers to reduce per-rank HLO size, allowing larger vision batch sizes.
     """
 
     def __init__(self, vision_config):
         super().__init__()
         embed_dim = vision_config.hidden_size
         self.embeddings = NeuronGemma3SigLIPVisionEmbeddings(vision_config)
-        self.encoder = NeuronSigLIPEncoder(vision_config)
+        self.encoder = NeuronGemma3SigLIPEncoder(vision_config)
         self.post_layernorm = nn.LayerNorm(embed_dim, eps=vision_config.layer_norm_eps)
 
     def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
@@ -808,9 +904,9 @@ class Gemma3NxDModelForImageTextToText(NxDModelForImageTextToText):
 
         # Gemma3 does NOT tile images (unlike SmolVLM/Idefics3).
         # Each image produces exactly mm_tokens_per_image features.
-        # The 27-layer SigLIP at 896x896 generates very large HLOs;
-        # batch_size = 2 * max_num_images > 1 exceeds the compiler instruction limit.
-        max_num_images = 1
+        # The max number of images is arbitrary: it is just set to a value that we believe it should be enough for most
+        # cases.
+        max_num_images = 5
 
         return NxDVLMNeuronConfig(
             checkpoint_id=checkpoint_id,

--- a/optimum/neuron/vllm/model_loader.py
+++ b/optimum/neuron/vllm/model_loader.py
@@ -234,7 +234,7 @@ class OptimumNeuronModelForImageTextToText(OptimumNeuronModel):
 
     def __init__(self, model: NeuronModelForImageTextToText) -> None:
         super().__init__(model)
-        self.logits_processor = LogitsProcessor(self.model.config.vocab_size, logits_as_input=True)
+        self.logits_processor = LogitsProcessor(self.model.config.get_text_config().vocab_size, logits_as_input=True)
 
     def forward(
         self,

--- a/optimum/neuron/vllm/runner.py
+++ b/optimum/neuron/vllm/runner.py
@@ -267,7 +267,7 @@ class OptimumNeuronModelRunnerForCausalLM(OptimumNeuronModelRunner):
         if self.model.model.neuron_config.on_device_sampling:
             max_topk = self.model.model.neuron_config.max_topk
         else:
-            max_topk = self.model.model.config.vocab_size
+            max_topk = self.model.model.config.get_text_config().vocab_size
 
         sampling_params_list: list[list[Any]] = []
         for params in sampling_params:
@@ -372,7 +372,9 @@ class OptimumNeuronModelRunnerForCausalLM(OptimumNeuronModelRunner):
                 seq_ids=seq_ids,
                 sampling_params=sampling_params_tensor,
             )
-            sampling_metadata = create_sampling_metadata(requests, vocab_size=self.model.model.config.vocab_size)
+            sampling_metadata = create_sampling_metadata(
+                requests, vocab_size=self.model.model.config.get_text_config().vocab_size
+            )
             sampler_outputs = self.sampler(logits, sampling_metadata)
             return sampler_outputs.sampled_token_ids, logits
 
@@ -483,7 +485,9 @@ class OptimumNeuronModelRunnerForCausalLM(OptimumNeuronModelRunner):
             per_seq_last_logits[i] = logits[0].clone()
 
         last_logits = torch.stack(per_seq_last_logits)
-        sampling_metadata = create_sampling_metadata(requests, vocab_size=self.model.model.config.vocab_size)
+        sampling_metadata = create_sampling_metadata(
+            requests, vocab_size=self.model.model.config.get_text_config().vocab_size
+        )
         sampler_outputs = self.sampler(last_logits, sampling_metadata)
         return requests, sampler_outputs.sampled_token_ids, last_logits
 
@@ -698,6 +702,8 @@ class OptimumNeuronModelRunnerForImageTextToText(OptimumNeuronModelRunnerForCaus
             # Non-chunked path with on-device sampling: model returns token IDs directly.
             # unsqueeze to [batch, 1] to match CPU sampler output shape
             return requests, last_logits.unsqueeze(-1), None
-        sampling_metadata = create_sampling_metadata(requests, vocab_size=self.model.model.config.vocab_size)
+        sampling_metadata = create_sampling_metadata(
+            requests, vocab_size=self.model.model.config.get_text_config().vocab_size
+        )
         sampler_outputs = self.sampler(last_logits, sampling_metadata)
         return requests, sampler_outputs.sampled_token_ids, last_logits

--- a/tests/decoder/test_decoder_export.py
+++ b/tests/decoder/test_decoder_export.py
@@ -23,6 +23,7 @@ from optimum.neuron import NeuronModelForCausalLM, NeuronModelForImageTextToText
 
 VLM_MODELS = {
     "smolvlm": "HuggingFaceTB/SmolVLM-256M-Instruct",
+    "gemma3": "tengomucho/tiny-random-gemma-3-vlm",
 }
 
 DECODER_MODELS = {

--- a/tests/decoder/test_vlm_generation.py
+++ b/tests/decoder/test_vlm_generation.py
@@ -68,33 +68,20 @@ def test_vlm_generation_greedy_expectations(any_vlm_generate_model: dict[str, An
     assert torch.equal(neuron_outputs, cpu_outputs), "Neuron and CPU outputs differ at the token level"
 
 
-@is_inferentia_test
-@requires_neuronx
-@pytest.mark.parametrize(
-    "num_images, prompt_text",
-    [
-        (1, "Can you describe this image?"),
-        (16, "Are all these images the same?"),
-    ],
-    ids=["single-image", "multi-image-cross-chunk"],
-)
-def test_vlm_generation_with_image(any_vlm_generate_model: dict[str, Any], num_images, prompt_text):
-    """Test VLM greedy generation with images matches the HF CPU reference.
+def _generate_with_image(vlm_config, num_images, prompt_text, processor_kwargs=None):
+    """Helper: run VLM generation with images on both Neuron and CPU.
 
-    The multi-image variant uses 16 images with ``longest_edge=512`` (1 tile each)
-    to produce ~1087 tokens, exceeding the default ``prefill_chunk_size=1024``.
-    This forces image tokens to span two prefill chunks, exercising the
-    cross-chunk feature indexing logic.
+    Returns (neuron_outputs, cpu_outputs, neuron_text, cpu_text, inputs).
     """
     image_path = os.path.join(os.path.dirname(__file__), "venus_botticelli.png")
     image = Image.open(image_path).convert("RGB")
 
-    model_id = any_vlm_generate_model["model_id"]
-    neuron_model_path = any_vlm_generate_model["neuron_model_path"]
+    model_id = vlm_config["model_id"]
+    neuron_model_path = vlm_config["neuron_model_path"]
 
+    neuron_model = NeuronModelForImageTextToText.from_pretrained(neuron_model_path)
     processor = AutoProcessor.from_pretrained(neuron_model_path)
 
-    # SmolVLM / Idefics3 requires the chat template to emit image tokens correctly.
     messages = [
         {
             "role": "user",
@@ -102,12 +89,7 @@ def test_vlm_generation_with_image(any_vlm_generate_model: dict[str, Any], num_i
         }
     ]
     text = processor.apply_chat_template(messages, add_generation_prompt=True)
-    # For multi-image: set longest_edge=image_size (512) so each image produces
-    # exactly 1 tile, keeping total tiles within the compiled max_num_images=17.
-    # Without this, the Idefics3 processor upscales to longest_edge=2048 and
-    # splits each image into up to 17 tiles.
-    processor_kwargs = {"size": {"longest_edge": 512}} if num_images > 1 else {}
-    inputs = processor(text=text, images=[image] * num_images, return_tensors="pt", **processor_kwargs)
+    inputs = processor(text=text, images=[image] * num_images, return_tensors="pt", **(processor_kwargs or {}))
     max_new_tokens = 20
 
     # CPU reference
@@ -116,7 +98,6 @@ def test_vlm_generation_with_image(any_vlm_generate_model: dict[str, Any], num_i
     cpu_text = processor.decode(cpu_outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True)
 
     # Neuron model
-    neuron_model = NeuronModelForImageTextToText.from_pretrained(neuron_model_path)
     neuron_outputs = neuron_model.generate(
         inputs["input_ids"],
         pixel_values=inputs["pixel_values"],
@@ -125,7 +106,67 @@ def test_vlm_generation_with_image(any_vlm_generate_model: dict[str, Any], num_i
     )
     neuron_text = processor.decode(neuron_outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True)
 
-    # Check output is non-empty and matches the CPU reference.
+    return neuron_outputs, cpu_outputs, neuron_text, cpu_text, inputs
+
+
+@is_inferentia_test
+@requires_neuronx
+def test_vlm_generation_with_single_image(any_vlm_generate_model: dict[str, Any]):
+    """Test single-image VLM generation matches CPU reference exactly.
+
+    This is the universal VLM correctness test: one image, exact token match.
+    All VLM models must pass this.
+    """
+    neuron_outputs, cpu_outputs, neuron_text, cpu_text, _ = _generate_with_image(
+        any_vlm_generate_model, num_images=1, prompt_text="Can you describe this image?"
+    )
+    assert len(neuron_text.strip()) > 0, "Neuron model produced empty output"
+    assert cpu_text == neuron_text, f"Neuron and CPU outputs differ.\nNeuron: {neuron_text!r}\nCPU:    {cpu_text!r}"
+    assert torch.equal(neuron_outputs, cpu_outputs), "Neuron and CPU outputs differ at the token level"
+
+
+@is_inferentia_test
+@requires_neuronx
+@pytest.mark.parametrize(
+    "neuron_vlm_config, num_images, prompt_text, processor_kwargs",
+    [
+        pytest.param(
+            "gemma3-2x2048",
+            5,
+            "Are these images the same?",
+            None,
+            id="gemma3-5-images",
+        ),
+        pytest.param(
+            "smolvlm-2x2048",
+            16,
+            "Are all these images the same?",
+            {"size": {"longest_edge": 512}},
+            id="smolvlm-16-images-cross-chunk",
+        ),
+    ],
+    indirect=["neuron_vlm_config"],
+)
+def test_vlm_generation_with_multiple_images(
+    neuron_vlm_config: dict[str, Any],
+    num_images: int,
+    prompt_text: str,
+    processor_kwargs: dict | None,
+):
+    """Test multi-image VLM generation matches CPU reference exactly.
+
+    Parameterized per model to exercise model-specific multi-image paths:
+    - Gemma3: 5 images at full resolution (no tiling), TP-sharded vision encoder.
+    - SmolVLM: 16 tiled images (longest_edge=512, 1 tile each) producing ~1087
+      tokens that exceed prefill_chunk_size=1024, exercising cross-chunk feature
+      indexing.
+    """
+    neuron_outputs, cpu_outputs, neuron_text, cpu_text, _ = _generate_with_image(
+        neuron_vlm_config,
+        num_images=num_images,
+        prompt_text=prompt_text,
+        processor_kwargs=processor_kwargs,
+    )
     assert len(neuron_text.strip()) > 0, "Neuron model produced empty output"
     assert cpu_text == neuron_text, f"Neuron and CPU outputs differ.\nNeuron: {neuron_text!r}\nCPU:    {cpu_text!r}"
     assert torch.equal(neuron_outputs, cpu_outputs), "Neuron and CPU outputs differ at the token level"

--- a/tests/fixtures/llm/export_models.py
+++ b/tests/fixtures/llm/export_models.py
@@ -143,6 +143,7 @@ EMBED_LLM_MODEL_IDS = {
 
 VLM_MODEL_IDS = {
     "smolvlm": "HuggingFaceTB/SmolVLM-256M-Instruct",
+    "gemma3": "unsloth/gemma-3-4b-it",
 }
 
 


### PR DESCRIPTION
## Summary
- Add Gemma3 VLM inference support with TP-sharded SigLIP vision encoder, multi-modal projector, and VLM-aware text decoder
- Vision encoder uses `ColumnParallelLinear`/`RowParallelLinear` to distribute across TP ranks, avoiding Neuron compiler instruction limits for larger vision batch sizes
- Registered as `("gemma3", "image-text-to-text")` with two compiled bundles: `model_vision.pt` (SigLIP + projector) and `model_text.pt` (decoder with image injection)

## Key design decisions
- **No image tiling**: Gemma3 processes images at full resolution (unlike SmolVLM/Idefics3), each producing exactly `mm_tokens_per_image` features
- **Chunked prefill disabled**: mixed sliding/full attention masks are not compatible with chunked prefill
- **`max_num_images=5`**: determines vision batch size (`batch_size * max_num_images`)

## Test plan
- [x] Export test: `test_vlm_export_hub_models[gemma3]`
- [x] Single-image generation: exact token match vs CPU
- [x] Multi-image generation (5 images): exact token match vs CPU
- [x] Style checks: `ruff check` + `ruff format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)