### PR TITLE
ci: assume an AWS role over OIDC to build the AMI

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -27,6 +27,9 @@ jobs:
           run:
             working-directory: infrastructure/ami
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          id-token: write # Required to mint the OIDC token the AWS role is assumed with.
         env:
           AWS_REGION: us-east-1
         steps:
@@ -42,8 +45,7 @@ jobs:
           - name: configure aws credentials
             uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
             with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_BUILD_AMI }}
-              aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET_BUILD_AMI }}
+              role-to-assume: arn:aws:iam::907797767998:role/optimum-neuron-build-ami
               aws-region: ${{ env.AWS_REGION }}
 
           - name: Packer format


### PR DESCRIPTION
The AMI build authenticates with a long-lived AWS access key stored in the repository secrets. This replaces it with a role assumed over OIDC, so no permanent credential is needed.

**Do not merge yet.** The IAM role is provisioned separately and must exist first, otherwise AWS answers `Not authorized to perform sts:AssumeRoleWithWebIdentity`, which reads like a permissions problem rather than a missing role.

## What changes

```diff
             with:
-              aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_BUILD_AMI }}
-              aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET_BUILD_AMI }}
+              role-to-assume: arn:aws:iam::907797767998:role/optimum-neuron-build-ami
               aws-region: ${{ env.AWS_REGION }}
```

plus `id-token: write` on the job, which is what lets the runner mint the token. `contents: read` is stated alongside it because declaring any permission block resets the rest to none, and `actions/checkout` needs it.

The action is already `configure-aws-credentials@v6.2.0`, and the role carries the same permissions the key had, so nothing else moves.

## This does not change who can build

The role trusts exact subjects and no wildcard: the `main` branch and same-repo pull requests.

The `Packer Build` step is not conditional, so pull requests really do build and really do need credentials. Fork pull requests cannot mint an OIDC token, and repository secrets are already unavailable to them, so they fail at this step today and will keep failing. Same-repo pull requests keep working.

## Follow-up

Once a build is green, `AWS_ACCESS_KEY_ID_BUILD_AMI` and `AWS_ACCESS_KEY_SECRET_BUILD_AMI` can be removed from the repository secrets.