### PR TITLE
Handle sharded checkpoints in qkv state dict adaptation

### DIFF
--- a/optimum/neuron/models/training/transformations_utils.py
+++ b/optimum/neuron/models/training/transformations_utils.py
@@ -1005,6 +1005,27 @@ class GQAQKVColumnParallelLinearSpec(ModelWeightTransformationSpec):
             q_name = f"{module_fully_qualified_name}.{self.query_projection_name}.{param_name}"
             k_name = f"{module_fully_qualified_name}.{self.key_projection_name}.{param_name}"
             v_name = f"{module_fully_qualified_name}.{self.value_projection_name}.{param_name}"
+            output_projection_name = f"{module_fully_qualified_name}.{self.output_projection_name}.{param_name}"
+            full_weight_names = [q_name, k_name, v_name, output_projection_name]
+
+            # This function is called once per checkpoint shard file, for every module, so most of the time none of
+            # these weights are available yet.
+            if not any(name in state_dict or name in upstanding_sharded_params for name in full_weight_names):
+                continue
+
+            # Move the weights to the upstanding_sharded_params dict, so that if they are not found in the
+            # state_dict, they will be added next time the function is called.
+            for full_k in full_weight_names:
+                if full_k in state_dict:
+                    upstanding_sharded_params[full_k] = state_dict.pop(full_k)
+
+            if any(name not in upstanding_sharded_params for name in full_weight_names):
+                # This means state_dict is not fully loaded for this module, move on
+                continue
+
+            for full_k in full_weight_names:
+                state_dict[full_k] = upstanding_sharded_params.pop(full_k)
+
             if self.fuse_qkv:
                 new_name = f"{module_fully_qualified_name}.{self.gqa_qkv_projection_name}.{param_name}_qkv"
 
@@ -1055,7 +1076,6 @@ class GQAQKVColumnParallelLinearSpec(ModelWeightTransformationSpec):
                     )
                 )
 
-            output_projection_name = f"{module_fully_qualified_name}.{self.output_projection_name}.{param_name}"
             state_dict[output_projection_name] = (
                 GQAQKVColumnParallelLinearSpec.create_query_or_output_projection_local_weight_from_regular_weight(
                     state_dict[output_projection_name],


### PR DESCRIPTION
# What does this PR do?

Fixes #1111

`GQAQKVColumnParallelLinearSpec._adapt_state_dict` pops `q_proj`, `k_proj` and `v_proj`
out of the state dict unconditionally. But `adapt_state_dict` is called once per
checkpoint shard file and iterates over every module of the model, so the spec also runs
for layers whose weights live in a different file, and the pop raises
`KeyError: 'model.layers.<N>.self_attn.q_proj.weight'`. Any checkpoint split over more
than one safetensors file is therefore unloadable once `tp_size > num_key_value_heads`,
which is exactly when the GQA path turns on. Qwen3-32B has 8 key-value heads and ships as
17 files, so it fails on the first one. I hit this on hardware at TP=16.

The fix follows `FusedLinearsSpec._adapt_state_dict`. The module is skipped when none of
its weights have arrived yet, and a partial group is parked in `upstanding_sharded_params`
until all four projections are present. The fusion and sharding math is not touched.

The early return when nothing at all is present is deliberate: it keeps the common case
from ever writing to `upstanding_sharded_params`, which `FusedLinearsSpec` assumes holds
at most one group at a time. Relaxing that assumption felt like a separate change.

## How it was tested

A hardware-free reproduction is in the issue. It loads the real `transformations_utils.py`
with the Neuron imports stubbed and replays the loader's shard-by-shard behaviour over the
published Qwen3-32B shard layout (17 files), using the real layer and head counts with a
smaller `head_dim`. Before the patch it raises the `KeyError`. After it, the shard-by-shard
result is bit-identical (`torch.equal`) to a single-shot load of the complete state dict
for all 32 tensor parallel ranks, including an artificial layout where `q_proj` is placed
in a different file from `k/v/o_proj`. `make style_check` is clean on the changed file.

I have not been able to run the existing training test suite, which needs Trainium.
`_lora_adapt_state_dict` has the same unguarded pops and is likely affected the same way,
but I did not test it and have not changed it.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
