### PR TITLE
Fix tracing crashes for yolos, wav2vec2, hubert and convbert (aws-neuron-sdk#1265)

### DIFF
--- a/optimum/exporters/neuron/convert.py
+++ b/optimum/exporters/neuron/convert.py
@@ -45,6 +45,7 @@ from ...utils import (
     is_sentence_transformers_available,
     logging,
 )
+from .neuron_trace_patches import patch_model_for_neuron_tracing
 
 
 if TYPE_CHECKING:
@@ -536,6 +537,12 @@ def export_neuronx(
 
     dummy_inputs = prepare_dummy_inputs(config, input_shapes, return_dict=True)
     dummy_inputs_tuple = tuple(dummy_inputs.values())
+
+    # Some architectures apply an op that has no XLA lowering to a weight rather than
+    # to an activation, which kills the tracing process outright (SIGABRT / SIGSEGV).
+    # See `neuron_trace_patches` and https://github.com/aws-neuron/aws-neuron-sdk/issues/1265.
+    if isinstance(model_or_path, PreTrainedModel):
+        patch_model_for_neuron_tracing(model_or_path)
 
     # Prepare the model / function(tp) to trace
     if getattr(config, "is_encoder_decoder", False):

--- a/optimum/exporters/neuron/neuron_trace_patches.py
+++ b/optimum/exporters/neuron/neuron_trace_patches.py
@@ -1,0 +1,294 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compatibility patches that make certain models traceable by `torch_neuronx.trace`.
+
+Background
+----------
+`torch_neuronx.trace` lowers a model by running it once with tensors on an XLA
+device. An ``aten`` op that has no XLA lowering falls back to CPU through
+``at::native::cpu_fallback``, which calls ``XLANativeFunctions::_to_cpu()`` on the
+op's operands.
+
+That transfer only succeeds if the operand has already been materialized into a
+real PjRt buffer:
+
+* operand derived from a **model input** -> a buffer exists -> the fallback works.
+* operand derived from a **parameter or buffer** -> torch-xla still holds an
+  un-materialized placeholder whose buffer is ``nullptr``. The transfer then trips
+  ``Check failed: pjrt_data->buffer != nullptr`` and the process dies, either with
+  ``SIGABRT`` (the ``LOG(FATAL)`` path) or with a bare ``SIGSEGV``. Because the
+  crash happens in C++, it cannot be caught from Python.
+
+So a model breaks only when it applies an unlowered op to a *weight* rather than
+to an activation. This affects, on Neuron SDK >= 2.27:
+
+======================  ==============================  ===========================
+Model                   Unlowered op                    Operand
+======================  ==============================  ===========================
+``wav2vec2``            ``aten::_weight_norm_interface``  ``weight_norm`` parametrization
+``hubert``              ``aten::_weight_norm_interface``  ``weight_norm`` parametrization
+``yolos``               ``aten::upsample_bicubic2d``      ``position_embeddings``
+``convbert``            ``aten::im2col``                  conv-weight-derived tensor
+======================  ==============================  ===========================
+
+The patches below rewrite each of those call sites using ops that *do* have XLA
+lowerings, so no CPU fallback is attempted. Every patch is mathematically
+equivalent to the code it replaces; none of them changes model outputs.
+
+Upstream tracking: https://github.com/aws-neuron/aws-neuron-sdk/issues/1265
+"""
+
+import logging
+
+import torch
+from torch import nn
+
+
+logger = logging.getLogger(__name__)
+
+
+def fold_weight_norm_parametrizations(model: "torch.nn.Module") -> list[str]:
+    """Materialize ``weight_norm`` parametrizations so tracing does not hit a CPU fallback.
+
+    ``torch.nn.utils.weight_norm`` recomputes ``w = g * v / ||v||`` on every forward
+    through ``aten::_weight_norm_interface``, which has no XLA lowering. ``g`` and
+    ``v`` are parameters, so the CPU fallback receives un-materialized placeholders
+    and the tracing process is killed.
+
+    Folding the parametrization evaluates that expression once, eagerly, and stores
+    the result as a plain weight. The module stays numerically identical while
+    containing only lowerable ops.
+
+    This is applied to every model, not just the ones listed in the module
+    docstring: any architecture using weight normalization (speech encoders,
+    vocoders, some GANs) is affected in the same way, and folding is a no-op for
+    models that do not use it.
+
+    Args:
+        model: the model about to be traced. Modified in place.
+
+    Returns:
+        The names of the parametrizations that were folded.
+    """
+    folded = []
+    for name, module in model.named_modules():
+        parametrizations = getattr(module, "parametrizations", None)
+        if parametrizations is not None:
+            for param_name in list(parametrizations.keys()):
+                torch.nn.utils.parametrize.remove_parametrizations(module, param_name, leave_parametrized=True)
+                folded.append(f"{name}.{param_name}" if name else param_name)
+        elif hasattr(module, "weight_g") and hasattr(module, "weight_v"):
+            # weight_norm implementation used before torch 1.12
+            try:
+                nn.utils.remove_weight_norm(module)
+            except ValueError:
+                continue
+            folded.append(f"{name}.weight" if name else "weight")
+
+    if folded:
+        logger.info("Folded %d weight_norm parametrization(s) for Neuron tracing: %s", len(folded), folded)
+    return folded
+
+
+def unfold_via_slices(
+    inputs: "torch.Tensor",
+    kernel_size: list[int],
+    dilation: int = 1,
+    padding: list[int] | int = 0,
+    stride: int = 1,
+) -> "torch.Tensor":
+    """Replacement for ``nn.functional.unfold`` covering ConvBert's usage.
+
+    ``nn.functional.unfold`` lowers to ``aten::im2col``, which has no XLA lowering.
+    ConvBert calls it with a ``[K, 1]`` kernel over a ``[B, C, L, 1]`` tensor, unit
+    stride and dilation, and padding on the sequence dimension only. That case is
+    expressible with pad / slice / stack / reshape, all of which lower cleanly.
+
+    The output matches ``nn.functional.unfold`` exactly, including its
+    channel-major, kernel-minor column ordering.
+
+    Args:
+        inputs: tensor shaped ``[B, C, L, 1]``.
+        kernel_size: ``[K, 1]``.
+        dilation: must be 1.
+        padding: ``[P, 0]`` or an int applied to the sequence dimension.
+        stride: must be 1.
+
+    Returns:
+        Tensor shaped ``[B, C * K, L]``.
+
+    Raises:
+        ValueError: if called with arguments outside the supported case, so that an
+            unsupported call is reported instead of silently computing something else.
+    """
+    kernel_height, kernel_width = kernel_size if isinstance(kernel_size, (list, tuple)) else (kernel_size, kernel_size)
+    pad_height, pad_width = padding if isinstance(padding, (list, tuple)) else (padding, padding)
+
+    if kernel_width != 1 or pad_width != 0 or dilation != 1 or stride != 1 or inputs.shape[-1] != 1:
+        raise ValueError(
+            "unfold_via_slices only supports a [K, 1] kernel over a [B, C, L, 1] tensor with "
+            f"dilation=1 and stride=1, got kernel_size={kernel_size}, dilation={dilation}, "
+            f"padding={padding}, stride={stride}, input shape={tuple(inputs.shape)}."
+        )
+
+    batch_size, channels, length, _ = inputs.shape
+    padded = nn.functional.pad(inputs, (0, 0, pad_height, pad_height)).squeeze(-1)
+    columns = torch.stack([padded[:, :, offset : offset + length] for offset in range(kernel_height)], dim=2)
+    return columns.reshape(batch_size, channels * kernel_height, length)
+
+
+def _patch_convbert() -> bool:
+    """Route ConvBert's ``unfold`` call through :func:`unfold_via_slices`."""
+    try:
+        from transformers.models.convbert import modeling_convbert
+    except ImportError:
+        return False
+
+    if getattr(modeling_convbert, "_neuron_unfold_patched", False):
+        return True
+
+    original_nn = modeling_convbert.nn
+
+    class _FunctionalProxy:
+        """Forwards to ``nn.functional`` but substitutes ``unfold``."""
+
+        def __init__(self, functional):
+            self._functional = functional
+
+        def unfold(self, *args, **kwargs):
+            return unfold_via_slices(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._functional, name)
+
+    class _NNProxy:
+        """Forwards to ``torch.nn`` but exposes the patched ``functional``."""
+
+        def __init__(self, module):
+            self._module = module
+            self.functional = _FunctionalProxy(module.functional)
+
+        def __getattr__(self, name):
+            return getattr(self._module, name)
+
+    modeling_convbert.nn = _NNProxy(original_nn)
+    modeling_convbert._neuron_unfold_patched = True
+    logger.info("Patched ConvBert to use a lowerable unfold implementation for Neuron tracing.")
+    return True
+
+
+def _patch_yolos(model: "torch.nn.Module") -> bool:
+    """Precompute YOLOS position-embedding interpolation.
+
+    YOLOS interpolates ``position_embeddings`` with ``mode="bicubic"``, and
+    ``aten::upsample_bicubic2d`` has no XLA lowering. The result depends only on
+    that parameter and on ``img_size``, which is fixed for a traced model, so it is
+    a constant with respect to the traced graph. Evaluating it eagerly and caching
+    it keeps the value identical while removing the op from the graph.
+
+    The parameter values are snapshotted to CPU **here**, before tracing starts,
+    and the patched forward reads only from that snapshot. Copying the live tensor
+    during tracing instead would force a synchronization on an XLA tensor whose
+    computation is still in flight, which fails with
+    ``Check failed: handle->HasValue()``.
+    """
+    try:
+        from transformers.models.yolos import modeling_yolos
+    except ImportError:
+        return False
+
+    interpolation_classes = tuple(
+        cls
+        for cls in (
+            getattr(modeling_yolos, "InterpolateInitialPositionEmbeddings", None),
+            getattr(modeling_yolos, "InterpolateMidPositionEmbeddings", None),
+        )
+        if cls is not None
+    )
+    if not interpolation_classes:
+        return False
+
+    # Snapshot the position embeddings now, while the model is still on CPU, keyed
+    # by shape. Reading the live tensor inside the patched forward instead would
+    # synchronize an XLA tensor whose computation is still in flight, which fails
+    # with `Check failed: handle->HasValue()`. Shape is a stable key here: the two
+    # interpolation modules consume differently shaped embeddings (3D for the
+    # initial one, 4D for the mid ones), and each is a single named parameter.
+    snapshots = {}
+    for name, param in model.named_parameters():
+        if "position_embeddings" in name:
+            snapshots[tuple(param.shape)] = param.detach().clone()
+
+    if not snapshots:
+        return False
+
+    patched_any = False
+    for module in model.modules():
+        if not isinstance(module, interpolation_classes) or getattr(module, "_neuron_patched", False):
+            continue
+
+        def make_forward(interpolation_module):
+            original_forward = type(interpolation_module).forward
+            cache = {}
+
+            def forward(pos_embed, img_size=(800, 1344)):
+                key = (tuple(pos_embed.shape), tuple(img_size))
+                if key not in cache:
+                    source = snapshots.get(tuple(pos_embed.shape))
+                    if source is None:
+                        # Not a snapshotted embedding, e.g. plain CPU execution.
+                        source = pos_embed.detach().cpu()
+                    with torch.no_grad():
+                        cache[key] = original_forward(interpolation_module, source, img_size).detach()
+                return cache[key].to(device=pos_embed.device, dtype=pos_embed.dtype)
+
+            return forward
+
+        module.forward = make_forward(module)
+        module._neuron_patched = True
+        patched_any = True
+
+    if patched_any:
+        logger.info("Patched YOLOS to precompute position-embedding interpolation for Neuron tracing.")
+    return patched_any
+
+
+# Model types needing a patch beyond the always-applied weight_norm folding.
+# Each callable takes the model and returns whether it patched anything.
+_MODEL_TYPE_PATCHES = {
+    "convbert": lambda model: _patch_convbert(),
+    "yolos": _patch_yolos,
+}
+
+
+def patch_model_for_neuron_tracing(model: "torch.nn.Module") -> None:
+    """Apply the compatibility patches a model needs before `torch_neuronx.trace`.
+
+    Without this, ``wav2vec2``, ``hubert``, ``yolos`` and ``convbert`` terminate the
+    tracing process with ``SIGABRT`` or ``SIGSEGV`` on Neuron SDK >= 2.27. See the
+    module docstring for the mechanism.
+
+    All patches preserve model outputs exactly, and are safe to apply to models
+    that do not need them.
+
+    Args:
+        model: the model about to be traced. Modified in place.
+    """
+    fold_weight_norm_parametrizations(model)
+
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    patch = _MODEL_TYPE_PATCHES.get(model_type)
+    if patch is not None:
+        patch(model)

--- a/optimum/neuron/utils/testing_utils.py
+++ b/optimum/neuron/utils/testing_utils.py
@@ -19,22 +19,6 @@ import unittest
 from .import_utils import is_neuronx_available
 
 
-# Conv-based models whose tracing segfaults/aborts inside torch_neuronx HLO
-# generation with Neuron SDK 2.31 (torch-neuronx 2.9 / torch-xla 2.9). The crash
-# is in the compiler's tracer, not in optimum-neuron code, so it cannot be caught
-# and takes the whole process down; skip them before export until the SDK is fixed.
-SDK_231_TRACE_CRASH_MODEL_TYPES = {"convbert", "hubert", "wav2vec2", "yolos"}
-
-
-def skip_if_sdk_231_trace_crash(model_type: str):
-    """Skip the current test if exporting `model_type` crashes the Neuron SDK 2.31 tracer."""
-    if model_type not in SDK_231_TRACE_CRASH_MODEL_TYPES:
-        return
-    import pytest
-
-    pytest.skip(f"{model_type} export crashes the Neuron SDK 2.31 tracer (see SDK_231_TRACE_CRASH_MODEL_TYPES)")
-
-
 def requires_neuronx(test_case):
     return unittest.skipUnless(is_neuronx_available(), "test requires Neuron X compiler")(test_case)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ from optimum.neuron.utils.cache_utils import (
     set_neuron_cache_path,
 )
 from optimum.neuron.utils.misc import is_precompilation
-from optimum.neuron.utils.testing_utils import skip_if_sdk_231_trace_crash
 
 
 # Not critical, only usable on the sandboxed CI instance.
@@ -91,9 +90,6 @@ INFERENTIA_MODEL_NAMES = {
 
 @pytest.fixture(scope="module", params=ENCODER_ARCHITECTURES)
 def inf_encoder_model(request):
-    # Parametrized on the architecture rather than the model id, so that the architectures
-    # crashing the Neuron SDK 2.31 tracer can be skipped.
-    skip_if_sdk_231_trace_crash(request.param)
     return INFERENTIA_MODEL_NAMES[request.param]
 
 

--- a/tests/exporters/test_neuron_trace_patches.py
+++ b/tests/exporters/test_neuron_trace_patches.py
@@ -1,0 +1,134 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Neuron tracing compatibility patches.
+
+These run on CPU: they check that each patch is mathematically equivalent to the
+code it replaces. Whether the patches actually make tracing succeed is covered by
+the existing exporter and inference tests for yolos / wav2vec2 / hubert / convbert,
+which crash without them.
+"""
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from transformers import AutoModel, AutoModelForObjectDetection
+
+from optimum.exporters.neuron.neuron_trace_patches import (
+    fold_weight_norm_parametrizations,
+    patch_model_for_neuron_tracing,
+    unfold_via_slices,
+)
+
+
+class UnfoldViaSlicesTest(unittest.TestCase):
+    """`unfold_via_slices` must match `nn.functional.unfold` exactly."""
+
+    @parameterized.expand([(3,), (9,)])
+    def test_matches_torch_unfold(self, kernel):
+        # Only the kernel size changes behaviour: it is the loop bound, and it sets
+        # the padding. Batch/channel/length flow through pad, slice, stack and
+        # reshape untouched, so sweeping them adds runtime without adding coverage.
+        # ConvBert uses odd kernels; 3 and 9 cover the small and large ends.
+        inputs = torch.randn(2, 16, 32, 1)
+        padding = (kernel - 1) // 2
+
+        expected = torch.nn.functional.unfold(
+            inputs, kernel_size=[kernel, 1], dilation=1, padding=[padding, 0], stride=1
+        )
+        actual = unfold_via_slices(inputs, kernel_size=[kernel, 1], dilation=1, padding=[padding, 0], stride=1)
+
+        self.assertEqual(expected.shape, actual.shape)
+        # Both are pure gather/copy over the same elements, so this is exact.
+        self.assertTrue(torch.equal(expected, actual))
+
+    @parameterized.expand(
+        [
+            # One case per clause of the guard, so each is actually exercised.
+            ("non_unit_kernel_width", (1, 8, 16, 1), {"kernel_size": [3, 2], "padding": [1, 0]}),
+            ("non_zero_width_padding", (1, 8, 16, 1), {"kernel_size": [3, 1], "padding": [1, 1]}),
+            ("non_unit_stride", (1, 8, 16, 1), {"kernel_size": [3, 1], "padding": [1, 0], "stride": 2}),
+            ("non_unit_dilation", (1, 8, 16, 1), {"kernel_size": [3, 1], "padding": [1, 0], "dilation": 2}),
+            ("non_unit_trailing_dim", (1, 8, 16, 2), {"kernel_size": [3, 1], "padding": [1, 0]}),
+        ]
+    )
+    def test_rejects_unsupported_arguments(self, _, shape, kwargs):
+        # Unsupported cases must raise rather than silently compute something else.
+        with self.assertRaises(ValueError):
+            unfold_via_slices(torch.randn(*shape), **kwargs)
+
+
+class FoldWeightNormTest(unittest.TestCase):
+    def test_folding_preserves_outputs(self):
+        torch.manual_seed(0)
+        module = torch.nn.utils.weight_norm(torch.nn.Conv1d(8, 8, 3, padding=1), dim=2)
+        module.eval()
+        inputs = torch.randn(1, 8, 32)
+
+        with torch.no_grad():
+            before = module(inputs)
+
+        folded = fold_weight_norm_parametrizations(module)
+
+        with torch.no_grad():
+            after = module(inputs)
+
+        self.assertEqual(len(folded), 1)
+        self.assertFalse(hasattr(module, "parametrizations"))
+        self.assertTrue(torch.allclose(before, after, atol=1e-6))
+
+    def test_is_a_no_op_without_weight_norm(self):
+        module = torch.nn.Conv1d(4, 4, 3)
+        self.assertEqual(fold_weight_norm_parametrizations(module), [])
+
+
+class PatchModelForNeuronTracingTest(unittest.TestCase):
+    """End-to-end equivalence on the models that need patching."""
+
+    def _assert_outputs_unchanged(self, model, inputs, atol=1e-6):
+        model.eval()
+        with torch.no_grad():
+            before = model(**inputs)
+
+        patch_model_for_neuron_tracing(model)
+
+        with torch.no_grad():
+            after = model(**inputs)
+
+        before_tensors = [value for value in before.to_tuple() if isinstance(value, torch.Tensor)]
+        after_tensors = [value for value in after.to_tuple() if isinstance(value, torch.Tensor)]
+        self.assertEqual(len(before_tensors), len(after_tensors))
+        for expected, actual in zip(before_tensors, after_tensors):
+            self.assertTrue(torch.allclose(expected, actual, atol=atol))
+
+    def test_wav2vec2_outputs_unchanged(self):
+        model = AutoModel.from_pretrained("hf-internal-testing/tiny-random-Wav2Vec2Model")
+        self._assert_outputs_unchanged(model, {"input_values": torch.rand(1, 16000)})
+
+    def test_hubert_outputs_unchanged(self):
+        model = AutoModel.from_pretrained("hf-internal-testing/tiny-random-HubertModel")
+        self._assert_outputs_unchanged(model, {"input_values": torch.rand(1, 16000)})
+
+    def test_convbert_outputs_unchanged(self):
+        model = AutoModel.from_pretrained("hf-internal-testing/tiny-random-ConvBertModel")
+        self._assert_outputs_unchanged(model, {"input_ids": torch.randint(0, 100, (1, 32))})
+
+    def test_yolos_outputs_unchanged(self):
+        model = AutoModelForObjectDetection.from_pretrained("hf-internal-testing/tiny-random-YolosModel")
+        self._assert_outputs_unchanged(model, {"pixel_values": torch.rand(1, 3, 30, 30)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/exporters/test_transformers.py
+++ b/tests/exporters/test_transformers.py
@@ -49,7 +49,7 @@ from optimum.exporters.neuron import (
 from optimum.exporters.neuron.__main__ import get_submodels_and_neuron_configs
 from optimum.exporters.neuron.model_configs import *  # noqa: F403
 from optimum.neuron.utils import InputShapesArguments
-from optimum.neuron.utils.testing_utils import requires_neuronx, skip_if_sdk_231_trace_crash
+from optimum.neuron.utils.testing_utils import requires_neuronx
 
 from .exporters_utils import (
     ENCODER_DECODER_MODELS_TINY,
@@ -79,8 +79,6 @@ class NeuronExportTestCase(unittest.TestCase):
         dynamic_batch_size: bool = False,
         inline_weights_to_neff: bool = True,
     ):
-        skip_if_sdk_231_trace_crash(model_type)
-
         library_name = TasksManager.infer_library_from_model(model_name)
         if library_name == "sentence_transformers":
             model_class = TasksManager.get_model_class_for_task(task, framework="pt", library=library_name)

--- a/tests/inference/inference_utils.py
+++ b/tests/inference/inference_utils.py
@@ -22,8 +22,6 @@ import huggingface_hub
 import torch
 from transformers import set_seed
 
-from optimum.neuron.utils.testing_utils import skip_if_sdk_231_trace_crash
-
 
 SEED = 42
 
@@ -123,7 +121,6 @@ class NeuronModelTestMixin(unittest.TestCase):
         We don't use unittest setUpClass, in order to still be able to run individual tests.
         """
         model_arch = model_args["model_arch"]
-        skip_if_sdk_231_trace_crash(model_arch)
         model_arch_and_params = model_args["test_name"]
         dynamic_batch_size = model_args.get("dynamic_batch_size", False)
 


### PR DESCRIPTION
> This is a clone of PR #1119, pushed to a branch on upstream repo to trigger CI properly.

Fixes the tracing crashes tracked in https://github.com/aws-neuron/aws-neuron-sdk/issues/1265, which are what currently pin this project below Neuron SDK 2.27.

## What was happening

`yolos`, `wav2vec2`, `hubert` and `convbert` don't raise during export — they **kill the Python process**, so there's nothing to catch.

All four are the same bug, and it isn't the individual ops. An `aten` op with no XLA lowering falls back to CPU through `at::native::cpu_fallback`, which calls `XLANativeFunctions::_to_cpu()` on the operands. That transfer only works if the operand has already been materialized into a PjRt buffer:

- operand derived from a **model input** → a buffer exists → fine
- operand derived from a **parameter or buffer** → torch-xla still holds an un-materialized placeholder whose buffer is `nullptr` → `Check failed: pjrt_data->buffer != nullptr` → `SIGABRT` or `SIGSEGV`

So a model only breaks when it applies an unlowered op to a **weight** rather than to an activation:

| Model | Unlowered op | Operand |
|---|---|---|
| `wav2vec2` | `aten::_weight_norm_interface` | `weight_norm` parametrization on `pos_conv_embed.conv` |
| `hubert` | `aten::_weight_norm_interface` | same |
| `yolos` | `aten::upsample_bicubic2d` | `position_embeddings` |
| `convbert` | `aten::im2col` | conv-weight-derived tensor |

The check: the same ops at the same shapes trace fine when fed a model input, and crash when fed a parameter or a registered buffer. Only provenance changes.

Two things worth correcting from the issue as filed:

- **The two reported failure classes are one bug.** The "segfault" and the `RuntimeError: PjRt buffer is null` are the same null-buffer dereference surfacing differently depending on timing. `wav2vec2` was filed under segfault but actually aborts.
- **`cvt` no longer reproduces on 2.31.** It passes untouched, so it needs no patch and could be un-skipped in a separate PR.

## What this PR does

Adds `optimum/exporters/neuron/neuron_trace_patches.py`, applied from `export_neuronx`, which rewrites each call site using ops that *do* have XLA lowerings so no CPU fallback is attempted:

- **`weight_norm`** — fold the parametrization so `w = g * v / ||v||` is evaluated once eagerly instead of on every forward. Applied to **every** model rather than just these two: any architecture using weight normalization (speech encoders, vocoders, some GANs) hits this identically, and folding is a no-op otherwise.
- **`yolos`** — the bicubic interpolation depends only on a parameter and on `img_size`, which is fixed for a traced model, so it's constant with respect to the graph. Snapshot the embeddings before tracing, then precompute and cache. The snapshot matters: reading the live tensor mid-trace synchronizes an XLA tensor whose computation is still in flight and fails with `Check failed: handle->HasValue()`.
- **`convbert`** — reimplement its narrow `unfold` case with pad/slice/stack/reshape. It raises on argument combinations it doesn't cover rather than silently computing something else.

All are monkey-patches applied at runtime, so no vendored `transformers` changes.

**Second commit removes the skip.** #1113 added `SDK_231_TRACE_CRASH_MODEL_TYPES` / `skip_if_sdk_231_trace_crash` to work around this, which silently drops export *and* inference coverage for all four models. Since the crash is fixed, this PR deletes the helper and its three call sites (`tests/conftest.py`, `tests/exporters/test_transformers.py`, `tests/inference/inference_utils.py`). Landing the fix without this would leave the tests that prove it disabled, so the two belong together.

## Verification

`tests/exporters/test_transformers.py` on SDK 2.31 / inf2.8xlarge, **one pytest process per model** so a crash is attributable rather than taking down the run:

| | before | after |
|---|---|---|
| `yolos` | `rc=139` (SIGSEGV) | pass |
| `wav2vec2` | `rc=134` (SIGABRT) | pass |
| `convbert` | `rc=139` (SIGSEGV) | pass |
| `hubert` | `rc=134` (SIGABRT) | pass |
| `cvt` | pass | pass |

Together: **18 passed, 36 skipped** (previously 2 failed / 16 passed, and the run aborted partway when invoked as one process).

Re-validated after rebasing onto `main` with #1113 merged, i.e. against the real SDK 2.31 pins (`neuronx-cc==2.26.6360.0`, `torch-neuronx==2.9.0.2.15.32035`), with the skip removed so these actually execute rather than skipping:

| Suite | Result |
|---|---|
| `tests/exporters/test_transformers.py -k "<the 5 models>"` | **18 passed**, 36 skipped |
| `tests/inference/transformers/test_modeling.py -k "<the 5 models>"` | **11 passed** |
| `tests/exporters/test_neuron_trace_patches.py` (new) | **13 passed** |

The inference tests are coverage that was **not** previously exercised — they were skipped by the same helper, so removing it re-enables the `NeuronModelForCTC`, `AudioClassification`, `AudioFrameClassification` and `XVector` paths for wav2vec2 in addition to the export path.

Note for whoever runs these in CI: the four audio inference tests need **FFmpeg** present, otherwise `torchcodec` cannot load `librispeech_asr_demo` and they fail with `Could not load libtorchcodec` before reaching any Neuron code. `apt-get install ffmpeg` fixes it; unrelated to this change but easy to mistake for a regression.

Numerical equivalence, against CPU, on the tiny-random fixtures *and* the real checkpoints:

| Checkpoint | before | after | cos_sim | patched-vs-unpatched on CPU |
|---|---|---|---|---|
| `facebook/wav2vec2-base-960h` | SIGABRT | pass | 1.0 | **0.0** |
| `facebook/hubert-base-ls960` | SIGABRT | pass | 1.000005 | **0.0** |
| `YituTech/conv-bert-base` | SIGSEGV | pass | 1.0 | **0.0** |
| `hustvl/yolos-tiny` | SIGSEGV | pass | 1.0 / 1.0 / 1.000004 | **0.0** |

The last column is the point: the patches are numerically inert. Residual `cos_sim` deviation is ordinary FP32 Neuron-vs-CPU noise. Also verified with `dynamic_batch_size=True`, since `test_compare_to_transformers_dyn_bs` was one of the failing tests.

New tests in `tests/exporters/test_neuron_trace_patches.py` (13 cases, CPU-only, no Neuron needed, ~13s): `unfold_via_slices` exactness vs `nn.functional.unfold`, one case per clause of its argument guard, weight-norm folding equivalence, and output equivalence for all four models.

## Still worth fixing upstream

These are workarounds; the real issue is in torch-xla. `_to_cpu()` could materialize the placeholder instead of asserting on it — parameters are known constants at trace time. Failing that, replacing the `CHECK` with a thrown exception would at least make it catchable from Python instead of killing the process. I've noted this on the Neuron issue.

## Environment

SDK 2.31 (DLAMI 20260708), inf2.8xlarge, torch-neuronx `2.9.0.2.15.32035`, neuronx-cc `2.26.6360.0`, torch `2.9.1`, transformers `4.57.6`, Python `3.12.3`.

Rebased onto `main` after #1113 merged, so this runs against the SDK 2.31 pins now on `main`. `pyproject.toml` is deliberately untouched — #1113 already relaxed `requires-python` to `>=3.11,<3.13`, which is what the DLAMI's Python 3.12.3 needs.

