### PR TITLE
make vLLM image build on without docker buildx

### DIFF
--- a/.github/workflows/build-vllm-image.yml
+++ b/.github/workflows/build-vllm-image.yml
@@ -20,7 +20,6 @@ jobs:
       -
         name: Extract version
         run: |
-          sudo apt-get install -y gawk
           export ON_VERSION=$(make version)
           echo "ON_VERSION=${ON_VERSION}">> $GITHUB_ENV
       -

--- a/.github/workflows/test_inf2_vllm.yml
+++ b/.github/workflows/test_inf2_vllm.yml
@@ -160,7 +160,6 @@ jobs:
           uv pip install .[vllm,vllm-tests]
       - name: Build docker image
         run: |
-          sudo apt-get install -y gawk
           make optimum-neuron-vllm
       - name: Run vLLM docker tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 
 rwildcard=$(wildcard $1) $(foreach d,$1,$(call rwildcard,$(addsuffix /$(notdir $d),$(wildcard $(dir $d)*))))
 
-VERSION := $(shell gawk 'match($$0, /__version__ = "(.*)"/, a) {print a[1]}' optimum/neuron/version.py)
+VERSION := $(shell awk -F'"' '/^__version__ = / {print $$2}' optimum/neuron/version.py)
 
 version:
 	@echo ${VERSION}

--- a/optimum/neuron/utils/misc.py
+++ b/optimum/neuron/utils/misc.py
@@ -132,7 +132,7 @@ def replace_weights(
     module_paths = [module_path for module_path in module_paths if module_path != ""]
 
     for module_path in module_paths:
-        if len(re.findall("\w\d+", module_path)) > 0:
+        if len(re.findall(r"\w\d+", module_path)) > 0:
             continue
         else:
             model_weights._c.setattr(

--- a/optimum/neuron/utils/version_utils.py
+++ b/optimum/neuron/utils/version_utils.py
@@ -40,7 +40,7 @@ def get_pinned_version(package_name: str) -> str:
         raise SystemError("An error occured while parsing package metadata")
     candidates = [r for r in requires if r.startswith(package_name)]
     if len(candidates) == 1 and f"{package_name}==" in candidates[0]:
-        match = re.search(f"{package_name}==([0-9\.]+)", candidates[0])
+        match = re.search(rf"{package_name}==([0-9\.]+)", candidates[0])
         if match is not None:
             return match.group(1)
     raise ValueError(f"No pinned version found for package {package_name}")


### PR DESCRIPTION
# What does this PR do?

Three small fixes around the vLLM docker image build:

- **Entrypoint as a file instead of a heredoc.** `RUN cat <<'EOF' > entrypoint.sh` produces an empty file on the docker builder (only BuildKit supports  heredocs in `RUN`), so the container failed at start with `exec format error`.
  The script now lives in `docker/vllm/entrypoint.sh` and is `COPY`-ed in.  Contents are unchanged. This is useful when building on Ubuntu 24.04 without buildx.
- **Drop the `gawk` dependency.** `make version` used a GNU-only `match(..., a)`  three-argument form; rewritten with a POSIX `awk -F'"'` one-liner. The `sudo apt-get install -y gawk` steps in `build-vllm-image.yml` and  `test_inf2_vllm.yml` are no longer needed.
- **Raw strings for regex patterns** in `utils/misc.py` and `utils/version_utils.py`, to silence invalid-escape-sequence warnings. These were visible when starting vLLM on docker.